### PR TITLE
Update Discord RPC to use 'Lime' instead of 'Citra'

### DIFF
--- a/src/citra_qt/discord_impl.cpp
+++ b/src/citra_qt/discord_impl.cpp
@@ -16,8 +16,8 @@ namespace DiscordRPC {
 DiscordImpl::DiscordImpl(const Core::System& system_) : system{system_} {
     DiscordEventHandlers handlers{};
 
-    // The number is the client ID for Citra, it's used for images and the
-    // application name
+    // The number is the client ID for Lime3DS, it's used for images and the
+    // application name. rustygrape238 on discord is the RPC maintainer.
     Discord_Initialize("1222229231367487539", &handlers, 1, nullptr);
 }
 

--- a/src/citra_qt/discord_impl.cpp
+++ b/src/citra_qt/discord_impl.cpp
@@ -18,7 +18,7 @@ DiscordImpl::DiscordImpl(const Core::System& system_) : system{system_} {
 
     // The number is the client ID for Citra, it's used for images and the
     // application name
-    Discord_Initialize("719647875465871400", &handlers, 1, nullptr);
+    Discord_Initialize("1222229231367487539", &handlers, 1, nullptr);
 }
 
 DiscordImpl::~DiscordImpl() {
@@ -41,8 +41,8 @@ void DiscordImpl::Update() {
     }
 
     DiscordRichPresence presence{};
-    presence.largeImageKey = "citra";
-    presence.largeImageText = "Citra is an emulator for the Nintendo 3DS";
+    presence.largeImageKey = "large_icon";
+    presence.largeImageText = "Lime is an emulator for the 3DS!";
     if (is_powered_on) {
         presence.state = title.c_str();
         presence.details = "Currently in game";


### PR DESCRIPTION
I have updated Citra's Discord RPC to be rebranded to use 'Lime' instead. I have used GitHub actions to build for Windows and the Discord RPC works.

I was thinking of starting a small Discord community to help get developers if possible? Although at this time lots of publicity might not be a good idea.

I plan on starting to change the icons and text now that we have successful builds.