### PR TITLE
GSP_GPU: Fix pokemon, mario & luigi games.

### DIFF
--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -362,9 +362,7 @@ void GSP_GPU::SignalInterruptForThread(InterruptId interrupt_id, u32 thread_id) 
         auto* info = GetFrameBufferInfo(thread_id, screen_id);
         if (info->is_dirty) {
             system.GPU().SetBufferSwap(screen_id, info->framebuffer_info[info->index]);
-            // Decompiling the GSP module shows that the dirty bit is assigned 1 for top screen, 0
-            // for bottom
-            info->is_dirty.Assign(screen_id == 0);
+            info->is_dirty.Assign(false);
         }
     }
 


### PR DESCRIPTION
This last implementation caused some games break (these are known ones), so revert it for now