### PR TITLE
Get the app loader to return long title string rather than short title

### DIFF
--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -374,9 +374,14 @@ ResultStatus AppLoader_NCCH::ReadTitle(std::string& title) {
 
     std::memcpy(&smdh, data.data(), sizeof(Loader::SMDH));
 
-    const auto& short_title = smdh.GetShortTitle(SMDH::TitleLanguage::English);
-    auto title_end = std::find(short_title.begin(), short_title.end(), u'\0');
-    title = Common::UTF16ToUTF8(std::u16string{short_title.begin(), title_end});
+    // Replace title string for game being played with long title string.
+    // This looks much nicer and more pleasant:
+    // "Mario & Luigi Superstar..." to "Mario & Luigi Superstar Saga + Bowser's Minions".
+
+    // const auto& short_title = smdh.GetShortTitle(SMDH::TitleLanguage::English);
+    const auto& long_title = smdh.GetLongTitle(SMDH::TitleLanguage::English);
+    auto title_end = std::find(long_title.begin(), long_title.end(), u'\0');
+    title = Common::UTF16ToUTF8(std::u16string{long_title.begin(), title_end});
 
     return ResultStatus::Success;
 }


### PR DESCRIPTION
When playing a game on Lime3DS the game's short title is used for the Discord RPC and window title. I have changed it to use the game's long title. This changes ``Mario & Luigi Superstar...`` to ``Mario & Luigi Superstar Saga + Bowser's Minions``. This is an improvement because some games (Mario & Luigi RPGs) have very similar short titles. Also it is much more pleasant to look at a full title than a short one.

Commit details:
Get the app loader to return long title string rather than short title string when emulator asks for the game title. This should make the window title when playing a game and the Discord RPC look cleaner.