### PR TITLE
Android haptic feedback

### DIFF
--- a/src/android/app/src/main/java/io/github/lime3ds/android/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/fragments/EmulationFragment.kt
@@ -581,6 +581,7 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
         popupMenu.menu.apply {
             findItem(R.id.menu_show_overlay).isChecked = EmulationMenuSettings.showOverlay
             findItem(R.id.menu_show_fps).isChecked = EmulationMenuSettings.showFps
+            findItem(R.id.menu_haptic_feedback).isChecked = EmulationMenuSettings.hapticFeedback
             findItem(R.id.menu_emulation_joystick_rel_center).isChecked =
                 EmulationMenuSettings.joystickRelCenter
             findItem(R.id.menu_emulation_dpad_slide_enable).isChecked =
@@ -597,6 +598,12 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
 
                 R.id.menu_show_fps -> {
                     EmulationMenuSettings.showFps = !EmulationMenuSettings.showFps
+                    updateShowFpsOverlay()
+                    true
+                }
+
+                R.id.menu_haptic_feedback -> {
+                    EmulationMenuSettings.hapticFeedback = !EmulationMenuSettings.hapticFeedback
                     updateShowFpsOverlay()
                     true
                 }

--- a/src/android/app/src/main/java/io/github/lime3ds/android/overlay/InputOverlay.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/overlay/InputOverlay.kt
@@ -86,7 +86,8 @@ class InputOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(contex
     }
 
     fun hapticFeedback(type:Int){
-        performHapticFeedback(type)
+        if(EmulationMenuSettings.hapticFeedback)
+            performHapticFeedback(type)
     }
 
     override fun onTouch(v: View, event: MotionEvent): Boolean {

--- a/src/android/app/src/main/java/io/github/lime3ds/android/overlay/InputOverlay.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/overlay/InputOverlay.kt
@@ -85,13 +85,17 @@ class InputOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(contex
         )
     }
 
+    fun hapticFeedback(type:Int){
+        performHapticFeedback(type)
+    }
+
     override fun onTouch(v: View, event: MotionEvent): Boolean {
         if (isInEditMode) {
             return onTouchWhileEditing(event)
         }
         var shouldUpdateView = false
         for (button in overlayButtons) {
-            if (!button.updateStatus(event)) {
+            if (!button.updateStatus(event, this)) {
                 continue
             }
 
@@ -103,7 +107,7 @@ class InputOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(contex
             shouldUpdateView = true
         }
         for (dpad in overlayDpads) {
-            if (!dpad.updateStatus(event, EmulationMenuSettings.dpadSlide)) {
+            if (!dpad.updateStatus(event, EmulationMenuSettings.dpadSlide, this)) {
                 continue
             }
             NativeLibrary.onGamePadEvent(NativeLibrary.TouchScreenDevice, dpad.upId, dpad.upStatus)
@@ -125,7 +129,7 @@ class InputOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(contex
             shouldUpdateView = true
         }
         for (joystick in overlayJoysticks) {
-            if (!joystick.updateStatus(event)) {
+            if (!joystick.updateStatus(event, this)) {
                 continue
             }
             val axisID = joystick.joystickId

--- a/src/android/app/src/main/java/io/github/lime3ds/android/overlay/InputOverlayDrawableButton.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/overlay/InputOverlayDrawableButton.kt
@@ -9,6 +9,7 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Rect
 import android.graphics.drawable.BitmapDrawable
+import android.view.HapticFeedbackConstants
 import android.view.MotionEvent
 import io.github.lime3ds.android.NativeLibrary
 
@@ -51,7 +52,7 @@ class InputOverlayDrawableButton(
      *
      * @return true if value was changed
      */
-    fun updateStatus(event: MotionEvent): Boolean {
+    fun updateStatus(event: MotionEvent, overlay:InputOverlay): Boolean {
         val pointerIndex = event.actionIndex
         val xPosition = event.getX(pointerIndex).toInt()
         val yPosition = event.getY(pointerIndex).toInt()
@@ -67,6 +68,7 @@ class InputOverlayDrawableButton(
             }
             pressedState = true
             trackId = pointerId
+            overlay.hapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
             return true
         }
         if (isActionUp) {
@@ -75,6 +77,7 @@ class InputOverlayDrawableButton(
             }
             pressedState = false
             trackId = -1
+            overlay.hapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY_RELEASE)
             return true
         }
         return false

--- a/src/android/app/src/main/java/io/github/lime3ds/android/overlay/InputOverlayDrawableDpad.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/overlay/InputOverlayDrawableDpad.kt
@@ -9,6 +9,7 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Rect
 import android.graphics.drawable.BitmapDrawable
+import android.view.HapticFeedbackConstants
 import android.view.MotionEvent
 import io.github.lime3ds.android.NativeLibrary
 
@@ -59,7 +60,8 @@ class InputOverlayDrawableDpad(
         trackId = -1
     }
 
-    fun updateStatus(event: MotionEvent, dpadSlide: Boolean): Boolean {
+    fun updateStatus(event: MotionEvent, dpadSlide: Boolean, overlay:InputOverlay): Boolean {
+        var isDown = false
         val pointerIndex = event.actionIndex
         val xPosition = event.getX(pointerIndex).toInt()
         val yPosition = event.getY(pointerIndex).toInt()
@@ -73,6 +75,7 @@ class InputOverlayDrawableDpad(
             if (!bounds.contains(xPosition, yPosition)) {
                 return false
             }
+            isDown = true
             trackId = pointerId
         }
         if (isActionUp) {
@@ -84,6 +87,7 @@ class InputOverlayDrawableDpad(
             downButtonState = false
             leftButtonState = false
             rightButtonState = false
+            overlay.hapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY_RELEASE)
             return true
         }
         if (trackId == -1) {
@@ -114,7 +118,15 @@ class InputOverlayDrawableDpad(
             downButtonState = yAxis > VIRT_AXIS_DEADZONE
             leftButtonState = xAxis < -VIRT_AXIS_DEADZONE
             rightButtonState = xAxis > VIRT_AXIS_DEADZONE
-            return upState != upButtonState || downState != downButtonState || leftState != leftButtonState || rightState != rightButtonState
+
+            val stateChanged = upState != upButtonState || downState != downButtonState || leftState != leftButtonState || rightState != rightButtonState
+
+            if(stateChanged)
+                overlay.hapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+            else if(isDown)
+                overlay.hapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
+
+            return stateChanged
         }
         return false
     }

--- a/src/android/app/src/main/java/io/github/lime3ds/android/utils/EmulationMenuSettings.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/utils/EmulationMenuSettings.kt
@@ -41,8 +41,15 @@ object EmulationMenuSettings {
         get() = preferences.getBoolean("EmulationMenuSettings_ShowFps", false)
         set(value) {
             preferences.edit()
-                .putBoolean("EmulationMenuSettings_ShowFps", value)
-                .apply()
+                    .putBoolean("EmulationMenuSettings_ShowFps", value)
+                    .apply()
+        }
+    var hapticFeedback: Boolean
+        get() = preferences.getBoolean("EmulationMenuSettings_HapticFeedback", true)
+        set(value) {
+            preferences.edit()
+                    .putBoolean("EmulationMenuSettings_HapticFeedback", value)
+                    .apply()
         }
     var swapScreens: Boolean
         get() = preferences.getBoolean("EmulationMenuSettings_SwapScreens", false)

--- a/src/android/app/src/main/res/menu/menu_overlay_options.xml
+++ b/src/android/app/src/main/res/menu/menu_overlay_options.xml
@@ -12,6 +12,11 @@
         android:checkable="true" />
 
     <item
+        android:id="@+id/menu_haptic_feedback"
+        android:title="@string/emulation_haptic_feedback"
+        android:checkable="true" />
+
+    <item
         android:id="@+id/menu_emulation_edit_layout"
         android:title="@string/emulation_edit_layout" />
 

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -324,6 +324,7 @@
     <string name="emulation_empty_state_slot">Slot %1$d</string>
     <string name="emulation_occupied_state_slot">Slot %1$d - %2$tF %2$tR</string>
     <string name="emulation_show_fps">Show FPS</string>
+    <string name="emulation_haptic_feedback">Haptic Feedback</string>
     <string name="emulation_overlay_options">Overlay Options</string>
     <string name="emulation_configure_controls">Configure Controls</string>
     <string name="emulation_edit_layout">Edit Layout</string>


### PR DESCRIPTION
Add haptic feedback to the overlay controls.
Can be disabled in the overlay menu.