### PR TITLE
Implement core downcount hack

### DIFF
--- a/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/model/IntSetting.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/model/IntSetting.kt
@@ -38,6 +38,7 @@ enum class IntSetting(
     CPU_JIT("use_cpu_jit", Settings.SECTION_CORE, 1),
     HW_SHADER("use_hw_shader", Settings.SECTION_RENDERER, 1),
     VSYNC("use_vsync_new", Settings.SECTION_RENDERER, 1),
+    CORE_DOWNCOUNT_HACK("core_downcount_hack", Settings.SECTION_CORE, 0),
     DEBUG_RENDERER("renderer_debug", Settings.SECTION_DEBUG, 0),
     TEXTURE_FILTER("texture_filter", Settings.SECTION_RENDERER, 0),
     USE_FRAME_LIMIT("use_frame_limit", Settings.SECTION_RENDERER, 1);
@@ -65,6 +66,7 @@ enum class IntSetting(
             LLE_APPLETS,
             GRAPHICS_API,
             VSYNC,
+            CORE_DOWNCOUNT_HACK,
             DEBUG_RENDERER,
             CPU_JIT,
             ASYNC_CUSTOM_LOADING,

--- a/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/ui/SettingsFragmentPresenter.kt
@@ -957,6 +957,15 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
             )
             add(
                 SwitchSetting(
+                    IntSetting.CORE_DOWNCOUNT_HACK,
+                    R.string.core_downcount_hack,
+                    R.string.core_downcount_hack_description,
+                    IntSetting.CORE_DOWNCOUNT_HACK.key,
+                    IntSetting.CORE_DOWNCOUNT_HACK.defaultValue
+                )
+            )
+            add(
+                SwitchSetting(
                     IntSetting.DEBUG_RENDERER,
                     R.string.renderer_debug,
                     R.string.renderer_debug_description,

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -131,6 +131,7 @@ void Config::ReadValues() {
     // Core
     ReadSetting("Core", Settings::values.use_cpu_jit);
     ReadSetting("Core", Settings::values.cpu_clock_percentage);
+    ReadSetting("Core", Settings::values.core_downcount_hack);
 
     // Renderer
     Settings::values.use_gles = sdl2_config->GetBoolean("Renderer", "use_gles", true);

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -213,6 +213,8 @@
     <string name="async_shaders_description">Compiles shaders in the background to reduce stuttering during gameplay. When enabled expect temporary graphical glitches</string>
     <string name="renderer_debug">Debug Renderer</string>
     <string name="renderer_debug_description">Log additional graphics related debug information. When enabled, game performance will be significantly reduced.</string>
+    <string name="core_downcount_hack">Enable Core Downcount Hack</string>
+    <string name="core_downcount_hack_description">When enabled, core downcount will be limited to a smaller time slice, reducing CPU usage. May cause performance issues for some games, or may improve for another games</string>
     <string name="vsync">Enable V-Sync</string>
     <string name="vsync_description">Synchronizes the game frame rate to the refresh rate of your device.</string>
     <string name="linear_filtering">Linear Filtering</string>

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -82,7 +82,7 @@ void LogSettings() {
 
     LOG_INFO(Config, "Citra Configuration:");
     log_setting("Core_UseCpuJit", values.use_cpu_jit.GetValue());
-    log_setting("Core_CoreDowncountHack", values.core_downcount_hack.GetValue());
+    log_setting("Core_DowncountHack", values.core_downcount_hack.GetValue());
     log_setting("Core_CPUClockPercentage", values.cpu_clock_percentage.GetValue());
     log_setting("Renderer_UseGLES", values.use_gles.GetValue());
     log_setting("Renderer_GraphicsAPI", GetGraphicsAPIName(values.graphics_api.GetValue()));

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -82,6 +82,7 @@ void LogSettings() {
 
     LOG_INFO(Config, "Citra Configuration:");
     log_setting("Core_UseCpuJit", values.use_cpu_jit.GetValue());
+    log_setting("Core_CoreDowncountHack", values.core_downcount_hack.GetValue());
     log_setting("Core_CPUClockPercentage", values.cpu_clock_percentage.GetValue());
     log_setting("Renderer_UseGLES", values.use_gles.GetValue());
     log_setting("Renderer_GraphicsAPI", GetGraphicsAPIName(values.graphics_api.GetValue()));

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -463,6 +463,7 @@ struct Values {
         GraphicsAPI::Software, GraphicsAPI::Vulkan, "graphics_api"};
     SwitchableSetting<u32> physical_device{0, "physical_device"};
     Setting<bool> use_gles{false, "use_gles"};
+    Setting<bool> core_downcount_hack{false, "core_downcount_hack"};
     Setting<bool> renderer_debug{false, "renderer_debug"};
     Setting<bool> dump_command_buffers{false, "dump_command_buffers"};
     SwitchableSetting<bool> spirv_shader_gen{true, "spirv_shader_gen"};

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -425,6 +425,10 @@ System::ResultStatus System::Init(Frontend::EmuWindow& emu_window,
     kernel->SetCPUs(cpu_cores);
     kernel->SetRunningCPU(cpu_cores[0].get());
 
+    if (Settings::values.core_downcount_hack) {
+        SetDowncountHack(true, num_cores);
+    }
+
     const auto audio_emulation = Settings::values.audio_emulation.GetValue();
     if (audio_emulation == Settings::AudioEmulation::HLE) {
         dsp_core = std::make_unique<AudioCore::DspHle>(*this);
@@ -562,6 +566,19 @@ void System::RegisterSoftwareKeyboard(std::shared_ptr<Frontend::SoftwareKeyboard
 
 void System::RegisterImageInterface(std::shared_ptr<Frontend::ImageInterface> image_interface) {
     registered_image_interface = std::move(image_interface);
+}
+
+void System::SetDowncountHack(bool enabled, u32 num_cores) {
+    if (enabled) {
+        u32 hacks[4] = {1, 4, 2, 2};
+        for (u32 i = 0; i < num_cores; ++i) {
+            timing->GetTimer(i)->SetDowncountHack(hacks[i]);
+        }
+    } else {
+        for (u32 i = 0; i < num_cores; ++i) {
+            timing->GetTimer(i)->SetDowncountHack(0);
+        }
+    }
 }
 
 void System::Shutdown(bool is_deserializing) {

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -352,6 +352,9 @@ public:
         return false;
     }
 
+    /// Core downcount will be limited to a smaller time slice.
+    void SetDowncountHack(bool enabled, u32 num_cores);
+
     /// Applies any changes to settings to this core instance.
     void ApplySettings();
 

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -242,7 +242,7 @@ void Timing::Timer::SetNextSlice(s64 max_slice_length) {
             std::min<s64>(event_queue.front().time - executed_ticks, max_slice_length));
     }
 
-    downcount = slice_length;
+    downcount = slice_length >> downcount_hack;
 }
 
 void Timing::Timer::Idle() {

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -207,6 +207,10 @@ public:
 
         void MoveEvents();
 
+        void SetDowncountHack(u32 hack) {
+            downcount_hack = hack;
+        }
+
     private:
         friend class Timing;
         // The queue is a min-heap using std::make_heap/push_heap/pop_heap.
@@ -231,6 +235,7 @@ public:
         s64 downcount = MAX_SLICE_LENGTH;
         s64 executed_ticks = 0;
         u64 idled_cycles = 0;
+        u32 downcount_hack = 0;
 
         // Stores a scaling for the internal clockspeed. Changing this number results in
         // under/overclocking the guest cpu

--- a/src/lime/config.cpp
+++ b/src/lime/config.cpp
@@ -130,6 +130,7 @@ void Config::ReadValues() {
     // Core
     ReadSetting("Core", Settings::values.use_cpu_jit);
     ReadSetting("Core", Settings::values.cpu_clock_percentage);
+    ReadSetting("Core", Settings::values.core_downcount_hack);
 
     // Renderer
     ReadSetting("Renderer", Settings::values.graphics_api);

--- a/src/lime_qt/configuration/config.cpp
+++ b/src/lime_qt/configuration/config.cpp
@@ -457,6 +457,7 @@ void Config::ReadCoreValues() {
 
     if (global) {
         ReadBasicSetting(Settings::values.use_cpu_jit);
+        ReadBasicSetting(Settings::values.core_downcount_hack);
         ReadBasicSetting(Settings::values.delay_start_for_lle_modules);
     }
 
@@ -993,6 +994,7 @@ void Config::SaveCoreValues() {
 
     if (global) {
         WriteBasicSetting(Settings::values.use_cpu_jit);
+        WriteBasicSetting(Settings::values.core_downcount_hack);
         WriteBasicSetting(Settings::values.delay_start_for_lle_modules);
     }
 

--- a/src/lime_qt/configuration/configure_debug.cpp
+++ b/src/lime_qt/configuration/configure_debug.cpp
@@ -71,6 +71,7 @@ ConfigureDebug::ConfigureDebug(bool is_powered_on_, QWidget* parent)
 #endif
 
     ui->toggle_cpu_jit->setEnabled(!is_powered_on);
+    ui->toggle_core_downcount_hack->setEnabled(!is_powered_on);
     ui->toggle_renderer_debug->setEnabled(!is_powered_on);
     ui->toggle_dump_command_buffers->setEnabled(!is_powered_on);
 
@@ -100,6 +101,7 @@ void ConfigureDebug::SetConfiguration() {
     ui->toggle_cpu_jit->setChecked(Settings::values.use_cpu_jit.GetValue());
     ui->delay_start_for_lle_modules->setChecked(
         Settings::values.delay_start_for_lle_modules.GetValue());
+    ui->toggle_core_downcount_hack->setChecked(Settings::values.core_downcount_hack.GetValue());
     ui->toggle_renderer_debug->setChecked(Settings::values.renderer_debug.GetValue());
     ui->toggle_dump_command_buffers->setChecked(Settings::values.dump_command_buffers.GetValue());
 
@@ -132,6 +134,7 @@ void ConfigureDebug::ApplyConfiguration() {
     Common::Log::SetGlobalFilter(filter);
     Settings::values.use_cpu_jit = ui->toggle_cpu_jit->isChecked();
     Settings::values.delay_start_for_lle_modules = ui->delay_start_for_lle_modules->isChecked();
+    Settings::values.core_downcount_hack = ui->toggle_core_downcount_hack->isChecked();
     Settings::values.renderer_debug = ui->toggle_renderer_debug->isChecked();
     Settings::values.dump_command_buffers = ui->toggle_dump_command_buffers->isChecked();
 

--- a/src/lime_qt/configuration/configure_debug.ui
+++ b/src/lime_qt/configuration/configure_debug.ui
@@ -203,13 +203,23 @@
        </widget>
       </item>
       <item row="3" column="0">
+       <widget class="QCheckBox" name="toggle_core_downcount_hack">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When enabled, core downcount will be limited to a smaller time slice, reducing CPU usage. May cause performance issues for some games, or may improve for another games&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Enable Core Downcount Hack</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
        <widget class="QCheckBox" name="toggle_renderer_debug">
         <property name="text">
          <string>Enable debug renderer</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
+      <item row="5" column="0">
        <widget class="QCheckBox" name="toggle_dump_command_buffers">
         <property name="text">
          <string>Dump command buffers</string>


### PR DESCRIPTION
When enabled, core downcount will be limited to a smaller time slice, reducing CPU usage. May cause performance issues for some games, or may improve for another games. Benefits a lot for some games as luigi's mansion 2 if you also want to upscale it.

Some of this hack base is from Citra MMJ and its hack "CPU Usage Limit", rest is reworked from me.