### PR TITLE
Rebrand log filenames

### DIFF
--- a/src/android/app/src/main/java/io/github/lime3ds/android/fragments/HomeSettingsFragment.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/fragments/HomeSettingsFragment.kt
@@ -201,8 +201,8 @@ class HomeSettingsFragment : Fragment() {
             requireContext(),
             PermissionsHandler.citraDirectory
         )?.findFile("log")
-        val currentLog = logDirectory?.findFile("citra_log.txt")
-        val oldLog = logDirectory?.findFile("citra_log.txt.old.txt")
+        val currentLog = logDirectory?.findFile("lime3ds_log.txt")
+        val oldLog = logDirectory?.findFile("lime3ds_log.old.txt")
 
         val intent = Intent().apply {
             action = Intent.ACTION_SEND

--- a/src/android/app/src/main/java/io/github/lime3ds/android/utils/DocumentsTree.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/utils/DocumentsTree.kt
@@ -17,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap
  * A cached document tree for Citra user directory.
  * For every filepath which is not startsWith "content://" will need to use this class to traverse.
  * For example:
- * C++ Citra log file directory will be /log/citra_log.txt.
+ * C++ Lime3DS log file directory will be /log/lime3ds_log.txt.
  * After DocumentsTree.resolvePath() it will become content URI.
  */
 class DocumentsTree {

--- a/src/common/common_paths.h
+++ b/src/common/common_paths.h
@@ -55,7 +55,7 @@
 
 // Filenames
 // Files in the directory returned by GetUserPath(UserPath::LogDir)
-#define LOG_FILE "citra_log.txt"
+#define LOG_FILE "lime3ds_log.txt"
 
 // Files in the directory returned by GetUserPath(UserPath::ConfigDir)
 #define EMU_CONFIG "emu.ini"

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -13,6 +13,7 @@
 #define _SH_DENYWR 0
 #endif
 
+#include <boost/algorithm/string/replace.hpp>
 #ifdef CITRA_LINUX_GCC_BACKTRACE
 #define BOOST_STACKTRACE_USE_BACKTRACE
 #include <boost/stacktrace.hpp>
@@ -89,7 +90,7 @@ class FileBackend final : public Backend {
 public:
     explicit FileBackend(const std::string& filename) {
         auto old_filename = filename;
-        old_filename += ".old.txt";
+        boost::replace_all(old_filename, ".txt", ".old.txt");
 
         // Existence checks are done within the functions themselves.
         // We don't particularly care if these succeed or not.


### PR DESCRIPTION
Changes the filenames of produced logs as follows:
`citra_log.txt` --> `lime3ds_log.txt`
`citra_log.txt.old.txt` --> `lime3ds_log.old.txt`

Closes #133