### PR TITLE
Update Android resolution setting interface

### DIFF
--- a/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/ui/SettingsFragmentPresenter.kt
@@ -680,15 +680,14 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                 )
             )
             add(
-                SliderSetting(
+                SingleChoiceSetting(
                     IntSetting.RESOLUTION_FACTOR,
                     R.string.internal_resolution,
                     R.string.internal_resolution_description,
-                    1,
-                    10,
-                    "x",
+                    R.array.resolutionFactorNames,
+                    R.array.resolutionFactorValues,
                     IntSetting.RESOLUTION_FACTOR.key,
-                    IntSetting.RESOLUTION_FACTOR.defaultValue.toFloat()
+                    IntSetting.RESOLUTION_FACTOR.defaultValue
                 )
             )
             add(

--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -233,6 +233,31 @@
         <item>2</item>
     </integer-array>
 
+    <string-array name="resolutionFactorNames">
+        <item>@string/internal_resolution_setting_1x</item>
+        <item>@string/internal_resolution_setting_2x</item>
+        <item>@string/internal_resolution_setting_3x</item>
+        <item>@string/internal_resolution_setting_4x</item>
+        <item>@string/internal_resolution_setting_5x</item>
+        <item>@string/internal_resolution_setting_6x</item>
+        <item>@string/internal_resolution_setting_7x</item>
+        <item>@string/internal_resolution_setting_8x</item>
+        <item>@string/internal_resolution_setting_9x</item>
+        <item>@string/internal_resolution_setting_10x</item>
+    </string-array>
+    <integer-array name="resolutionFactorValues">
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+        <item>8</item>
+        <item>9</item>
+        <item>10</item>
+    </integer-array>
+
     <string-array name="countries">
         <item></item>
         <item>@string/japan</item>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -231,6 +231,16 @@
     <string name="frame_limit_slider_description">Specifies the percentage to limit emulation speed. With the default of 100% emulation will be limited to normal speed. Values higher or lower will increase or decrease the speed limit.</string>
     <string name="internal_resolution">Internal Resolution</string>
     <string name="internal_resolution_description">Specifies the resolution used to render at. A high resolution will improve visual quality a lot but is also quite heavy on performance and might cause glitches in certain games.</string>
+    <string name="internal_resolution_setting_1x">Native (400x240)</string>
+    <string name="internal_resolution_setting_2x">2x Native (800x480)</string>
+    <string name="internal_resolution_setting_3x">3x Native (1200x720)</string>
+    <string name="internal_resolution_setting_4x">4x Native (1600x960)</string>
+    <string name="internal_resolution_setting_5x">5x Native (2000x1200)</string>
+    <string name="internal_resolution_setting_6x">6x Native (2400x1440)</string>
+    <string name="internal_resolution_setting_7x">7x Native (2800x1680)</string>
+    <string name="internal_resolution_setting_8x">8x Native (3200x1920)</string>
+    <string name="internal_resolution_setting_9x">9x Native (3600x2160)</string>
+    <string name="internal_resolution_setting_10x">10x Native (4000x2400)</string>
     <string name="performance_warning">Turning off this setting will significantly reduce emulation performance! For the best experience, it is recommended that you leave this setting enabled.</string>
     <string name="debug_warning">Warning: Modifying these settings will slow emulation</string>
     <string name="stereoscopy">Stereoscopy</string>


### PR DESCRIPTION
This pull request updates the internal resolution setting on Android to match the experience of the desktop interface

Changes include:
- Now has a radio button interface instead of a slider
- Now shows resolution alongside multiplier

This screenshot shows the updated interface:
<img src=https://github.com/Lime3DS/Lime3DS/assets/48618519/6240bc24-2b93-4106-a809-7343eb07d337 height=500px/>

This screenshot shows the current desktop interface:
<img src=https://github.com/Lime3DS/Lime3DS/assets/48618519/1ae3f244-2dbf-42fe-9919-a9c23a1e6e71 width=500px/>

Closes #141