### PR TITLE
ci: Strip Clang binaries

### DIFF
--- a/.ci/linux.sh
+++ b/.ci/linux.sh
@@ -20,6 +20,7 @@ cmake .. -G Ninja \
     -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON \
     -DUSE_DISCORD_PRESENCE=ON
 ninja
+strip -s bin/Release/*
 
 if [ "$TARGET" = "appimage" ]; then
     ninja bundle

--- a/.ci/windows.sh
+++ b/.ci/windows.sh
@@ -11,6 +11,7 @@ cmake .. -G Ninja \
     -DUSE_DISCORD_PRESENCE=ON
 ninja
 ninja bundle
+strip -s bundle/*.exe
 
 ccache -s -v
 


### PR DESCRIPTION
Reduces the size of the executables by removing unnecessary symbols. CMake doesn't do it automatically unless you invoke the Install script (which Citra never did). XCode and MSVC supposedly does it for Release builds. Not sure about Android.

Edit: As an example, the stock file size of msys2 lime-qt.exe is about 47,295 KB while the stripped version is about 30,043 KB, according to Windows Explorer.