### PR TITLE
lime_qt: Add Open Log Folder option to Help menu

### DIFF
--- a/src/lime_qt/main.cpp
+++ b/src/lime_qt/main.cpp
@@ -951,6 +951,10 @@ void GMainWindow::ConnectMenuEvents() {
 
     // Help
     connect_menu(ui->action_Open_Citra_Folder, &GMainWindow::OnOpenCitraFolder);
+    connect_menu(ui->action_Open_Log_Folder, []() {
+        QString path = QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::LogDir));
+        QDesktopServices::openUrl(QUrl::fromLocalFile(path));
+    });
     connect_menu(ui->action_FAQ, []() {
         QDesktopServices::openUrl(QUrl(QStringLiteral("https://discord.com/invite/4ZjMpAp3M6")));
     });

--- a/src/lime_qt/main.ui
+++ b/src/lime_qt/main.ui
@@ -485,7 +485,7 @@
     <string>Open Log Folder</string>
    </property>
    <property name="toolTip">
-    <string>Opens the Lime3DS Log folder</string>
+    <string>Opens the Lime3DS log folder</string>
    </property>
   </action>
   <action name="action_Open_Maintenance_Tool">

--- a/src/lime_qt/main.ui
+++ b/src/lime_qt/main.ui
@@ -203,6 +203,7 @@
     <addaction name="separator"/>
     <addaction name="action_Report_Compatibility"/>
     <addaction name="separator"/>
+    <addaction name="action_Open_Log_Folder"/>
     <addaction name="action_FAQ"/>
     <addaction name="action_About"/>
    </widget>
@@ -477,6 +478,14 @@
    </property>
    <property name="text">
     <string>Fullscreen</string>
+   </property>
+  </action>
+  <action name="action_Open_Log_Folder">
+   <property name="text">
+    <string>Open Log Folder</string>
+   </property>
+   <property name="toolTip">
+    <string>Opens the Lime3DS Log folder</string>
    </property>
   </action>
   <action name="action_Open_Maintenance_Tool">


### PR DESCRIPTION
This may help decrease the support burden by making the accessing of logs more obvious. Plus, it'd be easier to refer people to `Help->Open Log Folder` rather than `File->Open Lime3DS Folder->Logs` or `Emulation->Configure->General->Debug->Open Log Location`.

Addresses #157 

![help-log](https://github.com/Lime3DS/Lime3DS/assets/8913195/db95e1ae-a450-4342-b2cf-9a23afb50833)
