### PR TITLE
Implement realtime audio playback option

### DIFF
--- a/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/model/IntSetting.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/model/IntSetting.kt
@@ -35,6 +35,7 @@ enum class IntSetting(
     ASYNC_CUSTOM_LOADING("async_custom_loading", Settings.SECTION_UTILITY, 1),
     PRELOAD_TEXTURES("preload_textures", Settings.SECTION_UTILITY, 0),
     ENABLE_AUDIO_STRETCHING("enable_audio_stretching", Settings.SECTION_AUDIO, 1),
+    ENABLE_REALTIME_AUDIO("enable_realtime_audio", Settings.SECTION_AUDIO, 0),
     CPU_JIT("use_cpu_jit", Settings.SECTION_CORE, 1),
     HW_SHADER("use_hw_shader", Settings.SECTION_RENDERER, 1),
     VSYNC("use_vsync_new", Settings.SECTION_RENDERER, 1),

--- a/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/ui/SettingsFragmentPresenter.kt
@@ -860,6 +860,15 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                 )
             )
             add(
+                SwitchSetting(
+                    IntSetting.ENABLE_REALTIME_AUDIO,
+                    R.string.realtime_audio,
+                    R.string.realtime_audio_description,
+                    IntSetting.ENABLE_REALTIME_AUDIO.key,
+                    IntSetting.ENABLE_REALTIME_AUDIO.defaultValue
+                )
+            )
+            add(
                 SingleChoiceSetting(
                     IntSetting.AUDIO_INPUT_TYPE,
                     R.string.audio_input_type,

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -195,6 +195,7 @@ void Config::ReadValues() {
     // Audio
     ReadSetting("Audio", Settings::values.audio_emulation);
     ReadSetting("Audio", Settings::values.enable_audio_stretching);
+    ReadSetting("Audio", Settings::values.enable_realtime_audio);
     ReadSetting("Audio", Settings::values.volume);
     ReadSetting("Audio", Settings::values.output_type);
     ReadSetting("Audio", Settings::values.output_device);

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -240,6 +240,10 @@ enable_dsp_lle_thread =
 # 0: No, 1 (default): Yes
 enable_audio_stretching =
 
+# Simulates the Nintendo 3DS audio for HLE
+# 0 (default): No, 1: Yes
+enable_realtime_audio =
+
 # Output volume.
 # 1.0 (default): 100%, 0.0; mute
 volume =

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -240,7 +240,7 @@ enable_dsp_lle_thread =
 # 0: No, 1 (default): Yes
 enable_audio_stretching =
 
-# Simulates the Nintendo 3DS audio for HLE
+# Scales audio playback speed to account for drops in emulation framerate
 # 0 (default): No, 1: Yes
 enable_realtime_audio =
 

--- a/src/android/app/src/main/res/values-es/strings.xml
+++ b/src/android/app/src/main/res/values-es/strings.xml
@@ -246,6 +246,8 @@ Se esperan fallos gráficos temporales cuando ésta esté activado.</string>
     <string name="audio_volume">Volumen</string>
     <string name="audio_stretch">Extensión de Audio</string>
     <string name="audio_stretch_description">Extiende el audio para reducir los parones. Cuando se active, la latencia de audio se incrementará y reducirá un poco el rendimiento.</string>
+    <string name="realtime_audio">Activar audio en tiempo real</string>
+    <string name="realtime_audio_description">Simula el audio de la Nintendo 3DS para HLE, corrigiendo el retraso del audio cuando la velocidad es inferior al 100%. Podría causar problemas de desincronización del audio</string>
     <string name="audio_input_type">Dispositivo de entrada de audio</string>
     <string name="sound_output_mode">Modo de salida del audio</string>
 

--- a/src/android/app/src/main/res/values-es/strings.xml
+++ b/src/android/app/src/main/res/values-es/strings.xml
@@ -247,7 +247,7 @@ Se esperan fallos gráficos temporales cuando ésta esté activado.</string>
     <string name="audio_stretch">Extensión de Audio</string>
     <string name="audio_stretch_description">Extiende el audio para reducir los parones. Cuando se active, la latencia de audio se incrementará y reducirá un poco el rendimiento.</string>
     <string name="realtime_audio">Activar audio en tiempo real</string>
-    <string name="realtime_audio_description">Simula el audio de la Nintendo 3DS para HLE, corrigiendo el retraso del audio cuando la velocidad es inferior al 100%. Podría causar problemas de desincronización del audio</string>
+    <string name="realtime_audio_description">Ajusta la velocidad de reproducción de audio para compensar las caídas en la velocidad de emulación de cuadros. Esto significa que el audio se reproducirá a velocidad completa incluso cuando la velocidad de cuadros del juego sea baja. Puede causar problemas de desincronización de audio.</string>
     <string name="audio_input_type">Dispositivo de entrada de audio</string>
     <string name="sound_output_mode">Modo de salida del audio</string>
 

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -271,8 +271,8 @@
     <string name="audio_volume">Volume</string>
     <string name="audio_stretch">Audio Stretching</string>
     <string name="audio_stretch_description">Stretches audio to reduce stuttering. When enabled, increases audio latency and slightly reduces performance.</string>
-    <string name="realtime_audio">Enable real-time audio</string>
-    <string name="realtime_audio_description">Simulates the Nintendo 3DS audio for HLE, fixing audio lag when speed is lower from 100%. Might cause audio desync issues</string>
+    <string name="realtime_audio">Enable realtime audio</string>
+    <string name="realtime_audio_description">Scales audio playback speed to account for drops in emulation framerate. This means that audio will play at full speed even while the game framerate is low. May cause audio desync issues.</string>
     <string name="audio_input_type">Audio Input Device</string>
     <string name="sound_output_mode">Sound Output Mode</string>
 

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -271,6 +271,8 @@
     <string name="audio_volume">Volume</string>
     <string name="audio_stretch">Audio Stretching</string>
     <string name="audio_stretch_description">Stretches audio to reduce stuttering. When enabled, increases audio latency and slightly reduces performance.</string>
+    <string name="realtime_audio">Enable real-time audio</string>
+    <string name="realtime_audio_description">Simulates the Nintendo 3DS audio for HLE, fixing audio lag when speed is lower from 100%. Might cause audio desync issues</string>
     <string name="audio_input_type">Audio Input Device</string>
     <string name="sound_output_mode">Sound Output Mode</string>
 

--- a/src/audio_core/hle/hle.cpp
+++ b/src/audio_core/hle/hle.cpp
@@ -419,7 +419,7 @@ void DspHle::Impl::AudioTickCallback(s64 cycles_late) {
     // Reschedule recurrent event
     const double time_scale =
         Settings::values.enable_realtime_audio
-            ? std::clamp(Core::System::GetInstance().GetLastFrameTimeScale(), 1.0, 3.0)
+            ? std::clamp(Core::System::GetInstance().GetStableFrameTimeScale(), 1.0, 3.0)
             : 1.0;
     s64 adjusted_ticks = static_cast<s64>(audio_frame_ticks / time_scale - cycles_late);
     core_timing.ScheduleEvent(adjusted_ticks, tick_event);

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -121,6 +121,7 @@ void LogSettings() {
     log_setting("Audio_InputType", values.input_type.GetValue());
     log_setting("Audio_InputDevice", values.input_device.GetValue());
     log_setting("Audio_EnableAudioStretching", values.enable_audio_stretching.GetValue());
+    log_setting("Audio_EnableRealtime", values.enable_realtime_audio.GetValue());
     using namespace Service::CAM;
     log_setting("Camera_OuterRightName", values.camera_name[OuterRightCamera]);
     log_setting("Camera_OuterRightConfig", values.camera_config[OuterRightCamera]);
@@ -171,6 +172,7 @@ void RestoreGlobalState(bool is_powered_on) {
     // Audio
     values.audio_emulation.SetGlobal(true);
     values.enable_audio_stretching.SetGlobal(true);
+    values.enable_realtime_audio.SetGlobal(true);
     values.volume.SetGlobal(true);
 
     // Core

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -521,6 +521,7 @@ struct Values {
     bool audio_muted;
     SwitchableSetting<AudioEmulation> audio_emulation{AudioEmulation::HLE, "audio_emulation"};
     SwitchableSetting<bool> enable_audio_stretching{true, "enable_audio_stretching"};
+    SwitchableSetting<bool> enable_realtime_audio{false, "enable_realtime_audio"};
     SwitchableSetting<float, true> volume{1.f, 0.f, 1.f, "volume"};
     Setting<AudioCore::SinkType> output_type{AudioCore::SinkType::Auto, "output_type"};
     Setting<std::string> output_device{"auto", "output_device"};

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -392,6 +392,10 @@ PerfStats::Results System::GetLastPerfStats() {
     return perf_stats ? perf_stats->GetLastStats() : PerfStats::Results{};
 }
 
+double System::GetLastFrameTimeScale() {
+    return perf_stats->GetLastFrameTimeScale();
+}
+
 void System::Reschedule() {
     if (!reschedule_pending) {
         return;

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -392,8 +392,8 @@ PerfStats::Results System::GetLastPerfStats() {
     return perf_stats ? perf_stats->GetLastStats() : PerfStats::Results{};
 }
 
-double System::GetLastFrameTimeScale() {
-    return perf_stats->GetLastFrameTimeScale();
+double System::GetStableFrameTimeScale() {
+    return perf_stats->GetStableFrameTimeScale();
 }
 
 void System::Reschedule() {

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -193,6 +193,8 @@ public:
 
     [[nodiscard]] PerfStats::Results GetLastPerfStats();
 
+    double GetLastFrameTimeScale();
+
     /**
      * Gets a reference to the emulated CPU.
      * @returns A reference to the emulated CPU.

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -193,7 +193,7 @@ public:
 
     [[nodiscard]] PerfStats::Results GetLastPerfStats();
 
-    double GetLastFrameTimeScale();
+    double GetStableFrameTimeScale();
 
     /**
      * Gets a reference to the emulated CPU.

--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -133,7 +133,7 @@ double PerfStats::GetStableFrameTimeScale() const {
     std::scoped_lock lock{object_mutex};
 
     constexpr double FRAME_LENGTH_MILLIS = (1.0 / SCREEN_REFRESH_RATE) * 1000;
-    const short num_frames = std::min(50ul, current_index + 1);
+    const size_t num_frames = std::min<size_t>(50UL, current_index + 1);
     const double sum = std::accumulate(perf_history.begin() + current_index - num_frames,
                                        perf_history.begin() + current_index, 0.0);
     const double stable_frame_length = sum / num_frames;

--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -129,6 +129,17 @@ double PerfStats::GetLastFrameTimeScale() const {
     return duration_cast<DoubleSecs>(previous_frame_length).count() / FRAME_LENGTH;
 }
 
+double PerfStats::GetStableFrameTimeScale() const {
+    std::scoped_lock lock{object_mutex};
+
+    constexpr double FRAME_LENGTH_MILLIS = (1.0 / SCREEN_REFRESH_RATE) * 1000;
+    const short num_frames = std::min(50ul, current_index + 1);
+    const double sum = std::accumulate(perf_history.begin() + current_index - num_frames,
+                                       perf_history.begin() + current_index, 0.0);
+    const double stable_frame_length = sum / num_frames;
+    return stable_frame_length / FRAME_LENGTH_MILLIS;
+}
+
 void FrameLimiter::WaitOnce() {
     if (frame_advancing_enabled) {
         // Frame advancing is enabled: wait on event instead of doing framelimiting

--- a/src/core/perf_stats.h
+++ b/src/core/perf_stats.h
@@ -82,6 +82,12 @@ public:
      */
     double GetLastFrameTimeScale() const;
 
+    /**
+     * Has the same functionality as GetLastFrameTimeScale, but uses the mean frame time over the
+     * last 50 frames rather than only the frame time of the previous frame.
+     */
+    double GetStableFrameTimeScale() const;
+
     void AddArticBaseTraffic(u32 bytes) {
         artic_transmitted += bytes;
     }

--- a/src/lime/config.cpp
+++ b/src/lime/config.cpp
@@ -184,6 +184,7 @@ void Config::ReadValues() {
     // Audio
     ReadSetting("Audio", Settings::values.audio_emulation);
     ReadSetting("Audio", Settings::values.enable_audio_stretching);
+    ReadSetting("Audio", Settings::values.enable_realtime_audio);
     ReadSetting("Audio", Settings::values.volume);
     ReadSetting("Audio", Settings::values.output_type);
     ReadSetting("Audio", Settings::values.output_device);

--- a/src/lime/default_ini.h
+++ b/src/lime/default_ini.h
@@ -252,7 +252,7 @@ enable_dsp_lle_thread =
 # 0: No, 1 (default): Yes
 enable_audio_stretching =
 
-# Simulates the Nintendo 3DS audio for HLE
+# Scales audio playback speed to account for drops in emulation framerate
 # 0 (default): No, 1: Yes
 enable_realtime_audio =
 

--- a/src/lime/default_ini.h
+++ b/src/lime/default_ini.h
@@ -252,6 +252,10 @@ enable_dsp_lle_thread =
 # 0: No, 1 (default): Yes
 enable_audio_stretching =
 
+# Simulates the Nintendo 3DS audio for HLE
+# 0 (default): No, 1: Yes
+enable_realtime_audio =
+
 # Output volume.
 # 1.0 (default): 100%, 0.0; mute
 volume =

--- a/src/lime_qt/configuration/config.cpp
+++ b/src/lime_qt/configuration/config.cpp
@@ -278,6 +278,7 @@ void Config::ReadAudioValues() {
 
     ReadGlobalSetting(Settings::values.audio_emulation);
     ReadGlobalSetting(Settings::values.enable_audio_stretching);
+    ReadGlobalSetting(Settings::values.enable_realtime_audio);
     ReadGlobalSetting(Settings::values.volume);
 
     if (global) {
@@ -885,6 +886,7 @@ void Config::SaveAudioValues() {
 
     WriteGlobalSetting(Settings::values.audio_emulation);
     WriteGlobalSetting(Settings::values.enable_audio_stretching);
+    WriteGlobalSetting(Settings::values.enable_realtime_audio);
     WriteGlobalSetting(Settings::values.volume);
 
     if (global) {

--- a/src/lime_qt/configuration/configure_audio.cpp
+++ b/src/lime_qt/configuration/configure_audio.cpp
@@ -49,6 +49,8 @@ ConfigureAudio::ConfigureAudio(bool is_powered_on, QWidget* parent)
             &ConfigureAudio::UpdateAudioOutputDevices);
     connect(ui->input_type_combo_box, qOverload<int>(&QComboBox::currentIndexChanged), this,
             &ConfigureAudio::UpdateAudioInputDevices);
+    connect(ui->emulation_combo_box, qOverload<int>(&QComboBox::currentIndexChanged), this,
+            &ConfigureAudio::SetHleFeaturesEnabled);
 }
 
 ConfigureAudio::~ConfigureAudio() {}
@@ -65,6 +67,7 @@ void ConfigureAudio::SetConfiguration() {
 
     ui->toggle_audio_stretching->setChecked(Settings::values.enable_audio_stretching.GetValue());
     ui->toggle_realtime_audio->setChecked(Settings::values.enable_realtime_audio.GetValue());
+    SetHleFeaturesEnabled();
 
     const s32 volume =
         static_cast<s32>(Settings::values.volume.GetValue() * ui->volume_slider->maximum());
@@ -151,6 +154,14 @@ void ConfigureAudio::SetInputDeviceFromDeviceID() {
 
 void ConfigureAudio::SetVolumeIndicatorText(int percentage) {
     ui->volume_indicator->setText(tr("%1%", "Volume percentage (e.g. 50%)").arg(percentage));
+}
+
+void ConfigureAudio::SetHleFeaturesEnabled() {
+    const bool is_hle =
+        ui->emulation_combo_box->currentIndex() == static_cast<int>(Settings::AudioEmulation::HLE);
+
+    ui->toggle_audio_stretching->setEnabled(is_hle);
+    ui->toggle_realtime_audio->setEnabled(is_hle);
 }
 
 void ConfigureAudio::ApplyConfiguration() {

--- a/src/lime_qt/configuration/configure_audio.cpp
+++ b/src/lime_qt/configuration/configure_audio.cpp
@@ -64,6 +64,7 @@ void ConfigureAudio::SetConfiguration() {
     SetInputDeviceFromDeviceID();
 
     ui->toggle_audio_stretching->setChecked(Settings::values.enable_audio_stretching.GetValue());
+    ui->toggle_realtime_audio->setChecked(Settings::values.enable_realtime_audio.GetValue());
 
     const s32 volume =
         static_cast<s32>(Settings::values.volume.GetValue() * ui->volume_slider->maximum());
@@ -155,6 +156,8 @@ void ConfigureAudio::SetVolumeIndicatorText(int percentage) {
 void ConfigureAudio::ApplyConfiguration() {
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.enable_audio_stretching,
                                              ui->toggle_audio_stretching, audio_stretching);
+    ConfigurationShared::ApplyPerGameSetting(&Settings::values.enable_realtime_audio,
+                                             ui->toggle_realtime_audio, realtime_audio);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.audio_emulation,
                                              ui->emulation_combo_box);
     ConfigurationShared::ApplyPerGameSetting(
@@ -235,4 +238,7 @@ void ConfigureAudio::SetupPerGameUI() {
 
     ConfigurationShared::SetColoredTristate(
         ui->toggle_audio_stretching, Settings::values.enable_audio_stretching, audio_stretching);
+
+    ConfigurationShared::SetColoredTristate(ui->toggle_realtime_audio,
+                                            Settings::values.enable_realtime_audio, realtime_audio);
 }

--- a/src/lime_qt/configuration/configure_audio.h
+++ b/src/lime_qt/configuration/configure_audio.h
@@ -39,5 +39,6 @@ private:
     void SetupPerGameUI();
 
     ConfigurationShared::CheckState audio_stretching;
+    ConfigurationShared::CheckState realtime_audio;
     std::unique_ptr<Ui::ConfigureAudio> ui;
 };

--- a/src/lime_qt/configuration/configure_audio.h
+++ b/src/lime_qt/configuration/configure_audio.h
@@ -35,6 +35,7 @@ private:
     void SetInputTypeFromInputType();
     void SetInputDeviceFromDeviceID();
     void SetVolumeIndicatorText(int percentage);
+    void SetHleFeaturesEnabled();
 
     void SetupPerGameUI();
 

--- a/src/lime_qt/configuration/configure_audio.ui
+++ b/src/lime_qt/configuration/configure_audio.ui
@@ -96,6 +96,16 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="toggle_realtime_audio">
+        <property name="toolTip">
+         <string>Simulates the Nintendo 3DS audio for HLE, fixing audio lag when speed is lower from 100%. Might cause audio desync issues</string>
+        </property>
+        <property name="text">
+         <string>Enable real-time audio</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QWidget" name="volume_layout" native="true">
         <layout class="QHBoxLayout" name="horizontalLayout_2">
          <property name="leftMargin">

--- a/src/lime_qt/configuration/configure_audio.ui
+++ b/src/lime_qt/configuration/configure_audio.ui
@@ -98,10 +98,10 @@
       <item>
        <widget class="QCheckBox" name="toggle_realtime_audio">
         <property name="toolTip">
-         <string>Simulates the Nintendo 3DS audio for HLE, fixing audio lag when speed is lower from 100%. Might cause audio desync issues</string>
+         <string>Scales audio playback speed to account for drops in emulation framerate. This means that audio will play at full speed even while the game framerate is low. May cause audio desync issues.</string>
         </property>
         <property name="text">
-         <string>Enable real-time audio</string>
+         <string>Enable realtime audio</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This pull request ports the realtime audio option which was recently added to Citra Enhanced, although I have made a notable improvement to how the feature behaves.

The version of the feature which is currently present in Citra Enhanced calculates the audio timescale by using only data from the previous frame. This means that if the emulation framerate is inconsistent, the audio playback will reflect this inconsistency, leading to frequent and very noticeable speedups and slowdowns.

To remedy this, I have tweaked the implementation of this feature when bringing it over to Lime3DS. Instead of only using the data from the previous frame to calculate the audio timescale, a mean average of the last 50 displayed frames is used. This results in significantly smoother playback when the framerate is inconsistent.

This '50 frames' number was the result of personal testing. Values lower than this did not properly address the issue enough and still had speedups and slowdowns in audio playback when framerate was inconsistent, whereas values higher than this did not account for changes in framerate fast enough, which resulted in the same issue when entering large lag spikes. 50 frames of data seems to be the Goldilocks zone for consistent playback