### PR TITLE
Android: Fix non-runnable settings not being still changeable after closing a game

### DIFF
--- a/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/ui/viewholder/RunnableViewHolder.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/ui/viewholder/RunnableViewHolder.kt
@@ -44,10 +44,10 @@ class RunnableViewHolder(val binding: ListItemSettingBinding, adapter: SettingsA
     }
 
     override fun onClick(clicked: View) {
-        if (!setting.isRuntimeRunnable && !NativeLibrary.isRunning()) {
-            setting.runnable.invoke()
-        } else {
+        if (!setting.isRuntimeRunnable && NativeLibrary.isRunning()) {
             adapter.onClickDisabledSetting()
+        } else {
+            setting.runnable.invoke()
         }
     }
 


### PR DESCRIPTION
Sometimes, non-runnable settings were still blocked after closing the game, needing a app reboot. Now this should be fixed.