### PR TITLE
Android & PC: Implement Raise CPU Ticks option

### DIFF
--- a/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/model/IntSetting.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/model/IntSetting.kt
@@ -39,6 +39,7 @@ enum class IntSetting(
     CPU_JIT("use_cpu_jit", Settings.SECTION_CORE, 1),
     HW_SHADER("use_hw_shader", Settings.SECTION_RENDERER, 1),
     VSYNC("use_vsync_new", Settings.SECTION_RENDERER, 1),
+    RAISE_CPU_TICKS("raise_cpu_ticks", Settings.SECTION_CORE, 0),
     DEBUG_RENDERER("renderer_debug", Settings.SECTION_DEBUG, 0),
     TEXTURE_FILTER("texture_filter", Settings.SECTION_RENDERER, 0),
     USE_FRAME_LIMIT("use_frame_limit", Settings.SECTION_RENDERER, 1);

--- a/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/ui/SettingsFragmentPresenter.kt
@@ -965,6 +965,15 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
             )
             add(
                 SwitchSetting(
+                    IntSetting.RAISE_CPU_TICKS,
+                    R.string.raise_cpu_ticks,
+                    R.string.raise_cpu_ticks_description,
+                    IntSetting.RAISE_CPU_TICKS.key,
+                    IntSetting.RAISE_CPU_TICKS.defaultValue
+                )
+            )
+            add(
+                SwitchSetting(
                     IntSetting.DEBUG_RENDERER,
                     R.string.renderer_debug,
                     R.string.renderer_debug_description,

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -131,6 +131,7 @@ void Config::ReadValues() {
     // Core
     ReadSetting("Core", Settings::values.use_cpu_jit);
     ReadSetting("Core", Settings::values.cpu_clock_percentage);
+    ReadSetting("Core", Settings::values.raise_cpu_ticks);
 
     // Renderer
     Settings::values.use_gles = sdl2_config->GetBoolean("Renderer", "use_gles", true);

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -97,6 +97,10 @@ use_cpu_jit =
 # Range is any positive integer (but we suspect 25 - 400 is a good idea) Default is 100
 cpu_clock_percentage =
 
+# Adds 16000 CPU ticks.
+# 0 (default): Off, 1: On
+raise_cpu_ticks =
+
 [Renderer]
 # Whether to render using OpenGL
 # 1: OpenGL ES (default), 2: Vulkan

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -97,7 +97,7 @@ use_cpu_jit =
 # Range is any positive integer (but we suspect 25 - 400 is a good idea) Default is 100
 cpu_clock_percentage =
 
-# Adds 16000 CPU ticks.
+# Sets 16000 CPU ticks.
 # 0 (default): Off, 1: On
 raise_cpu_ticks =
 

--- a/src/android/app/src/main/res/values-es/strings.xml
+++ b/src/android/app/src/main/res/values-es/strings.xml
@@ -200,6 +200,8 @@ Se esperan fallos gráficos temporales cuando ésta esté activado.</string>
     <string name="renderer_debug_description">Archiva información adicional gráfica relacionada con la depuración. Cuando está activada, el rendimiento de los juegos será reducido considerablemente</string>
     <string name="vsync">Activar Sincronización Vertical</string>
     <string name="vsync_description">Sincroniza los cuadros por segundo del juego con la tasa de refresco de tu dispositivo.</string>
+    <string name="raise_cpu_ticks">Incrementar Ticks CPU</string>
+    <string name="raise_cpu_ticks_description">Agrega 16000 CPU ticks. Puede mejorar o disminuir el rendimiento, dependiendo del juego o si es un dispositivo de gama baja</string>
     <string name="linear_filtering">Filtro Linear</string>
     <string name="linear_filtering_description">Activa el filtro linear, que hace que los gráficos del juego se vean más suaves.</string>
     <string name="texture_filter_name">Filtro de Texturas</string>

--- a/src/android/app/src/main/res/values-es/strings.xml
+++ b/src/android/app/src/main/res/values-es/strings.xml
@@ -201,7 +201,7 @@ Se esperan fallos gráficos temporales cuando ésta esté activado.</string>
     <string name="vsync">Activar Sincronización Vertical</string>
     <string name="vsync_description">Sincroniza los cuadros por segundo del juego con la tasa de refresco de tu dispositivo.</string>
     <string name="raise_cpu_ticks">Incrementar Ticks CPU</string>
-    <string name="raise_cpu_ticks_description">Agrega 16000 CPU ticks. Puede mejorar o disminuir el rendimiento, dependiendo del juego o si es un dispositivo de gama baja</string>
+    <string name="raise_cpu_ticks_description">Establece 16000 CPU ticks. Puede mejorar o disminuir el rendimiento, dependiendo del juego o si es un dispositivo de gama baja</string>
     <string name="linear_filtering">Filtro Linear</string>
     <string name="linear_filtering_description">Activa el filtro linear, que hace que los gráficos del juego se vean más suaves.</string>
     <string name="texture_filter_name">Filtro de Texturas</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -216,7 +216,7 @@
     <string name="vsync">Enable V-Sync</string>
     <string name="vsync_description">Synchronizes the game frame rate to the refresh rate of your device.</string>
     <string name="raise_cpu_ticks">Raise CPU Ticks</string>
-    <string name="raise_cpu_ticks_description">Adds 16000 CPU ticks. May improve the performance or decrease, depending of the game or if it is a low-end device</string>
+    <string name="raise_cpu_ticks_description">Sets 16000 CPU ticks. May improve the performance or decrease, depending of the game or if it is a low-end device</string>
     <string name="linear_filtering">Linear Filtering</string>
     <string name="linear_filtering_description">Enables linear filtering, which causes game visuals to appear smoother.</string>
     <string name="texture_filter_name">Texture Filter</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -215,6 +215,8 @@
     <string name="renderer_debug_description">Log additional graphics related debug information. When enabled, game performance will be significantly reduced.</string>
     <string name="vsync">Enable V-Sync</string>
     <string name="vsync_description">Synchronizes the game frame rate to the refresh rate of your device.</string>
+    <string name="raise_cpu_ticks">Raise CPU Ticks</string>
+    <string name="raise_cpu_ticks_description">Adds 16000 CPU ticks. May improve the performance or decrease, depending of the game or if it is a low-end device</string>
     <string name="linear_filtering">Linear Filtering</string>
     <string name="linear_filtering_description">Enables linear filtering, which causes game visuals to appear smoother.</string>
     <string name="texture_filter_name">Texture Filter</string>

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -83,7 +83,7 @@ void LogSettings() {
     LOG_INFO(Config, "Lime3DS Configuration:");
     log_setting("Core_UseCpuJit", values.use_cpu_jit.GetValue());
     log_setting("Core_CPUClockPercentage", values.cpu_clock_percentage.GetValue());
-    log_setting("Core_RaiseTicks", values.raise_cpu_ticks.GetValue());
+    log_setting("Core_RaiseCPUTicks", values.raise_cpu_ticks.GetValue());
     log_setting("Renderer_UseGLES", values.use_gles.GetValue());
     log_setting("Renderer_GraphicsAPI", GetGraphicsAPIName(values.graphics_api.GetValue()));
     log_setting("Renderer_AsyncShaders", values.async_shader_compilation.GetValue());

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -83,6 +83,7 @@ void LogSettings() {
     LOG_INFO(Config, "Lime3DS Configuration:");
     log_setting("Core_UseCpuJit", values.use_cpu_jit.GetValue());
     log_setting("Core_CPUClockPercentage", values.cpu_clock_percentage.GetValue());
+    log_setting("Core_RaiseTicks", values.raise_cpu_ticks.GetValue());
     log_setting("Renderer_UseGLES", values.use_gles.GetValue());
     log_setting("Renderer_GraphicsAPI", GetGraphicsAPIName(values.graphics_api.GetValue()));
     log_setting("Renderer_AsyncShaders", values.async_shader_compilation.GetValue());
@@ -177,6 +178,7 @@ void RestoreGlobalState(bool is_powered_on) {
 
     // Core
     values.cpu_clock_percentage.SetGlobal(true);
+    values.raise_cpu_ticks.SetGlobal(true);
     values.is_new_3ds.SetGlobal(true);
     values.lle_applets.SetGlobal(true);
 

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -431,6 +431,7 @@ struct Values {
     // Core
     Setting<bool> use_cpu_jit{true, "use_cpu_jit"};
     SwitchableSetting<s32, true> cpu_clock_percentage{100, 5, 400, "cpu_clock_percentage"};
+    SwitchableSetting<bool> raise_cpu_ticks{false, "raise_cpu_ticks"};
     SwitchableSetting<bool> is_new_3ds{true, "is_new_3ds"};
     SwitchableSetting<bool> lle_applets{false, "lle_applets"};
 

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -176,7 +176,8 @@ u64 Timing::Timer::GetTicks() const {
 }
 
 void Timing::Timer::AddTicks(u64 ticks) {
-    downcount -= static_cast<u64>(ticks * cpu_clock_scale);
+    downcount -=
+        static_cast<u64>((Settings::values.raise_cpu_ticks ? 16000 : ticks) * cpu_clock_scale);
 }
 
 u64 Timing::Timer::GetIdleTicks() const {

--- a/src/lime/config.cpp
+++ b/src/lime/config.cpp
@@ -130,6 +130,7 @@ void Config::ReadValues() {
     // Core
     ReadSetting("Core", Settings::values.use_cpu_jit);
     ReadSetting("Core", Settings::values.cpu_clock_percentage);
+    ReadSetting("Core", Settings::values.raise_cpu_ticks);
 
     // Renderer
     ReadSetting("Renderer", Settings::values.graphics_api);

--- a/src/lime/default_ini.h
+++ b/src/lime/default_ini.h
@@ -97,6 +97,10 @@ use_cpu_jit =
 # Range is any positive integer (but we suspect 25 - 400 is a good idea) Default is 100
 cpu_clock_percentage =
 
+# Adds 16000 CPU ticks.
+# 0 (default): Off, 1: On
+raise_cpu_ticks =
+
 [Renderer]
 # Whether to render using OpenGL or Software
 # 0: Software, 1: OpenGL (default), 2: Vulkan

--- a/src/lime/default_ini.h
+++ b/src/lime/default_ini.h
@@ -97,7 +97,7 @@ use_cpu_jit =
 # Range is any positive integer (but we suspect 25 - 400 is a good idea) Default is 100
 cpu_clock_percentage =
 
-# Adds 16000 CPU ticks.
+# Sets 16000 CPU ticks.
 # 0 (default): Off, 1: On
 raise_cpu_ticks =
 

--- a/src/lime_qt/configuration/config.cpp
+++ b/src/lime_qt/configuration/config.cpp
@@ -455,6 +455,7 @@ void Config::ReadCoreValues() {
     qt_config->beginGroup(QStringLiteral("Core"));
 
     ReadGlobalSetting(Settings::values.cpu_clock_percentage);
+    ReadGlobalSetting(Settings::values.raise_cpu_ticks);
 
     if (global) {
         ReadBasicSetting(Settings::values.use_cpu_jit);
@@ -1003,6 +1004,7 @@ void Config::SaveCoreValues() {
     qt_config->beginGroup(QStringLiteral("Core"));
 
     WriteGlobalSetting(Settings::values.cpu_clock_percentage);
+    WriteGlobalSetting(Settings::values.raise_cpu_ticks);
 
     if (global) {
         WriteBasicSetting(Settings::values.use_cpu_jit);

--- a/src/lime_qt/configuration/configure_debug.cpp
+++ b/src/lime_qt/configuration/configure_debug.cpp
@@ -102,6 +102,7 @@ void ConfigureDebug::SetConfiguration() {
         Settings::values.delay_start_for_lle_modules.GetValue());
     ui->toggle_renderer_debug->setChecked(Settings::values.renderer_debug.GetValue());
     ui->toggle_dump_command_buffers->setChecked(Settings::values.dump_command_buffers.GetValue());
+    ui->toggle_raise_cpu_ticks->setChecked(Settings::values.raise_cpu_ticks.GetValue());
 
     if (!Settings::IsConfiguringGlobal()) {
         if (Settings::values.cpu_clock_percentage.UsingGlobal()) {
@@ -134,6 +135,7 @@ void ConfigureDebug::ApplyConfiguration() {
     Settings::values.delay_start_for_lle_modules = ui->delay_start_for_lle_modules->isChecked();
     Settings::values.renderer_debug = ui->toggle_renderer_debug->isChecked();
     Settings::values.dump_command_buffers = ui->toggle_dump_command_buffers->isChecked();
+    Settings::values.raise_cpu_ticks = ui->toggle_raise_cpu_ticks->isChecked();
 
     ConfigurationShared::ApplyPerGameSetting(
         &Settings::values.cpu_clock_percentage, ui->clock_speed_combo,

--- a/src/lime_qt/configuration/configure_debug.ui
+++ b/src/lime_qt/configuration/configure_debug.ui
@@ -219,7 +219,7 @@
       <item row="5" column="0">
        <widget class="QCheckBox" name="toggle_raise_cpu_ticks">
        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds 16000 CPU ticks. May improve the performance or decrease, depending of the game or if it is a low-end device&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sets 16000 CPU ticks. May improve the performance or decrease, depending of the game or if it is a low-end device&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
          <string>Raise CPU Ticks</string>

--- a/src/lime_qt/configuration/configure_debug.ui
+++ b/src/lime_qt/configuration/configure_debug.ui
@@ -216,6 +216,16 @@
         </property>
        </widget>
       </item>
+      <item row="5" column="0">
+       <widget class="QCheckBox" name="toggle_raise_cpu_ticks">
+       <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds 16000 CPU ticks. May improve the performance or decrease, depending of the game or if it is a low-end device&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Raise CPU Ticks</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
This option adds 16000 ticks to CPU timing, improving the performance for some games, as Luigi's Mansion Dark Moon or Street Fighter 4. May help a lot for low end devices as well.

I didn't make a slider for it because ticks use very high values, so an average user may not know handle this setting correctly