### PR TITLE
actions: disable spirv-tools installation for MacOS x86_64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,10 @@ jobs:
         with:
           xcode-version: latest-stable
       - name: Install tools
-        run: brew install ccache ninja spirv-tools
+        run: brew install ccache ninja 
+      - name: Install spirv-tools (arm64)
+        run: brew install spirv-tools
+        if: ${{ matrix.target == 'arm64' }}
       - name: Build
         run: ./.ci/macos.sh
       - name: Prepare outputs for caching


### PR DESCRIPTION
It was discovered that the spirv-opt libraries bundled on Mac builds do not work on older versions of the OS. Currently, MacOS 13 is used for building x86_64 binaries, and 14 for arm64. Lime3DS wishes to support at least MacOS 11, so disable the installation of spirv-tools for MacOS x86_64 builds but leave it for arm64 builds.

Fixes #218 