### PR TITLE
video_core: Restore Frame Skip functionality

### DIFF
--- a/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/model/IntSetting.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/model/IntSetting.kt
@@ -41,6 +41,7 @@ enum class IntSetting(
     VSYNC("use_vsync_new", Settings.SECTION_RENDERER, 1),
     DEBUG_RENDERER("renderer_debug", Settings.SECTION_DEBUG, 0),
     TEXTURE_FILTER("texture_filter", Settings.SECTION_RENDERER, 0),
+    FRAME_SKIP("frame_skip", Settings.SECTION_RENDERER, 0),
     USE_FRAME_LIMIT("use_frame_limit", Settings.SECTION_RENDERER, 1);
 
     override var int: Int = defaultValue

--- a/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/ui/SettingsFragmentPresenter.kt
@@ -736,6 +736,18 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                 )
             )
 
+            add(
+                SingleChoiceSetting(
+                    IntSetting.FRAME_SKIP,
+                    R.string.frame_skip_name,
+                    R.string.frame_skip_description,
+                    R.array.frameSkipNames,
+                    R.array.frameSkipValues,
+                    IntSetting.FRAME_SKIP.key,
+                    IntSetting.FRAME_SKIP.defaultValue
+                )
+            )
+
             add(HeaderSetting(R.string.stereoscopy))
             add(
                 SingleChoiceSetting(

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -147,6 +147,7 @@ void Config::ReadValues() {
     ReadSetting("Renderer", Settings::values.use_vsync_new);
     ReadSetting("Renderer", Settings::values.texture_filter);
     ReadSetting("Renderer", Settings::values.texture_sampling);
+    ReadSetting("Renderer", Settings::values.frame_skip);
 
     // Work around to map Android setting for enabling the frame limiter to the format Citra expects
     if (sdl2_config->GetBoolean("Renderer", "use_frame_limit", true)) {

--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -181,6 +181,20 @@
         <item>5</item>
     </integer-array>
 
+    <string-array name="frameSkipNames">
+        <item>@string/disabled</item>
+        <item>@string/x2</item>
+        <item>@string/x4</item>
+        <item>@string/x8</item>
+    </string-array>
+
+    <integer-array name="frameSkipValues">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+    </integer-array>
+
     <string-array name="themeModeEntries">
         <item>@string/theme_mode_follow_system</item>
         <item>@string/theme_mode_light</item>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -235,6 +235,8 @@
     <string name="frame_limit_enable_description">When enabled, emulation speed will be limited to a specified percentage of normal speed.</string>
     <string name="frame_limit_slider">Limit Speed Percent</string>
     <string name="frame_limit_slider_description">Specifies the percentage to limit emulation speed. With the default of 100% emulation will be limited to normal speed. Values higher or lower will increase or decrease the speed limit.</string>
+    <string name="frame_skip_name">Frame Skip</string>
+    <string name="frame_skip_description">The amount of frames to skip. Best matched with the Enable VSync and Enable Real Time Audio options.</string>
     <string name="internal_resolution">Internal Resolution</string>
     <string name="internal_resolution_description">Specifies the resolution used to render at. A high resolution will improve visual quality a lot but is also quite heavy on performance and might cause glitches in certain games.</string>
     <string name="internal_resolution_setting_1x">Native (400x240)</string>
@@ -551,6 +553,12 @@
     <string name="scaleforce">ScaleForce</string>
     <string name="xbrz">xBRZ</string>
     <string name="mmpx">MMPX</string>
+
+    <!-- Frame skip names -->
+    <string name="disabled">Disabled</string>
+    <string name="x2">x2</string>
+    <string name="x4">x4</string>
+    <string name="x8">x8</string>
 
     <!-- Sound output modes -->
     <string name="mono">Mono</string>

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -94,6 +94,7 @@ void LogSettings() {
     log_setting("Renderer_UseShaderJit", values.use_shader_jit.GetValue());
     log_setting("Renderer_UseResolutionFactor", values.resolution_factor.GetValue());
     log_setting("Renderer_FrameLimit", values.frame_limit.GetValue());
+    log_setting("Renderer_FrameSkip", values.frame_skip.GetValue());
     log_setting("Renderer_VSyncNew", values.use_vsync_new.GetValue());
     log_setting("Renderer_PostProcessingShader", values.pp_shader_name.GetValue());
     log_setting("Renderer_FilterMode", values.filter_mode.GetValue());
@@ -192,6 +193,7 @@ void RestoreGlobalState(bool is_powered_on) {
     values.use_vsync_new.SetGlobal(true);
     values.resolution_factor.SetGlobal(true);
     values.frame_limit.SetGlobal(true);
+    values.frame_skip.SetGlobal(true);
     values.texture_filter.SetGlobal(true);
     values.texture_sampling.SetGlobal(true);
     values.layout_option.SetGlobal(true);

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -433,6 +433,7 @@ struct Values {
 
     // Core
     Setting<bool> use_cpu_jit{true, "use_cpu_jit"};
+    SwitchableSetting<u8> frame_skip{0, "frame_skip"};
     SwitchableSetting<s32, true> cpu_clock_percentage{100, 5, 400, "cpu_clock_percentage"};
     SwitchableSetting<bool> is_new_3ds{true, "is_new_3ds"};
     SwitchableSetting<bool> lle_applets{false, "lle_applets"};

--- a/src/lime/config.cpp
+++ b/src/lime/config.cpp
@@ -129,6 +129,7 @@ void Config::ReadValues() {
 
     // Core
     ReadSetting("Core", Settings::values.use_cpu_jit);
+    ReadSetting("Core", Settings::values.frame_skip);
     ReadSetting("Core", Settings::values.cpu_clock_percentage);
 
     // Renderer
@@ -144,6 +145,7 @@ void Config::ReadValues() {
     ReadSetting("Renderer", Settings::values.resolution_factor);
     ReadSetting("Renderer", Settings::values.use_disk_shader_cache);
     ReadSetting("Renderer", Settings::values.frame_limit);
+    ReadSetting("Renderer", Settings::values.frame_skip);
     ReadSetting("Renderer", Settings::values.use_vsync_new);
     ReadSetting("Renderer", Settings::values.texture_filter);
     ReadSetting("Renderer", Settings::values.texture_sampling);

--- a/src/lime/default_ini.h
+++ b/src/lime/default_ini.h
@@ -91,6 +91,10 @@ udp_pad_index=
 # 0: Interpreter (slow), 1 (default): JIT (fast)
 use_cpu_jit =
 
+# The amount of frames to skip.
+# 0 (default): No frameskip, 1:  skip 1 frame, 2: skip 2 frames, etc.
+frame_skip =
+
 # Change the Clock Frequency of the emulated 3DS CPU.
 # Underclocking can increase the performance of the game at the risk of freezing.
 # Overclocking may fix lag that happens on console, but also comes with the risk of freezing.

--- a/src/lime_qt/configuration/config.cpp
+++ b/src/lime_qt/configuration/config.cpp
@@ -458,6 +458,7 @@ void Config::ReadCoreValues() {
 
     if (global) {
         ReadBasicSetting(Settings::values.use_cpu_jit);
+        ReadBasicSetting(Settings::values.frame_skip);
         ReadBasicSetting(Settings::values.delay_start_for_lle_modules);
     }
 
@@ -659,6 +660,7 @@ void Config::ReadRendererValues() {
     ReadGlobalSetting(Settings::values.use_vsync_new);
     ReadGlobalSetting(Settings::values.resolution_factor);
     ReadGlobalSetting(Settings::values.frame_limit);
+    ReadGlobalSetting(Settings::values.frame_skip);
 
     ReadGlobalSetting(Settings::values.bg_red);
     ReadGlobalSetting(Settings::values.bg_green);
@@ -1006,6 +1008,7 @@ void Config::SaveCoreValues() {
 
     if (global) {
         WriteBasicSetting(Settings::values.use_cpu_jit);
+        WriteBasicSetting(Settings::values.frame_skip);
         WriteBasicSetting(Settings::values.delay_start_for_lle_modules);
     }
 
@@ -1169,6 +1172,7 @@ void Config::SaveRendererValues() {
     WriteGlobalSetting(Settings::values.use_vsync_new);
     WriteGlobalSetting(Settings::values.resolution_factor);
     WriteGlobalSetting(Settings::values.frame_limit);
+    WriteGlobalSetting(Settings::values.frame_skip);
 
     WriteGlobalSetting(Settings::values.bg_red);
     WriteGlobalSetting(Settings::values.bg_green);

--- a/src/lime_qt/configuration/configure_enhancements.cpp
+++ b/src/lime_qt/configuration/configure_enhancements.cpp
@@ -48,11 +48,17 @@ void ConfigureEnhancements::SetConfiguration() {
                                                &Settings::values.texture_filter);
         ConfigurationShared::SetHighlight(ui->widget_texture_filter,
                                           !Settings::values.texture_filter.UsingGlobal());
+        ConfigurationShared::SetPerGameSetting(ui->frame_skip_combobox,
+                                               &Settings::values.frame_skip);
+        ConfigurationShared::SetHighlight(ui->widget_frame_skip,
+                                          !Settings::values.frame_skip.UsingGlobal());
     } else {
         ui->resolution_factor_combobox->setCurrentIndex(
             Settings::values.resolution_factor.GetValue());
         ui->texture_filter_combobox->setCurrentIndex(
             static_cast<int>(Settings::values.texture_filter.GetValue()));
+        ui->frame_skip_combobox->setCurrentIndex(
+            static_cast<int>(Settings::values.frame_skip.GetValue()));
     }
 
     ui->render_3d_combobox->setCurrentIndex(
@@ -125,6 +131,7 @@ void ConfigureEnhancements::ApplyConfiguration() {
                                              ui->toggle_linear_filter, linear_filter);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.texture_filter,
                                              ui->texture_filter_combobox);
+    ConfigurationShared::ApplyPerGameSetting(&Settings::values.frame_skip, ui->frame_skip_combobox);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.dump_textures,
                                              ui->toggle_dump_textures, dump_textures);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.custom_textures,
@@ -140,6 +147,7 @@ void ConfigureEnhancements::SetupPerGameUI() {
     if (Settings::IsConfiguringGlobal()) {
         ui->widget_resolution->setEnabled(Settings::values.resolution_factor.UsingGlobal());
         ui->widget_texture_filter->setEnabled(Settings::values.texture_filter.UsingGlobal());
+        ui->widget_frame_skip->setEnabled(Settings::values.frame_skip.UsingGlobal());
         ui->toggle_linear_filter->setEnabled(Settings::values.filter_mode.UsingGlobal());
         ui->toggle_dump_textures->setEnabled(Settings::values.dump_textures.UsingGlobal());
         ui->toggle_custom_textures->setEnabled(Settings::values.custom_textures.UsingGlobal());
@@ -171,4 +179,8 @@ void ConfigureEnhancements::SetupPerGameUI() {
     ConfigurationShared::SetColoredComboBox(
         ui->texture_filter_combobox, ui->widget_texture_filter,
         static_cast<int>(Settings::values.texture_filter.GetValue(true)));
+
+    ConfigurationShared::SetColoredComboBox(
+        ui->frame_skip_combobox, ui->widget_frame_skip,
+        static_cast<int>(Settings::values.frame_skip.GetValue(true)));
 }

--- a/src/lime_qt/configuration/configure_enhancements.ui
+++ b/src/lime_qt/configuration/configure_enhancements.ui
@@ -204,6 +204,58 @@
         </layout>
        </widget>
       </item>
+      <item>
+       <widget class="QWidget" name="widget_frame_skip" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="frame_skip_label">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The number of frames to skip.&lt;/p&gt;&lt;p&gt;WARNING: Results may vary depending on using the Vulkan or OpenGL renderer. If set too high, the screen may not render at all. Use with caution.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Frame Skip</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="frame_skip_combobox">
+           <item>
+            <property name="text">
+             <string>Disabled</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>x2</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>x4</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>x8</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -214,7 +266,7 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_4">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
         <item>
          <widget class="QLabel" name="label_4">
           <property name="text">
@@ -254,7 +306,7 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
+       <layout class="QHBoxLayout" name="horizontalLayout_6">
         <item>
          <widget class="QLabel" name="label_3">
           <property name="text">
@@ -281,7 +333,7 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_6">
+       <layout class="QHBoxLayout" name="horizontalLayout_7">
         <item>
          <widget class="QLabel" name="label_6">
           <property name="text">
@@ -377,6 +429,7 @@
   <tabstop>toggle_linear_filter</tabstop>
   <tabstop>shader_combobox</tabstop>
   <tabstop>texture_filter_combobox</tabstop>
+  <tabstop>frame_skip_combobox</tabstop>
   <tabstop>render_3d_combobox</tabstop>
   <tabstop>factor_3d</tabstop>
   <tabstop>mono_rendering_eye</tabstop>

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -38,6 +38,9 @@ constexpr u64 FRAME_TICKS = 4481136ull;
 class GraphicsDebugger;
 class RendererBase;
 
+// Frame skip
+extern bool g_skip_frame;
+
 /**
  * The GPU class is the high level interface to the video_core for core services.
  */

--- a/src/video_core/pica/pica_core.cpp
+++ b/src/video_core/pica/pica_core.cpp
@@ -10,6 +10,7 @@
 #include "core/core.h"
 #include "core/memory.h"
 #include "video_core/debug_utils/debug_utils.h"
+#include "video_core/gpu.h"
 #include "video_core/pica/pica_core.h"
 #include "video_core/pica/vertex_loader.h"
 #include "video_core/rasterizer_interface.h"
@@ -54,6 +55,7 @@ PicaCore::PicaCore(Memory::MemorySystem& memory_, std::shared_ptr<DebugContext> 
 PicaCore::~PicaCore() = default;
 
 void PicaCore::InitializeRegs() {
+
     auto& framebuffer_top = regs.framebuffer_config[0];
     auto& framebuffer_sub = regs.framebuffer_config[1];
 
@@ -119,6 +121,7 @@ void PicaCore::ProcessCmdList(PAddr list, u32 size) {
 }
 
 void PicaCore::WriteInternalReg(u32 id, u32 value, u32 mask) {
+
     if (id >= RegsInternal::NUM_REGS) {
         LOG_ERROR(
             HW_GPU,
@@ -133,6 +136,10 @@ void PicaCore::WriteInternalReg(u32 id, u32 value, u32 mask) {
         0x00ffff00, 0x00ffffff, 0xff000000, 0xff0000ff, 0xff00ff00, 0xff00ffff,
         0xffff0000, 0xffff00ff, 0xffffff00, 0xffffffff,
     };
+
+    // If we're skipping this frame, only allow trigger IRQ
+    if (VideoCore::g_skip_frame && id != PICA_REG_INDEX(trigger_irq))
+        return;
 
     // TODO: Figure out how register masking acts on e.g. vs.uniform_setup.set_value
     const u32 old_value = regs.internal.reg_array[id];


### PR DESCRIPTION
Citra actually had Frame Skip functionality years ago, but it was removed because people felt it was broken and essentially a hack. In fact, the PR to remove it was titled “DIE FRAME SKIP DIE” which goes to show you how some people felt about it back in the day.

This PR restores that functionality. It takes the algorithm from back then and updates it to work with today’s modern code. As such, it has all the limitations the old algorithm had as well; no fixes or improvements were implemented.

I also added UI access. However, I’m not an Android developer, nor do I have a 64-bit device to test things on, so the Android part could use some extra eyes. The QT interface is fine.

In my testing, results vary a lot. Some games won’t run with it on. Some games blink a lot. And some games run just fine. Rendering method is also a factor; some games run better on OpenGL and some on Vulkan. It really depends. And of course, if you set it too high, you'll just get a black screen (audio works, though). Cutscenes and FMVs may not render properly either.

That said, it does give my potato of a laptop the extra push it needs to hit full 60fps in some games where it struggles at 45fps, so for my purposes, that’s good enough.

Since it’s basically a hack, I’ll leave it to the project to determine if it’s worth including.

![frameskip](https://github.com/Lime3DS/Lime3DS/assets/8913195/3b885226-764f-4cfd-b5ba-91c200244e4b)
