### PR TITLE
Restore Legacy Custom Layout option

### DIFF
--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -173,7 +173,18 @@ void Config::ReadValues() {
     // Layout
     Settings::values.layout_option = static_cast<Settings::LayoutOption>(sdl2_config->GetInteger(
         "Layout", "layout_option", static_cast<int>(Settings::LayoutOption::MobileLandscape)));
+
     ReadSetting("Layout", Settings::values.custom_layout);
+    ReadSetting("Layout", Settings::values.custom_top_left);
+    ReadSetting("Layout", Settings::values.custom_top_top);
+    ReadSetting("Layout", Settings::values.custom_top_right);
+    ReadSetting("Layout", Settings::values.custom_top_bottom);
+    ReadSetting("Layout", Settings::values.custom_bottom_left);
+    ReadSetting("Layout", Settings::values.custom_bottom_top);
+    ReadSetting("Layout", Settings::values.custom_bottom_right);
+    ReadSetting("Layout", Settings::values.custom_bottom_bottom);
+
+    ReadSetting("Layout", Settings::values.new_custom_layout);
     ReadSetting("Layout", Settings::values.custom_top_x);
     ReadSetting("Layout", Settings::values.custom_top_y);
     ReadSetting("Layout", Settings::values.custom_top_width);
@@ -182,6 +193,7 @@ void Config::ReadValues() {
     ReadSetting("Layout", Settings::values.custom_bottom_y);
     ReadSetting("Layout", Settings::values.custom_bottom_width);
     ReadSetting("Layout", Settings::values.custom_bottom_height);
+
     ReadSetting("Layout", Settings::values.cardboard_screen_size);
     ReadSetting("Layout", Settings::values.cardboard_x_shift);
     ReadSetting("Layout", Settings::values.cardboard_y_shift);

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -180,11 +180,26 @@ filter_mode =
 # 0 (default): Default Top Bottom Screen, 1: Single Screen Only, 2: Large Screen Small Screen, 3: Side by Side
 layout_option =
 
-# Toggle custom layout (using the settings below) on or off.
+# Toggle the Legacy Custom Layout (using the settings below) on or off.
 # 0 (default): Off, 1: On
 custom_layout =
 
-# Screen placement when using Custom layout option
+# Screen placement when using the Legacy Custom layout option
+# 0x, 0y is the top left corner of the render window.
+custom_top_left =
+custom_top_top =
+custom_top_right =
+custom_top_bottom =
+custom_bottom_left =
+custom_bottom_top =
+custom_bottom_right =
+custom_bottom_bottom =
+
+# Toggle the New Custom Layout (using the settings below) on or off.
+# 0 (default): Off, 1: On
+new_custom_layout =
+
+# Screen placement when using the New Custom Layout option
 # 0x, 0y is the top left corner of the render window.
 custom_top_x =
 custom_top_y =

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -488,6 +488,17 @@ struct Values {
     SwitchableSetting<float, true> large_screen_proportion{4.f, 1.f, 16.f,
                                                            "large_screen_proportion"};
     Setting<bool> custom_layout{false, "custom_layout"};
+    Setting<u16> custom_top_left{0, "custom_top_left"};
+    Setting<u16> custom_top_top{0, "custom_top_top"};
+    Setting<u16> custom_top_right{400, "custom_top_right"};
+    Setting<u16> custom_top_bottom{240, "custom_top_bottom"};
+    Setting<u16> custom_bottom_left{40, "custom_bottom_left"};
+    Setting<u16> custom_bottom_top{240, "custom_bottom_top"};
+    Setting<u16> custom_bottom_right{360, "custom_bottom_right"};
+    Setting<u16> custom_bottom_bottom{480, "custom_bottom_bottom"};
+    Setting<u16> custom_second_layer_opacity{100, "custom_second_layer_opacity"};
+
+    Setting<bool> new_custom_layout{false, "new_custom_layout"};
     Setting<u16> custom_top_x{0, "custom_top_x"};
     Setting<u16> custom_top_y{0, "custom_top_y"};
     Setting<u16> custom_top_width{400, "custom_top_width"};
@@ -496,7 +507,7 @@ struct Values {
     Setting<u16> custom_bottom_y{240, "custom_bottom_y"};
     Setting<u16> custom_bottom_width{320, "custom_bottom_width"};
     Setting<u16> custom_bottom_height{240, "custom_bottom_height"};
-    Setting<u16> custom_second_layer_opacity{100, "custom_second_layer_opacity"};
+    Setting<u16> new_custom_second_layer_opacity{100, "new_custom_second_layer_opacity"};
 
     SwitchableSetting<float> bg_red{0.f, "bg_red"};
     SwitchableSetting<float> bg_green{0.f, "bg_green"};

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -185,6 +185,9 @@ void EmuWindow::UpdateCurrentFramebufferLayout(u32 width, u32 height, bool is_po
 
     if (Settings::values.custom_layout.GetValue() == true) {
         layout = Layout::CustomFrameLayout(width, height, Settings::values.swap_screen.GetValue());
+    } else if (Settings::values.new_custom_layout.GetValue() == true) {
+        layout =
+            Layout::NewCustomFrameLayout(width, height, Settings::values.swap_screen.GetValue());
     } else {
         width = std::max(width, min_size.first);
         height = std::max(height, min_size.second);
@@ -230,8 +233,8 @@ void EmuWindow::UpdateCurrentFramebufferLayout(u32 width, u32 height, bool is_po
             break;
 #ifndef ANDROID // TODO: Implement custom layouts on Android
         case Settings::LayoutOption::CustomLayout:
-            layout =
-                Layout::CustomFrameLayout(width, height, Settings::values.swap_screen.GetValue());
+            layout = Layout::NewCustomFrameLayout(width, height,
+                                                  Settings::values.swap_screen.GetValue());
             break;
 #endif
         case Settings::LayoutOption::Default:

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -377,6 +377,31 @@ FramebufferLayout CustomFrameLayout(u32 width, u32 height, bool is_swapped) {
 
     FramebufferLayout res{width, height, true, true, {}, {}, !Settings::values.upright_screen};
 
+    Common::Rectangle<u32> top_screen{Settings::values.custom_top_left.GetValue(),
+                                      Settings::values.custom_top_top.GetValue(),
+                                      Settings::values.custom_top_right.GetValue(),
+                                      Settings::values.custom_top_bottom.GetValue()};
+    Common::Rectangle<u32> bot_screen{Settings::values.custom_bottom_left.GetValue(),
+                                      Settings::values.custom_bottom_top.GetValue(),
+                                      Settings::values.custom_bottom_right.GetValue(),
+                                      Settings::values.custom_bottom_bottom.GetValue()};
+
+    if (is_swapped) {
+        res.top_screen = bot_screen;
+        res.bottom_screen = top_screen;
+    } else {
+        res.top_screen = top_screen;
+        res.bottom_screen = bot_screen;
+    }
+    return res;
+}
+
+FramebufferLayout NewCustomFrameLayout(u32 width, u32 height, bool is_swapped) {
+    ASSERT(width > 0);
+    ASSERT(height > 0);
+
+    FramebufferLayout res{width, height, true, true, {}, {}, !Settings::values.upright_screen};
+
     Common::Rectangle<u32> top_screen{Settings::values.custom_top_x.GetValue(),
                                       Settings::values.custom_top_y.GetValue(),
                                       (u32)(Settings::values.custom_top_x.GetValue() +
@@ -407,6 +432,12 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
                                  std::max(Settings::values.custom_top_height.GetValue(),
                                           Settings::values.custom_bottom_height.GetValue()),
                                  Settings::values.swap_screen.GetValue());
+    } else if (Settings::values.new_custom_layout.GetValue() == true) {
+        return NewCustomFrameLayout(std::max(Settings::values.custom_top_right.GetValue(),
+                                             Settings::values.custom_bottom_right.GetValue()),
+                                    std::max(Settings::values.custom_top_bottom.GetValue(),
+                                             Settings::values.custom_bottom_bottom.GetValue()),
+                                    Settings::values.swap_screen.GetValue());
     }
 
     int width, height;

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -148,6 +148,14 @@ FramebufferLayout SeparateWindowsLayout(u32 width, u32 height, bool is_secondary
 FramebufferLayout CustomFrameLayout(u32 width, u32 height, bool is_swapped);
 
 /**
+ * Factory method for constructing a custom FramebufferLayout using the new options
+ * @param width Window framebuffer width in pixels
+ * @param height Window framebuffer height in pixels
+ * @return Newly created FramebufferLayout object with default screen regions initialized
+ */
+FramebufferLayout NewCustomFrameLayout(u32 width, u32 height, bool is_swapped);
+
+/**
  * Convenience method to get frame layout by resolution scale
  * Read from the current settings to determine which layout to use.
  * @param res_scale resolution scale factor

--- a/src/lime/config.cpp
+++ b/src/lime/config.cpp
@@ -164,7 +164,21 @@ void Config::ReadValues() {
     ReadSetting("Layout", Settings::values.swap_screen);
     ReadSetting("Layout", Settings::values.upright_screen);
     ReadSetting("Layout", Settings::values.large_screen_proportion);
+
+    // Legacy Custom Layout
     ReadSetting("Layout", Settings::values.custom_layout);
+    ReadSetting("Layout", Settings::values.custom_top_left);
+    ReadSetting("Layout", Settings::values.custom_top_top);
+    ReadSetting("Layout", Settings::values.custom_top_right);
+    ReadSetting("Layout", Settings::values.custom_top_bottom);
+    ReadSetting("Layout", Settings::values.custom_bottom_left);
+    ReadSetting("Layout", Settings::values.custom_bottom_top);
+    ReadSetting("Layout", Settings::values.custom_bottom_right);
+    ReadSetting("Layout", Settings::values.custom_bottom_bottom);
+    ReadSetting("Layout", Settings::values.custom_second_layer_opacity);
+
+    // New Custom Layout
+    ReadSetting("Layout", Settings::values.new_custom_layout);
     ReadSetting("Layout", Settings::values.custom_top_x);
     ReadSetting("Layout", Settings::values.custom_top_y);
     ReadSetting("Layout", Settings::values.custom_top_width);
@@ -173,7 +187,7 @@ void Config::ReadValues() {
     ReadSetting("Layout", Settings::values.custom_bottom_y);
     ReadSetting("Layout", Settings::values.custom_bottom_width);
     ReadSetting("Layout", Settings::values.custom_bottom_height);
-    ReadSetting("Layout", Settings::values.custom_second_layer_opacity);
+    ReadSetting("Layout", Settings::values.new_custom_second_layer_opacity);
 
     // Utility
     ReadSetting("Utility", Settings::values.dump_textures);

--- a/src/lime/default_ini.h
+++ b/src/lime/default_ini.h
@@ -191,11 +191,26 @@ filter_mode =
 # 6: Custom Layout
 layout_option =
 
-# Toggle custom layout (using the settings below) on or off.
+# Toggle the Legacy Custom Layout option (using the settings below) on or off.
 # 0 (default): Off, 1: On
 custom_layout =
 
-# Screen placement when using Custom layout option
+# Screen placement when using the Legacy Custom Layout option
+# 0x, 0y is the top left corner of the render window.
+custom_top_left =
+custom_top_top =
+custom_top_right =
+custom_top_bottom =
+custom_bottom_left =
+custom_bottom_top =
+custom_bottom_right =
+custom_bottom_bottom =
+
+# Toggle the New Custom Layout option (using the settings below) on or off.
+# 0 (default): Off, 1: On
+new_custom_layout =
+
+# Screen placement when using the New Custom layout option
 # 0x, 0y is the top left corner of the render window.
 custom_top_x =
 custom_top_y =

--- a/src/lime_qt/configuration/config.cpp
+++ b/src/lime_qt/configuration/config.cpp
@@ -518,7 +518,20 @@ void Config::ReadLayoutValues() {
 
     if (global) {
         ReadBasicSetting(Settings::values.mono_render_option);
+
+        // Legacy Custom Layout
         ReadBasicSetting(Settings::values.custom_layout);
+        ReadBasicSetting(Settings::values.custom_top_left);
+        ReadBasicSetting(Settings::values.custom_top_top);
+        ReadBasicSetting(Settings::values.custom_top_right);
+        ReadBasicSetting(Settings::values.custom_top_bottom);
+        ReadBasicSetting(Settings::values.custom_bottom_left);
+        ReadBasicSetting(Settings::values.custom_bottom_top);
+        ReadBasicSetting(Settings::values.custom_bottom_right);
+        ReadBasicSetting(Settings::values.custom_bottom_bottom);
+
+        // New Custom Layout
+        ReadBasicSetting(Settings::values.new_custom_layout);
         ReadBasicSetting(Settings::values.custom_top_x);
         ReadBasicSetting(Settings::values.custom_top_y);
         ReadBasicSetting(Settings::values.custom_top_width);
@@ -527,6 +540,7 @@ void Config::ReadLayoutValues() {
         ReadBasicSetting(Settings::values.custom_bottom_y);
         ReadBasicSetting(Settings::values.custom_bottom_width);
         ReadBasicSetting(Settings::values.custom_bottom_height);
+
         ReadBasicSetting(Settings::values.custom_second_layer_opacity);
     }
 
@@ -1060,7 +1074,20 @@ void Config::SaveLayoutValues() {
 
     if (global) {
         WriteBasicSetting(Settings::values.mono_render_option);
+
+        // Legacy Custom Layout
         WriteBasicSetting(Settings::values.custom_layout);
+        WriteBasicSetting(Settings::values.custom_top_left);
+        WriteBasicSetting(Settings::values.custom_top_top);
+        WriteBasicSetting(Settings::values.custom_top_right);
+        WriteBasicSetting(Settings::values.custom_top_bottom);
+        WriteBasicSetting(Settings::values.custom_bottom_left);
+        WriteBasicSetting(Settings::values.custom_bottom_top);
+        WriteBasicSetting(Settings::values.custom_bottom_right);
+        WriteBasicSetting(Settings::values.custom_bottom_bottom);
+
+        // New Custom Layout
+        WriteBasicSetting(Settings::values.new_custom_layout);
         WriteBasicSetting(Settings::values.custom_top_x);
         WriteBasicSetting(Settings::values.custom_top_y);
         WriteBasicSetting(Settings::values.custom_top_width);
@@ -1069,6 +1096,7 @@ void Config::SaveLayoutValues() {
         WriteBasicSetting(Settings::values.custom_bottom_y);
         WriteBasicSetting(Settings::values.custom_bottom_width);
         WriteBasicSetting(Settings::values.custom_bottom_height);
+
         WriteBasicSetting(Settings::values.custom_second_layer_opacity);
     }
 

--- a/src/lime_qt/configuration/configure_layout.cpp
+++ b/src/lime_qt/configuration/configure_layout.cpp
@@ -19,6 +19,7 @@ ConfigureLayout::ConfigureLayout(QWidget* parent)
     SetConfiguration();
 
     ui->layout_group->setEnabled(!Settings::values.custom_layout);
+    ui->layout_group->setEnabled(!Settings::values.new_custom_layout);
 
     ui->custom_layout_group->setEnabled(
         (Settings::values.layout_option.GetValue() == Settings::LayoutOption::CustomLayout));
@@ -74,8 +75,8 @@ void ConfigureLayout::SetConfiguration() {
     ui->custom_bottom_y->setValue(Settings::values.custom_bottom_y.GetValue());
     ui->custom_bottom_width->setValue(Settings::values.custom_bottom_width.GetValue());
     ui->custom_bottom_height->setValue(Settings::values.custom_bottom_height.GetValue());
-    ui->custom_second_layer_opacity->setValue(
-        Settings::values.custom_second_layer_opacity.GetValue());
+    ui->new_custom_second_layer_opacity->setValue(
+        Settings::values.new_custom_second_layer_opacity.GetValue());
     bg_color =
         QColor::fromRgbF(Settings::values.bg_red.GetValue(), Settings::values.bg_green.GetValue(),
                          Settings::values.bg_blue.GetValue());
@@ -100,7 +101,7 @@ void ConfigureLayout::ApplyConfiguration() {
     Settings::values.custom_bottom_y = ui->custom_bottom_y->value();
     Settings::values.custom_bottom_width = ui->custom_bottom_width->value();
     Settings::values.custom_bottom_height = ui->custom_bottom_height->value();
-    Settings::values.custom_second_layer_opacity = ui->custom_second_layer_opacity->value();
+    Settings::values.new_custom_second_layer_opacity = ui->new_custom_second_layer_opacity->value();
 
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.layout_option, ui->layout_combobox);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.swap_screen, ui->toggle_swap_screen,

--- a/src/lime_qt/configuration/configure_layout.ui
+++ b/src/lime_qt/configuration/configure_layout.ui
@@ -374,7 +374,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QSpinBox" name="custom_second_layer_opacity">
+            <widget class="QSpinBox" name="new_custom_second_layer_opacity">
              <property name="buttonSymbols">
               <enum>QAbstractSpinBox::PlusMinus</enum>
              </property>

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -698,13 +698,22 @@ void RendererOpenGL::DrawScreens(const Layout::FramebufferLayout& layout, bool f
 void RendererOpenGL::ApplySecondLayerOpacity() {
 #ifndef ANDROID // TODO: Implement custom layouts on Android
     if ((Settings::values.layout_option.GetValue() == Settings::LayoutOption::CustomLayout ||
-         Settings::values.custom_layout) &&
-        Settings::values.custom_second_layer_opacity.GetValue() < 100) {
+         Settings::values.custom_layout || Settings::values.new_custom_layout) &&
+        (Settings::values.custom_second_layer_opacity.GetValue() < 100 ||
+         Settings::values.new_custom_second_layer_opacity.GetValue() < 100)) {
         state.blend.src_rgb_func = GL_CONSTANT_ALPHA;
         state.blend.src_a_func = GL_CONSTANT_ALPHA;
         state.blend.dst_a_func = GL_ONE_MINUS_CONSTANT_ALPHA;
         state.blend.dst_rgb_func = GL_ONE_MINUS_CONSTANT_ALPHA;
-        state.blend.color.alpha = Settings::values.custom_second_layer_opacity.GetValue() / 100.0f;
+
+        // Legacy Custom Layout options takes priority
+        if (Settings::values.custom_second_layer_opacity.GetValue() < 100) {
+            state.blend.color.alpha =
+                Settings::values.custom_second_layer_opacity.GetValue() / 100.0f;
+        } else if (Settings::values.custom_second_layer_opacity.GetValue() < 100) {
+            state.blend.color.alpha =
+                Settings::values.new_custom_second_layer_opacity.GetValue() / 100.0f;
+        }
     }
 #endif
 }
@@ -712,7 +721,7 @@ void RendererOpenGL::ApplySecondLayerOpacity() {
 void RendererOpenGL::ResetSecondLayerOpacity() {
 #ifndef ANDROID // TODO: Implement custom layouts on Android
     if ((Settings::values.layout_option.GetValue() == Settings::LayoutOption::CustomLayout ||
-         Settings::values.custom_layout) &&
+         Settings::values.custom_layout || Settings::values.new_custom_layout) &&
         Settings::values.custom_second_layer_opacity.GetValue() < 100) {
         state.blend.src_rgb_func = GL_ONE;
         state.blend.dst_rgb_func = GL_ZERO;


### PR DESCRIPTION
Apparently [a lot of people](https://www.reddit.com/r/Citra/comments/afsq4a/various_custom_screen_layouts/) took advantage of the hidden Custom Layout functionality and took the time to do the math to figure out the optimum placement for various resolutions of displays. So if they were to switch to or upgrade to the current version of Lime3DS, they would find that their profiles no longer worked.

So in order to maintain backwards compatibility with those who have already specified Custom Layout profiles manually, this PR brings back the logic to handle the legacy Custom Layout functionality, similar to how the original project chose to support both the old way and new way of dealing with custom texture hashes.

The only meaningful change is that it brings back the old variable names and moves processing of the new variable names to a function called `NewCustomFrameLayout`. So if a user has a `.ini` file that's already set up using the old method, that will continue to work with no intervention. Conversely, if someone used the UI to set up the new method and never used the old method to begin with, that will continue to work. All of this should be completely transparent to the user.

In the case that both Legacy Custom Layout and New Custom Layout options have been set, the Legacy Custom Layout options will take priority and in that case, if the user wishes to migrate to the new method, they'll need to clear out the old variable values in their `.ini` file first.

This PR is really just to reduce the support burden of people chiming in after updating wondering why their Custom Layout profiles no longer work.