### PR TITLE
android: Gamepads can now control the in-game menu

### DIFF
--- a/src/android/app/src/main/java/io/github/lime3ds/android/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/fragments/EmulationFragment.kt
@@ -190,10 +190,16 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
 
             override fun onDrawerOpened(drawerView: View) {
                 binding.drawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED)
+                binding.surfaceInputOverlay.isClickable = false
+                binding.surfaceInputOverlay.isFocusable = false
+                binding.surfaceInputOverlay.isFocusableInTouchMode = false
             }
 
             override fun onDrawerClosed(drawerView: View) {
                 binding.drawerLayout.setDrawerLockMode(EmulationMenuSettings.drawerLockMode)
+                binding.surfaceInputOverlay.isClickable = true
+                binding.surfaceInputOverlay.isFocusable = true
+                binding.surfaceInputOverlay.isFocusableInTouchMode = true
             }
 
             override fun onDrawerStateChanged(newState: Int) {
@@ -410,6 +416,10 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
         }
 
         setInsets()
+    }
+
+    fun isDrawerOpen(): Boolean {
+        return binding.drawerLayout.isOpen
     }
 
     private fun togglePause() {


### PR DESCRIPTION
Closes #168

This feature was achieved by making the screen-wide surface which captures inputs uninteractable while the drawer is opened while also adding additional condition checks for input capture methods which allow inputs through if the drawer is open.

This video demonstrates the functionality allowed by this change: 

https://github.com/Lime3DS/Lime3DS/assets/48618519/06f38d66-d25d-4cbf-9c57-29011b4bbf7d


