### PR TITLE
Added Single Screen/ Separate Windows layout configuration options

### DIFF
--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -498,6 +498,13 @@ struct Values {
     Setting<u16> custom_bottom_height{240, "custom_bottom_height"};
     Setting<u16> custom_second_layer_opacity{100, "custom_second_layer_opacity"};
 
+    SwitchableSetting<bool> screen_top_stretch{false, "screen_top_stretch"};
+    Setting<u16> screen_top_leftright_padding{0, "screen_top_leftright_padding"};
+    Setting<u16> screen_top_topbottom_padding{0, "screen_top_topbottom_padding"};
+    SwitchableSetting<bool> screen_bottom_stretch{false, "screen_bottom_stretch"};
+    Setting<u16> screen_bottom_leftright_padding{0, "screen_bottom_leftright_padding"};
+    Setting<u16> screen_bottom_topbottom_padding{0, "screen_bottom_topbottom_padding"};
+
     SwitchableSetting<float> bg_red{0.f, "bg_red"};
     SwitchableSetting<float> bg_green{0.f, "bg_green"};
     SwitchableSetting<float> bg_blue{0.f, "bg_blue"};

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -173,9 +173,20 @@ FramebufferLayout SingleFrameLayout(u32 width, u32 height, bool swapped, bool up
         emulation_aspect_ratio = (swapped) ? BOT_SCREEN_ASPECT_RATIO : TOP_SCREEN_ASPECT_RATIO;
     }
 
+    const bool stretched = (Settings::values.screen_top_stretch.GetValue() && !swapped) ||
+                           (Settings::values.screen_bottom_stretch.GetValue() && swapped);
     float window_aspect_ratio = static_cast<float>(height) / width;
 
-    if (window_aspect_ratio < emulation_aspect_ratio) {
+    if (stretched) {
+        top_screen = {Settings::values.screen_top_leftright_padding.GetValue(),
+                      Settings::values.screen_top_topbottom_padding.GetValue(),
+                      width - Settings::values.screen_top_leftright_padding.GetValue(),
+                      height - Settings::values.screen_top_topbottom_padding.GetValue()};
+        bot_screen = {Settings::values.screen_bottom_leftright_padding.GetValue(),
+                      Settings::values.screen_bottom_topbottom_padding.GetValue(),
+                      width - Settings::values.screen_bottom_leftright_padding.GetValue(),
+                      height - Settings::values.screen_bottom_topbottom_padding.GetValue()};
+    } else if (window_aspect_ratio < emulation_aspect_ratio) {
         top_screen =
             top_screen.TranslateX((screen_window_area.GetWidth() - top_screen.GetWidth()) / 2);
         bot_screen =

--- a/src/lime/config.cpp
+++ b/src/lime/config.cpp
@@ -164,6 +164,7 @@ void Config::ReadValues() {
     ReadSetting("Layout", Settings::values.swap_screen);
     ReadSetting("Layout", Settings::values.upright_screen);
     ReadSetting("Layout", Settings::values.large_screen_proportion);
+
     ReadSetting("Layout", Settings::values.custom_layout);
     ReadSetting("Layout", Settings::values.custom_top_x);
     ReadSetting("Layout", Settings::values.custom_top_y);
@@ -174,6 +175,13 @@ void Config::ReadValues() {
     ReadSetting("Layout", Settings::values.custom_bottom_width);
     ReadSetting("Layout", Settings::values.custom_bottom_height);
     ReadSetting("Layout", Settings::values.custom_second_layer_opacity);
+
+    ReadSetting("Layout", Settings::values.screen_top_stretch);
+    ReadSetting("Layout", Settings::values.screen_top_leftright_padding);
+    ReadSetting("Layout", Settings::values.screen_top_topbottom_padding);
+    ReadSetting("Layout", Settings::values.screen_bottom_stretch);
+    ReadSetting("Layout", Settings::values.screen_bottom_leftright_padding);
+    ReadSetting("Layout", Settings::values.screen_bottom_topbottom_padding);
 
     // Utility
     ReadSetting("Utility", Settings::values.dump_textures);

--- a/src/lime_qt/configuration/config.cpp
+++ b/src/lime_qt/configuration/config.cpp
@@ -518,6 +518,7 @@ void Config::ReadLayoutValues() {
 
     if (global) {
         ReadBasicSetting(Settings::values.mono_render_option);
+
         ReadBasicSetting(Settings::values.custom_layout);
         ReadBasicSetting(Settings::values.custom_top_x);
         ReadBasicSetting(Settings::values.custom_top_y);
@@ -528,6 +529,13 @@ void Config::ReadLayoutValues() {
         ReadBasicSetting(Settings::values.custom_bottom_width);
         ReadBasicSetting(Settings::values.custom_bottom_height);
         ReadBasicSetting(Settings::values.custom_second_layer_opacity);
+
+        ReadBasicSetting(Settings::values.screen_top_stretch);
+        ReadBasicSetting(Settings::values.screen_top_leftright_padding);
+        ReadBasicSetting(Settings::values.screen_top_topbottom_padding);
+        ReadBasicSetting(Settings::values.screen_bottom_stretch);
+        ReadBasicSetting(Settings::values.screen_bottom_leftright_padding);
+        ReadBasicSetting(Settings::values.screen_bottom_topbottom_padding);
     }
 
     qt_config->endGroup();
@@ -1060,6 +1068,7 @@ void Config::SaveLayoutValues() {
 
     if (global) {
         WriteBasicSetting(Settings::values.mono_render_option);
+
         WriteBasicSetting(Settings::values.custom_layout);
         WriteBasicSetting(Settings::values.custom_top_x);
         WriteBasicSetting(Settings::values.custom_top_y);
@@ -1070,6 +1079,13 @@ void Config::SaveLayoutValues() {
         WriteBasicSetting(Settings::values.custom_bottom_width);
         WriteBasicSetting(Settings::values.custom_bottom_height);
         WriteBasicSetting(Settings::values.custom_second_layer_opacity);
+
+        WriteBasicSetting(Settings::values.screen_top_stretch);
+        WriteBasicSetting(Settings::values.screen_top_leftright_padding);
+        WriteBasicSetting(Settings::values.screen_top_topbottom_padding);
+        WriteBasicSetting(Settings::values.screen_bottom_stretch);
+        WriteBasicSetting(Settings::values.screen_bottom_leftright_padding);
+        WriteBasicSetting(Settings::values.screen_bottom_topbottom_padding);
     }
 
     qt_config->endGroup();

--- a/src/lime_qt/configuration/configure_layout.cpp
+++ b/src/lime_qt/configuration/configure_layout.cpp
@@ -27,6 +27,17 @@ ConfigureLayout::ConfigureLayout(QWidget* parent)
                     currentIndex == (uint)(Settings::LayoutOption::LargeScreen));
             });
 
+    ui->single_screen_layout_config_group->setEnabled(
+        (Settings::values.layout_option.GetValue() == Settings::LayoutOption::SingleScreen) ||
+        (Settings::values.layout_option.GetValue() == Settings::LayoutOption::SeparateWindows));
+    connect(ui->layout_combobox,
+            static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+            [this](int currentIndex) {
+                ui->single_screen_layout_config_group->setEnabled(
+                    (currentIndex == (uint)(Settings::LayoutOption::SingleScreen)) ||
+                    (currentIndex == (uint)(Settings::LayoutOption::SeparateWindows)));
+            });
+
     ui->custom_layout_group->setEnabled(
         (Settings::values.layout_option.GetValue() == Settings::LayoutOption::CustomLayout));
     connect(ui->layout_combobox,

--- a/src/lime_qt/configuration/configure_layout.cpp
+++ b/src/lime_qt/configuration/configure_layout.cpp
@@ -18,25 +18,44 @@ ConfigureLayout::ConfigureLayout(QWidget* parent)
     SetupPerGameUI();
     SetConfiguration();
 
-    ui->layout_group->setEnabled(!Settings::values.custom_layout);
+    ui->large_screen_proportion->setEnabled(
+        (Settings::values.layout_option.GetValue() == Settings::LayoutOption::LargeScreen));
+    connect(ui->layout_combobox,
+            static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+            [this](int currentIndex) {
+                ui->large_screen_proportion->setEnabled(
+                    currentIndex == (uint)(Settings::LayoutOption::LargeScreen));
+            });
 
     ui->custom_layout_group->setEnabled(
         (Settings::values.layout_option.GetValue() == Settings::LayoutOption::CustomLayout));
     connect(ui->layout_combobox,
             static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
             [this](int currentIndex) {
-                ui->custom_layout_group->setEnabled(ui->layout_combobox->currentIndex() ==
+                ui->custom_layout_group->setEnabled(currentIndex ==
                                                     (uint)(Settings::LayoutOption::CustomLayout));
             });
 
-    ui->large_screen_proportion->setEnabled(
-        (Settings::values.layout_option.GetValue() == Settings::LayoutOption::LargeScreen));
+    ui->screen_top_leftright_padding->setEnabled(Settings::values.screen_top_stretch.GetValue());
+    connect(ui->screen_top_stretch, static_cast<void (QCheckBox::*)(int)>(&QCheckBox::stateChanged),
+            this,
+            [this](bool checkState) { ui->screen_top_leftright_padding->setEnabled(checkState); });
+    ui->screen_top_topbottom_padding->setEnabled(Settings::values.screen_top_stretch.GetValue());
+    connect(ui->screen_top_stretch, static_cast<void (QCheckBox::*)(int)>(&QCheckBox::stateChanged),
+            this,
+            [this](bool checkState) { ui->screen_top_topbottom_padding->setEnabled(checkState); });
+    ui->screen_bottom_leftright_padding->setEnabled(
+        Settings::values.screen_bottom_topbottom_padding.GetValue());
     connect(
-        ui->layout_combobox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
-        this, [this](int currentIndex) {
-            ui->large_screen_proportion->setEnabled(ui->layout_combobox->currentIndex() ==
-                                                    (uint)(Settings::LayoutOption::LargeScreen));
-        });
+        ui->screen_bottom_stretch, static_cast<void (QCheckBox::*)(int)>(&QCheckBox::stateChanged),
+        this,
+        [this](bool checkState) { ui->screen_bottom_leftright_padding->setEnabled(checkState); });
+    ui->screen_bottom_topbottom_padding->setEnabled(
+        Settings::values.screen_bottom_topbottom_padding.GetValue());
+    connect(
+        ui->screen_bottom_stretch, static_cast<void (QCheckBox::*)(int)>(&QCheckBox::stateChanged),
+        this,
+        [this](bool checkState) { ui->screen_bottom_topbottom_padding->setEnabled(checkState); });
 
     connect(ui->bg_button, &QPushButton::clicked, this, [this] {
         const QColor new_bg_color = QColorDialog::getColor(bg_color);
@@ -66,6 +85,7 @@ void ConfigureLayout::SetConfiguration() {
     ui->toggle_swap_screen->setChecked(Settings::values.swap_screen.GetValue());
     ui->toggle_upright_screen->setChecked(Settings::values.upright_screen.GetValue());
     ui->large_screen_proportion->setValue(Settings::values.large_screen_proportion.GetValue());
+
     ui->custom_top_x->setValue(Settings::values.custom_top_x.GetValue());
     ui->custom_top_y->setValue(Settings::values.custom_top_y.GetValue());
     ui->custom_top_width->setValue(Settings::values.custom_top_width.GetValue());
@@ -76,6 +96,17 @@ void ConfigureLayout::SetConfiguration() {
     ui->custom_bottom_height->setValue(Settings::values.custom_bottom_height.GetValue());
     ui->custom_second_layer_opacity->setValue(
         Settings::values.custom_second_layer_opacity.GetValue());
+
+    ui->screen_top_stretch->setChecked(Settings::values.screen_top_stretch.GetValue());
+    ui->screen_top_leftright_padding->setValue(
+        Settings::values.screen_top_leftright_padding.GetValue());
+    ui->screen_top_topbottom_padding->setValue(
+        Settings::values.screen_top_topbottom_padding.GetValue());
+    ui->screen_bottom_stretch->setChecked(Settings::values.screen_bottom_stretch.GetValue());
+    ui->screen_bottom_leftright_padding->setValue(
+        Settings::values.screen_bottom_leftright_padding.GetValue());
+    ui->screen_bottom_topbottom_padding->setValue(
+        Settings::values.screen_bottom_topbottom_padding.GetValue());
     bg_color =
         QColor::fromRgbF(Settings::values.bg_red.GetValue(), Settings::values.bg_green.GetValue(),
                          Settings::values.bg_blue.GetValue());
@@ -101,6 +132,13 @@ void ConfigureLayout::ApplyConfiguration() {
     Settings::values.custom_bottom_width = ui->custom_bottom_width->value();
     Settings::values.custom_bottom_height = ui->custom_bottom_height->value();
     Settings::values.custom_second_layer_opacity = ui->custom_second_layer_opacity->value();
+
+    Settings::values.screen_top_stretch = ui->screen_top_stretch->checkState();
+    Settings::values.screen_top_leftright_padding = ui->screen_top_leftright_padding->value();
+    Settings::values.screen_top_topbottom_padding = ui->screen_top_topbottom_padding->value();
+    Settings::values.screen_bottom_stretch = ui->screen_bottom_stretch->checkState();
+    Settings::values.screen_bottom_leftright_padding = ui->screen_bottom_leftright_padding->value();
+    Settings::values.screen_bottom_topbottom_padding = ui->screen_bottom_topbottom_padding->value();
 
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.layout_option, ui->layout_combobox);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.swap_screen, ui->toggle_swap_screen,

--- a/src/lime_qt/configuration/configure_layout.ui
+++ b/src/lime_qt/configuration/configure_layout.ui
@@ -177,219 +177,394 @@
         </layout>
        </widget>
       </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="custom_layout_group">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Custom Layout</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_5">
       <item>
-       <widget class="QGroupBox" name="custom_layout_group">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="title">
-         <string>Custom Layout</string>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout_5">
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_4">
-           <item>
-            <widget class="QGroupBox" name="gb_top_screen">
-             <property name="title">
-              <string>Top Screen</string>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_2">
-              <item row="0" column="0">
-               <widget class="QLabel" name="lb_top_x">
-                <property name="text">
-                 <string>X Position</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QSpinBox" name="custom_top_x">
-                <property name="buttonSymbols">
-                 <enum>QAbstractSpinBox::NoButtons</enum>
-                </property>
-                <property name="maximum">
-                 <number>2147483647</number>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="lb_top_y">
-                <property name="text">
-                 <string>Y Position</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QSpinBox" name="custom_top_y">
-                <property name="buttonSymbols">
-                 <enum>QAbstractSpinBox::NoButtons</enum>
-                </property>
-                <property name="maximum">
-                 <number>2147483647</number>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="lb_top_width">
-                <property name="text">
-                 <string>Width</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QSpinBox" name="custom_top_width">
-                <property name="buttonSymbols">
-                 <enum>QAbstractSpinBox::NoButtons</enum>
-                </property>
-                <property name="maximum">
-                 <number>2147483647</number>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="lb_top_height">
-                <property name="text">
-                 <string>Height</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="QSpinBox" name="custom_top_height">
-                <property name="buttonSymbols">
-                 <enum>QAbstractSpinBox::NoButtons</enum>
-                </property>
-                <property name="maximum">
-                 <number>2147483647</number>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="gb_bottom_screen">
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="title">
-              <string>Bottom Screen</string>
-             </property>
-             <layout class="QGridLayout" name="gridLayout">
-              <item row="0" column="0">
-               <widget class="QLabel" name="lb_bottom_x">
-                <property name="text">
-                 <string>X Position</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QSpinBox" name="custom_bottom_x">
-                <property name="buttonSymbols">
-                 <enum>QAbstractSpinBox::NoButtons</enum>
-                </property>
-                <property name="maximum">
-                 <number>2147483647</number>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="lb_bottom_y">
-                <property name="text">
-                 <string>Y Position</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QSpinBox" name="custom_bottom_y">
-                <property name="buttonSymbols">
-                 <enum>QAbstractSpinBox::NoButtons</enum>
-                </property>
-                <property name="maximum">
-                 <number>2147483647</number>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="lb_bottom_width">
-                <property name="text">
-                 <string>Width</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QSpinBox" name="custom_bottom_width">
-                <property name="buttonSymbols">
-                 <enum>QAbstractSpinBox::NoButtons</enum>
-                </property>
-                <property name="maximum">
-                 <number>2147483647</number>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="lb_bottom_height">
-                <property name="text">
-                 <string>Height</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="QSpinBox" name="custom_bottom_height">
-                <property name="buttonSymbols">
-                 <enum>QAbstractSpinBox::NoButtons</enum>
-                </property>
-                <property name="maximum">
-                 <number>2147483647</number>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_2">
-           <item>
-            <widget class="QLabel" name="label_2">
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="QGroupBox" name="gb_top_screen">
+          <property name="title">
+           <string>Top Screen</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_2">
+           <item row="0" column="0">
+            <widget class="QLabel" name="lb_top_x">
              <property name="text">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;NOTE: Values are in pixels starting from the top left corner of the display. Positive numbers only.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              <string>X Position</string>
              </property>
             </widget>
            </item>
-          </layout>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_3">
-           <item>
-            <widget class="QLabel" name="lb_opacity_second_layer">
-             <property name="text">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Bottom Screen Opacity % (OpenGL Only)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSpinBox" name="custom_second_layer_opacity">
+           <item row="0" column="1">
+            <widget class="QSpinBox" name="custom_top_x">
              <property name="buttonSymbols">
-              <enum>QAbstractSpinBox::PlusMinus</enum>
+              <enum>QAbstractSpinBox::NoButtons</enum>
              </property>
-             <property name="minimum">
-              <number>10</number>
+             <property name="suffix">
+              <string>px</string>
              </property>
              <property name="maximum">
-              <number>100</number>
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="lb_top_y">
+             <property name="text">
+              <string>Y Position</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QSpinBox" name="custom_top_y">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="suffix">
+              <string>px</string>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="lb_top_width">
+             <property name="text">
+              <string>Width</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QSpinBox" name="custom_top_width">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="suffix">
+              <string>px</string>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="lb_top_height">
+             <property name="text">
+              <string>Height</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QSpinBox" name="custom_top_height">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="suffix">
+              <string>px</string>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
              </property>
             </widget>
            </item>
           </layout>
-         </item>
-        </layout>
-       </widget>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="gb_bottom_screen">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="title">
+           <string>Bottom Screen</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout">
+           <item row="0" column="0">
+            <widget class="QLabel" name="lb_bottom_x">
+             <property name="text">
+              <string>X Position</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QSpinBox" name="custom_bottom_x">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="suffix">
+              <string>px</string>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="lb_bottom_y">
+             <property name="text">
+              <string>Y Position</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QSpinBox" name="custom_bottom_y">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="suffix">
+              <string>px</string>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="lb_bottom_width">
+             <property name="text">
+              <string>Width</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QSpinBox" name="custom_bottom_width">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="suffix">
+              <string>px</string>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="lb_bottom_height">
+             <property name="text">
+              <string>Height</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QSpinBox" name="custom_bottom_height">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="suffix">
+              <string>px</string>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QLabel" name="lb_opacity_second_layer">
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Bottom Screen Opacity % (OpenGL Only)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="custom_second_layer_opacity">
+          <property name="buttonSymbols">
+           <enum>QAbstractSpinBox::PlusMinus</enum>
+          </property>
+          <property name="minimum">
+           <number>10</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="separate_window_config_group">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Single Screen Layout</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_5">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="QGroupBox" name="gb_top_screen_2">
+          <property name="title">
+           <string>Top Screen</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_2">
+           <item row="0" column="0">
+            <widget class="QLabel" name="lb_top_stretch">
+             <property name="text">
+              <string>Stretch</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QSpinBox" name="screen_top_leftright_padding">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="suffix">
+              <string>px</string>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="lb_top_leftright_padding">
+             <property name="text">
+              <string>Left/Right Padding</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="lb_top_topbottom_padding">
+             <property name="text">
+              <string>Top/Bottom Padding</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QSpinBox" name="screen_top_topbottom_padding">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="suffix">
+              <string>px</string>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QCheckBox" name="screen_top_stretch">
+             <property name="text">
+              <string notr="true"/>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="gb_bottom_screen">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="title">
+           <string>Bottom Screen</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout">
+           <item row="1" column="0">
+            <widget class="QLabel" name="lb_bottom_leftright_padding">
+             <property name="text">
+              <string>Left/Right Padding</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="lb_bottom_topbottom_padding">
+             <property name="text">
+              <string>Top/Bottom Padding</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QSpinBox" name="screen_bottom_leftright_padding">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="suffix">
+              <string>px</string>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QSpinBox" name="screen_bottom_topbottom_padding">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="suffix">
+              <string>px</string>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="lb_bottom_stretch">
+             <property name="text">
+              <string>Stretch</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QCheckBox" name="screen_bottom_stretch">
+             <property name="text">
+              <string notr="true"/>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Note: These settings affect the Single Screen and Separate Windows layouts</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>

--- a/src/lime_qt/configuration/configure_layout.ui
+++ b/src/lime_qt/configuration/configure_layout.ui
@@ -22,6 +22,9 @@
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <widget class="QGroupBox" name="layout_group">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
      <property name="title">
       <string>Screens</string>
      </property>
@@ -408,7 +411,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="separate_window_config_group">
+    <widget class="QGroupBox" name="single_screen_layout_config_group">
      <property name="minimumSize">
       <size>
        <width>0</width>


### PR DESCRIPTION
This pull request adds configuration options for controlling the appearance of the Single Screen and Separate Windows layout options. The pull request also minorly restructures the Layout tab of the configuration menu.

The updated Layout tab is displayed below:
![image](https://github.com/Lime3DS/Lime3DS/assets/48618519/4d798e3e-69bb-47ea-9783-a60989fc10ff)

The configuration group is named this way due to the Separate Windows layout being two isolated Single Screen layout windows internally, so it made the most sense from both an developer and end-user perspective to simply make this functionality shared between both layouts.

The padding options which are presented alongside the Stretch toggles allow for black bars to be created to maintain a desired aspect ratio regardless of window or display resolution.

Closes #251