### PR TITLE
Converts the remaining citra wiki links to archive.org snapshots till they're replaced.

### DIFF
--- a/externals/glad/Readme.md
+++ b/externals/glad/Readme.md
@@ -6,6 +6,6 @@ python -m glad --profile core --out-path glad/ --api "gl=4.3,gles2=3.2" --genera
 
 You can also generate the source using [this site](https://glad.dav1d.de/):
 1. Select '4.3' for GL, '3.2' for GLES2, and 'Core' for Profile.
-2. Input the currently supported extensions from [here](https://github.com/citra-emu/citra/blob/master/externals/glad/include/glad/glad.h#L9), plus any new required extensions.
+2. Input the currently supported extensions from [here](https://github.com/Lime3DS/Lime3DS/blob/master/externals/glad/include/glad/glad.h#L9), plus any new required extensions.
 3. Click Generate and download the generated source zip.
 4. Unzip the new source over the current glad source files.

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
 
     <!-- General application strings -->
     <string name="app_name" translatable="false">Lime3DS</string>
-    <string name="app_disclaimer">This software will run games for the Nintendo 3DS handheld game console. No game titles are included.\n\nBefore you can begin with emulating, please select a folder to store Lime3DS\'s user data in.\n\nWhat\'s this:\n<a href='https://github.com/citra-emu/citra/wiki/Citra-Android-user-data-and-storage'>Wiki - Lime3DS Android user data and storage</a></string>
+    <string name="app_disclaimer">This software will run games for the Nintendo 3DS handheld game console. No game titles are included.\n\nBefore you can begin with emulating, please select a folder to store Lime3DS\'s user data in.\n\nWhat\'s this:\n<a href='https://web.archive.org/web/20240304193549/https://github.com/citra-emu/citra/wiki/Citra-Android-user-data-and-storage'>Wiki - Lime3DS Android user data and storage</a></string>
     <string name="app_notification_channel_name" translatable="false">Lime3DS</string>
     <string name="app_notification_channel_id" translatable="false">Lime3DS</string>
     <string name="app_notification_channel_description">Lime3DS emulator notifications</string>
@@ -83,16 +83,16 @@
     <string name="permission_denied">Permission denied</string>
     <string name="add_games_warning">Skip selecting games folder?</string>
     <string name="add_games_warning_description">Games won\'t be displayed in the Games list if a folder isn\'t selected.</string>
-    <string name="add_games_warning_help">https://citra-emu.org/wiki/dumping-game-cartridges/</string>
+    <string name="add_games_warning_help">https://web.archive.org/web/20240304210021/https://citra-emu.org/wiki/dumping-game-cartridges/</string>
     <string name="warning_help">Help</string>
     <string name="warning_skip">Skip</string>
     <string name="warning_cancel">Cancel</string>
     <string name="select_citra_user_folder">Select User Folder</string>
-    <string name="select_citra_user_folder_description"><![CDATA[Select your <a href="https://github.com/citra-emu/citra/wiki/Citra-Android-user-data-and-storage">user data</a> directory with the button below.]]></string>
+    <string name="select_citra_user_folder_description"><![CDATA[Select your <a href="https://web.archive.org/web/20240304193549/https://github.com/citra-emu/citra/wiki/Citra-Android-user-data-and-storage">user data</a> directory with the button below.]]></string>
     <string name="select">Select</string>
     <string name="cannot_skip">You can\'t skip this step</string>
     <string name="cannot_skip_directory_description">This step is required to allow Lime3DS to work. Please select a directory and then you can continue.</string>
-    <string name="cannot_skip_directory_help">https://github.com/citra-emu/citra/wiki/Citra-Android-user-data-and-storage</string>
+    <string name="cannot_skip_directory_help">https://web.archive.org/web/20240304193549/https://github.com/citra-emu/citra/wiki/Citra-Android-user-data-and-storage</string>
 
     <!-- Search Strings -->
     <string name="search_and_filter_games">Search and Filter Games</string>
@@ -146,7 +146,7 @@
     <string name="download">Download</string>
     <string name="start">Start</string>
     <string name="keys_missing">Lime3DS is missing keys to download system files.</string>
-    <string name="how_to_get_keys"><![CDATA[<a href="https://citra-emu.org/wiki/aes-keys/">How to get keys?</a>]]></string>
+    <string name="how_to_get_keys"><![CDATA[<a href="https://web.archive.org/web/20240304203412/https://citra-emu.org/wiki/aes-keys/">How to get keys?</a>]]></string>
     <string name="show_home_apps">Show HOME menu apps in games list</string>
     <string name="run_system_setup">Run System Setup when the HOME Menu is launched</string>
     <string name="system_type_minimal">Minimal</string>
@@ -296,7 +296,7 @@
     <string name="learn_more">Learn More</string>
     <string name="close">Close</string>
     <string name="reset_to_default">Reset to Default</string>
-    <string name="redump_games"><![CDATA[Please follow the guides to redump your <a href="https://citra-emu.org/wiki/dumping-game-cartridges/">game cartidges</a> or <a href="https://citra-emu.org/wiki/dumping-installed-titles/">installed titles</a>.]]></string>
+    <string name="redump_games"><![CDATA[Please follow the guides to redump your <a href="https://web.archive.org/web/20240304210021/https://citra-emu.org/wiki/dumping-game-cartridges/">game cartidges</a> or <a href="https://web.archive.org/web/20240304210011/https://citra-emu.org/wiki/dumping-installed-titles/">installed titles</a>.]]></string>
     <string name="option_default">Default</string>
     <string name="none">None</string>
     <string name="auto">Auto</string>

--- a/src/lime/lime.cpp
+++ b/src/lime/lime.cpp
@@ -417,7 +417,8 @@ int main(int argc, char** argv) {
         LOG_CRITICAL(Frontend, "The game that you are trying to load must be decrypted before "
                                "being used with Lime. \n\n For more information on dumping and "
                                "decrypting games, please refer to: "
-                               "https://citra-emu.org/wiki/dumping-game-cartridges/");
+                               "https://web.archive.org/web/20240304210021/https://citra-emu.org/"
+                               "wiki/dumping-game-cartridges/");
         return -1;
     case Core::System::ResultStatus::ErrorLoader_ErrorInvalidFormat:
         LOG_CRITICAL(Frontend, "Error while loading ROM: The ROM format is not supported.");

--- a/src/lime_qt/configuration/configure_system.cpp
+++ b/src/lime_qt/configuration/configure_system.cpp
@@ -270,7 +270,8 @@ ConfigureSystem::ConfigureSystem(Core::System& system_, QWidget* parent)
         ui->label_nus_download->setOpenExternalLinks(true);
         ui->label_nus_download->setText(
             tr("Lime3DS is missing keys to download system files. <br><a "
-               "href='https://citra-emu.org/wiki/aes-keys/'><span style=\"text-decoration: "
+               "href='https://web.archive.org/web/20240304203412/https://citra-emu.org/wiki/"
+               "aes-keys/'><span style=\"text-decoration: "
                "underline; color:#039be5;\">How to get keys?</span></a>"));
     }
 

--- a/src/lime_qt/main.cpp
+++ b/src/lime_qt/main.cpp
@@ -1183,9 +1183,13 @@ bool GMainWindow::LoadROM(const QString& filename) {
             QMessageBox::critical(
                 this, tr("Invalid ROM Format"),
                 tr("Your ROM format is not supported.<br/>Please follow the guides to redump your "
-                   "<a href='https://citra-emu.org/wiki/dumping-game-cartridges/'>game "
+                   "<a "
+                   "href='https://web.archive.org/web/20240304210021/https://citra-emu.org/wiki/"
+                   "dumping-game-cartridges/'>game "
                    "cartridges</a> or "
-                   "<a href='https://citra-emu.org/wiki/dumping-installed-titles/'>installed "
+                   "<a "
+                   "href='https://web.archive.org/web/20240304210011/https://citra-emu.org/wiki/"
+                   "dumping-installed-titles/'>installed "
                    "titles</a>."));
             break;
 
@@ -1194,9 +1198,13 @@ bool GMainWindow::LoadROM(const QString& filename) {
             QMessageBox::critical(
                 this, tr("ROM Corrupted"),
                 tr("Your ROM is corrupted. <br/>Please follow the guides to redump your "
-                   "<a href='https://citra-emu.org/wiki/dumping-game-cartridges/'>game "
+                   "<a "
+                   "href='https://web.archive.org/web/20240304210021/https://citra-emu.org/wiki/"
+                   "dumping-game-cartridges/'>game "
                    "cartridges</a> or "
-                   "<a href='https://citra-emu.org/wiki/dumping-installed-titles/'>installed "
+                   "<a "
+                   "href='https://web.archive.org/web/20240304210011/https://citra-emu.org/wiki/"
+                   "dumping-installed-titles/'>installed "
                    "titles</a>."));
             break;
 
@@ -1204,9 +1212,13 @@ bool GMainWindow::LoadROM(const QString& filename) {
             QMessageBox::critical(
                 this, tr("ROM Encrypted"),
                 tr("Your ROM is encrypted. <br/>Please follow the guides to redump your "
-                   "<a href='https://citra-emu.org/wiki/dumping-game-cartridges/'>game "
+                   "<a "
+                   "href='https://web.archive.org/web/20240304210021/https://citra-emu.org/wiki/"
+                   "dumping-game-cartridges/'>game "
                    "cartridges</a> or "
-                   "<a href='https://citra-emu.org/wiki/dumping-installed-titles/'>installed "
+                   "<a "
+                   "href='https://web.archive.org/web/20240304210011/https://citra-emu.org/wiki/"
+                   "dumping-installed-titles/'>installed "
                    "titles</a>."));
             break;
         }
@@ -1214,9 +1226,13 @@ bool GMainWindow::LoadROM(const QString& filename) {
             QMessageBox::critical(
                 this, tr("Invalid ROM Format"),
                 tr("Your ROM format is not supported.<br/>Please follow the guides to redump your "
-                   "<a href='https://citra-emu.org/wiki/dumping-game-cartridges/'>game "
+                   "<a "
+                   "href='https://web.archive.org/web/20240304210021/https://citra-emu.org/wiki/"
+                   "dumping-game-cartridges/'>game "
                    "cartridges</a> or "
-                   "<a href='https://citra-emu.org/wiki/dumping-installed-titles/'>installed "
+                   "<a "
+                   "href='https://web.archive.org/web/20240304210011/https://citra-emu.org/wiki/"
+                   "dumping-installed-titles/'>installed "
                    "titles</a>."));
             break;
 


### PR DESCRIPTION
Closes #131