### PR TITLE
externals: Use `PabloMK7/dynarmic` instead of `blitzingeagle/dynarmic`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
     url = https://github.com/catchorg/Catch2
 [submodule "dynarmic"]
     path = externals/dynarmic
-    url = https://github.com/blitzingeagle/dynarmic.git
+    url = https://github.com/PabloMK7/dynarmic.git
 [submodule "xbyak"]
     path = externals/xbyak
     url = https://github.com/herumi/xbyak.git


### PR DESCRIPTION
This pull request updates the dynarmic dependency by using a more up-to-date archive which contains the final commits of the project before it was pulled from GitHub