### PR TITLE
Bundle Qt Wayland into Linux AppImage

### DIFF
--- a/.ci/linux.sh
+++ b/.ci/linux.sh
@@ -2,6 +2,9 @@
 
 if [ "$TARGET" = "appimage" ]; then
     export EXTRA_CMAKE_FLAGS=(-DCMAKE_LINKER=/etc/bin/ld.lld)
+    # Bundle required QT wayland libraries
+    export EXTRA_QT_PLUGINS="waylandcompositor"
+    export EXTRA_PLATFORM_PLUGINS="libqwayland-egl.so;libqwayland-generic.so"
 else
     # For the linux-fresh verification target, verify compilation without PCH as well.
     export EXTRA_CMAKE_FLAGS=(-DCITRA_USE_PRECOMPILED_HEADERS=OFF)


### PR DESCRIPTION
This MR is based on PabloMK7/citra#212. 

Depends on Lime3DS/lime3ds-build#1

This only affects the AppImage build, for flatpak see flathub/io.github.lime3ds.Lime3DS#24 (note: these MR doesn't have dependency on it, since the flatpak runtime bundles it's own Qt build).

