### PR TITLE
Allow use of frame advancing when paused

### DIFF
--- a/src/lime_qt/main.cpp
+++ b/src/lime_qt/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 Citra Emulator Project
+// Copyright Citra Emulator Project / Lime3DS Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -639,8 +639,6 @@ void GMainWindow::InitializeHotkeys() { // TODO: This code kind of sucks
     link_action_shortcut(ui->action_Capture_Screenshot, QStringLiteral("Capture Screenshot"));
     link_action_shortcut(ui->action_Screen_Layout_Swap_Screens, swap_screens);
     link_action_shortcut(ui->action_Screen_Layout_Upright_Screens, rotate_screens);
-    link_action_shortcut(ui->action_Enable_Frame_Advancing,
-                         QStringLiteral("Toggle Frame Advancing"));
     link_action_shortcut(ui->action_Advance_Frame, QStringLiteral("Advance Frame"));
     link_action_shortcut(ui->action_Load_from_Newest_Slot, QStringLiteral("Load from Newest Slot"));
     link_action_shortcut(ui->action_Save_to_Oldest_Slot, QStringLiteral("Save to Oldest Slot"));
@@ -946,16 +944,8 @@ void GMainWindow::ConnectMenuEvents() {
     connect_menu(ui->action_Save_Movie, &GMainWindow::OnSaveMovie);
     connect_menu(ui->action_Movie_Read_Only_Mode,
                  [this](bool checked) { movie.SetReadOnly(checked); });
-    connect_menu(ui->action_Enable_Frame_Advancing, [this] {
-        if (emulation_running) {
-            system.frame_limiter.SetFrameAdvancing(ui->action_Enable_Frame_Advancing->isChecked());
-            ui->action_Advance_Frame->setEnabled(ui->action_Enable_Frame_Advancing->isChecked());
-        }
-    });
     connect_menu(ui->action_Advance_Frame, [this] {
         if (emulation_running && system.frame_limiter.IsFrameAdvancing()) {
-            ui->action_Enable_Frame_Advancing->setChecked(true);
-            ui->action_Advance_Frame->setEnabled(true);
             system.frame_limiter.AdvanceFrame();
         }
     });
@@ -980,7 +970,8 @@ void GMainWindow::ConnectMenuEvents() {
 }
 
 void GMainWindow::UpdateMenuState() {
-    const bool is_paused = !emu_thread || !emu_thread->IsRunning();
+    const bool is_paused =
+        !emu_thread || !emu_thread->IsRunning() || system.frame_limiter.IsFrameAdvancing();
 
     const std::array running_actions{
         ui->action_Stop,
@@ -998,6 +989,7 @@ void GMainWindow::UpdateMenuState() {
     }
 
     ui->action_Capture_Screenshot->setEnabled(emulation_running && !is_paused);
+    ui->action_Advance_Frame->setEnabled(emulation_running && is_paused);
 
     if (emulation_running && is_paused) {
         ui->action_Pause->setText(tr("&Continue"));
@@ -1417,12 +1409,7 @@ void GMainWindow::BootGame(const QString& filename) {
         movie_playback_path.clear();
     }
 
-    if (ui->action_Enable_Frame_Advancing->isChecked()) {
-        ui->action_Advance_Frame->setEnabled(true);
-        system.frame_limiter.SetFrameAdvancing(true);
-    } else {
-        ui->action_Advance_Frame->setEnabled(false);
-    }
+    ui->action_Advance_Frame->setEnabled(false);
 
     if (video_dumping_on_start) {
         StartVideoDumping(video_dumping_path);
@@ -2302,6 +2289,7 @@ void GMainWindow::OnStartGame() {
     PreventOSSleep();
 
     emu_thread->SetRunning(true);
+    system.frame_limiter.SetFrameAdvancing(false);
     graphics_api_button->setEnabled(false);
     qRegisterMetaType<Core::System::ResultStatus>("Core::System::ResultStatus");
     qRegisterMetaType<std::string>("std::string");
@@ -2331,7 +2319,7 @@ void GMainWindow::OnRestartGame() {
 }
 
 void GMainWindow::OnPauseGame() {
-    emu_thread->SetRunning(false);
+    system.frame_limiter.SetFrameAdvancing(true);
     qt_cameras->PauseCameras();
 
     play_time_manager->Stop();
@@ -2346,7 +2334,7 @@ void GMainWindow::OnPauseGame() {
 
 void GMainWindow::OnPauseContinueGame() {
     if (emulation_running) {
-        if (emu_thread->IsRunning()) {
+        if (emu_thread->IsRunning() && !system.frame_limiter.IsFrameAdvancing()) {
             OnPauseGame();
         } else {
             OnStartGame();

--- a/src/lime_qt/main.ui
+++ b/src/lime_qt/main.ui
@@ -182,15 +182,8 @@
      <addaction name="action_Movie_Read_Only_Mode"/>
      <addaction name="action_Save_Movie"/>
     </widget>
-    <widget class="QMenu" name="menu_Frame_Advance">
-     <property name="title">
-      <string>Frame Advance</string>
-     </property>
-     <addaction name="action_Enable_Frame_Advancing"/>
-     <addaction name="action_Advance_Frame"/>
-    </widget>
+    <addaction name="action_Advance_Frame"/>
     <addaction name="menu_Movie"/>
-    <addaction name="menu_Frame_Advance"/>
     <addaction name="separator"/>
     <addaction name="action_Capture_Screenshot"/>
     <addaction name="action_Dump_Video"/>
@@ -402,14 +395,6 @@
    </property>
    <property name="text">
     <string>Read-Only Mode</string>
-   </property>
-  </action>
-  <action name="action_Enable_Frame_Advancing">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Enable Frame Advancing</string>
    </property>
   </action>
   <action name="action_Advance_Frame">


### PR DESCRIPTION
Closes #276

This commit changes how emulator pausing is implemented to allow for using the Advance Frame feature when paused in an attempt to make it more intuitive.

Where previously the emulator thread was halted, frame advancing mode is now enabled instead.
To my knowledge there should be no unforeseen consequences to this, but please try to think of some in case I missed something.

This commit also removes the "Enable Frame Advancing" option due to being obsolete.