### PR TITLE
Fix crash when cubemap face id is invalid

### DIFF
--- a/src/video_core/rasterizer_cache/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache/rasterizer_cache.h
@@ -647,10 +647,11 @@ typename T::Surface& RasterizerCache<T>::GetTextureCube(const TextureCubeConfig&
 
     Surface& cube_surface = slot_surfaces[cube.surface_id];
     for (u32 i = 0; i < addresses.size(); i++) {
-        if (!addresses[i]) {
+        const SurfaceId& face_id = cube.face_ids[i];
+        if (!addresses[i] || !face_id) {
             continue;
         }
-        Surface& surface = slot_surfaces[cube.face_ids[i]];
+        Surface& surface = slot_surfaces[face_id];
         if (cube.ticks[i] == surface.modification_tick) {
             continue;
         }


### PR DESCRIPTION
Pulled from https://github.com/PabloMK7/citra/commit/4f174f1c0b81266170aa8dac226be1b772f4c94d

May close #233

License warning is to be ignored as this code is being pulled from an external Citra fork. No review is required.