### PR TITLE
Flatpak shortcut creation fixes

### DIFF
--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -1,6 +1,9 @@
-// Copyright 2013 Dolphin Emulator Project / 2014 Citra Emulator Project
+// Copyright Citra Emulator Project / Lime3DS Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
+
+// Copyright Dolphin Emulator Project
+// Licensed under GPLv2 or any later version
 
 #include <array>
 #include <fstream>
@@ -707,8 +710,8 @@ std::string AppDataRoamingDirectory() {
 /**
  * @return The user’s home directory on POSIX systems
  */
-static const std::string& GetHomeDirectory() {
-    static std::string home_path;
+const std::string GetHomeDirectory() {
+    std::string home_path;
     if (home_path.empty()) {
         const char* envvar = getenv("HOME");
         if (envvar) {

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -1,6 +1,9 @@
-// Copyright 2013 Dolphin Emulator Project / 2014 Citra Emulator Project
+// Copyright Citra Emulator Project / Lime3DS Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
+
+// Copyright Dolphin Emulator Project
+// Licensed under GPLv2 or any later version
 
 #pragma once
 
@@ -207,6 +210,7 @@ void UpdateUserPath(UserPath path, const std::string& filename);
 [[nodiscard]] const std::string& GetExeDirectory();
 [[nodiscard]] std::string AppDataRoamingDirectory();
 #else
+[[nodiscard]] const std::string GetHomeDirectory();
 [[nodiscard]] const std::string GetUserDirectory(const std::string& envvar);
 #endif
 

--- a/src/lime/lime.cpp
+++ b/src/lime/lime.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 Citra Emulator Project
+// Copyright Citra Emulator Project / Lime3DS Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/lime/lime.cpp
+++ b/src/lime/lime.cpp
@@ -1,4 +1,4 @@
-// Copyright Citra Emulator Project / Lime3DS Emulator Project
+// Copyright 2014 Citra Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/lime_qt/main.cpp
+++ b/src/lime_qt/main.cpp
@@ -1902,10 +1902,10 @@ bool GMainWindow::MakeShortcutIcoPath(const u64 program_id, const std::string_vi
     out_icon_path = FileUtil::GetUserPath(FileUtil::UserPath::IconsDir);
     ico_extension = "ico";
 #elif defined(__linux__) || defined(__FreeBSD__)
-    out_icon_path = FileUtil::GetUserDirectory("XDG_DATA_HOME") + "/icons/hicolor/256x256";
+    out_icon_path = FileUtil::GetUserDirectory("XDG_DATA_HOME") + "/icons/hicolor/256x256/";
 #endif
     // Create icons directory if it doesn't exist
-    if (!FileUtil::CreateDir(out_icon_path.string())) {
+    if (!FileUtil::CreateFullPath(out_icon_path.string())) {
         QMessageBox::critical(
             this, tr("Create Icon"),
             tr("Cannot create icon file. Path \"%1\" does not exist and cannot be created.")

--- a/src/lime_qt/main.cpp
+++ b/src/lime_qt/main.cpp
@@ -1896,7 +1896,7 @@ bool GMainWindow::CreateShortcutMessagesGUI(QWidget* parent, int message,
 
 bool GMainWindow::MakeShortcutIcoPath(const u64 program_id, const std::string_view game_file_name,
                                       std::filesystem::path& out_icon_path) {
-    // Get path to Citra icons directory & icon extension
+    // Get path to Lime3DS icons directory & icon extension
     std::string ico_extension = "png";
 #if defined(_WIN32)
     out_icon_path = FileUtil::GetUserPath(FileUtil::UserPath::IconsDir);
@@ -1916,19 +1916,19 @@ bool GMainWindow::MakeShortcutIcoPath(const u64 program_id, const std::string_vi
     }
 
     // Create icon file path
-    out_icon_path /= (program_id == 0 ? fmt::format("citra-{}.{}", game_file_name, ico_extension)
-                                      : fmt::format("citra-{:016X}.{}", program_id, ico_extension));
+    out_icon_path /= (program_id == 0 ? fmt::format("lime-{}.{}", game_file_name, ico_extension)
+                                      : fmt::format("lime-{:016X}.{}", program_id, ico_extension));
     return true;
 }
 
 void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& game_path,
                                            GameListShortcutTarget target) {
-    // Get path to citra executable
+    // Get path to Lime3DS executable
     const QStringList args = QApplication::arguments();
-    std::filesystem::path citra_command = args[0].toStdString();
+    std::filesystem::path lime_command = args[0].toStdString();
     // If relative path, make it an absolute path
-    if (citra_command.c_str()[0] == '.') {
-        citra_command = FileUtil::GetCurrentDir().value_or("") + DIR_SEP + citra_command.string();
+    if (lime_command.c_str()[0] == '.') {
+        lime_command = FileUtil::GetCurrentDir().value_or("") + DIR_SEP + lime_command.string();
     }
 
     // Shortcut path
@@ -1984,7 +1984,7 @@ void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& ga
     // Warn once if we are making a shortcut to a volatile AppImage
     const std::string appimage_ending =
         std::string(Common::g_scm_rev).substr(0, 9).append(".AppImage");
-    if (citra_command.string().ends_with(appimage_ending) &&
+    if (lime_command.string().ends_with(appimage_ending) &&
         !UISettings::values.shortcut_already_warned) {
         if (CreateShortcutMessagesGUI(this, CREATE_SHORTCUT_MSGBOX_APPIMAGE_VOLATILE_WARNING,
                                       qt_game_title)) {
@@ -1998,11 +1998,11 @@ void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& ga
     if (CreateShortcutMessagesGUI(this, CREATE_SHORTCUT_MSGBOX_FULLSCREEN_PROMPT, qt_game_title)) {
         arguments = "-f " + arguments;
     }
-    const std::string comment = fmt::format("Start {:s} with the Citra Emulator", game_title);
+    const std::string comment = fmt::format("Start {:s} with the Lime3DS Emulator", game_title);
     const std::string categories = "Game;Emulator;Qt;";
     const std::string keywords = "3ds;Nintendo;";
 
-    if (CreateShortcutLink(shortcut_path, comment, out_icon_path, citra_command, arguments,
+    if (CreateShortcutLink(shortcut_path, comment, out_icon_path, lime_command, arguments,
                            categories, keywords, game_title)) {
         CreateShortcutMessagesGUI(this, CREATE_SHORTCUT_MSGBOX_SUCCESS, qt_game_title);
         return;

--- a/src/lime_qt/main.cpp
+++ b/src/lime_qt/main.cpp
@@ -1947,8 +1947,7 @@ void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& ga
         shortcut_path =
             QStandardPaths::writableLocation(QStandardPaths::DesktopLocation).toStdString();
     } else if (target == GameListShortcutTarget::Applications) {
-        shortcut_path =
-            QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation).toStdString();
+        shortcut_path = GetApplicationsDirectory();
     }
 
     // Icon path and title

--- a/src/lime_qt/main.cpp
+++ b/src/lime_qt/main.cpp
@@ -1819,7 +1819,7 @@ bool GMainWindow::CreateShortcutLink(const std::filesystem::path& shortcut_path,
         LOG_ERROR(Frontend, "Failed to create IShellLinkW instance");
         return false;
     }
-    hres = ps1->SetPath(command.c_str());
+    hres = ps1->SetPath(Common::UTF8ToUTF16W(command).data());
     if (FAILED(hres)) {
         LOG_ERROR(Frontend, "Failed to set path");
         return false;

--- a/src/lime_qt/main.h
+++ b/src/lime_qt/main.h
@@ -217,10 +217,10 @@ private:
     bool MakeShortcutIcoPath(const u64 program_id, const std::string_view game_file_name,
                              std::filesystem::path& out_icon_path);
     bool CreateShortcutLink(const std::filesystem::path& shortcut_path, const std::string& comment,
-                            const std::filesystem::path& icon_path,
-                            const std::filesystem::path& command, const std::string& arguments,
-                            const std::string& categories, const std::string& keywords,
-                            const std::string& name);
+                            const std::filesystem::path& icon_path, const std::string& command,
+                            const std::string& arguments, const std::string& categories,
+                            const std::string& keywords, const std::string& name,
+                            const bool& skip_tryexec);
 
 private slots:
     void OnStartGame();

--- a/src/lime_qt/util/util.cpp
+++ b/src/lime_qt/util/util.cpp
@@ -1,10 +1,13 @@
-// Copyright 2015 Citra Emulator Project
+// Copyright Citra Emulator Project / Lime3DS Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
 #include <array>
 #include <cmath>
 #include <QPainter>
+#include <QStandardPaths>
+#include "common/common_paths.h"
+#include "common/file_util.h"
 #include "common/logging/log.h"
 #include "core/loader/smdh.h"
 #include "lime_qt/util/util.h"
@@ -158,5 +161,17 @@ bool SaveIconToFile(const std::filesystem::path& icon_path, const QImage& image)
     return true;
 #else
     return false;
+#endif
+}
+
+const std::string GetApplicationsDirectory() {
+// This alternate method is required for Flatpak compatibility as
+// QStandardPaths::ApplicationsLocation returns a path inside the Flatpak data directory instead of
+// $HOME/.local/share
+#if defined(__linux__) || defined(__FreeBSD__)
+    return FileUtil::GetHomeDirectory() + DIR_SEP + ".local" + DIR_SEP + "share" + DIR_SEP +
+           "applications";
+#else
+    return QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation).toStdString();
 #endif
 }

--- a/src/lime_qt/util/util.h
+++ b/src/lime_qt/util/util.h
@@ -1,4 +1,4 @@
-// Copyright 2015 Citra Emulator Project
+// Copyright Citra Emulator Project / Lime3DS Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -36,3 +36,8 @@ QPixmap GetQPixmapFromSMDH(const std::vector<u8>& smdh_data);
  * @return bool If the operation succeeded
  */
 [[nodiscard]] bool SaveIconToFile(const std::filesystem::path& icon_path, const QImage& image);
+
+/**
+ * @return The user’s applications directory
+ */
+[[nodiscard]] const std::string GetApplicationsDirectory();


### PR DESCRIPTION
Closes #340

- [x] Fix desktop shortcut creation
  - [x] Fix shortcut creation failing if icons directory structure doesn't exist
  - [x] Fix Flatpak sandbox not having access to ~/Desktop
    - https://github.com/flathub/io.github.lime3ds.Lime3DS/pull/26
  - [x] Fix the `Exec` and `TryExec` sections of shortcuts created with the Flatpak being incorrect
- [x] Fix application menu shortcut creation
  - [x] Figure out reason for and fix shortcut creation failing
  - [x] Update Flatpak sandbox permissions to allow access to applications directory
    - https://github.com/flathub-infra/flatpak-builder-lint/pull/466
    - https://github.com/flathub/io.github.lime3ds.Lime3DS/pull/29
- [x] Testing
  - [x] Linux
  - [x] Windows