### PR TITLE
Added msvc vs msys2 explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ There is no emulation specific difference between the MSVC and MSYS2 versions of
 * MSVC generates a smaller file
 * Microsoft developed [MSVC](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist) and is closed source while [MSYS2](https://www.msys2.org/) is open-source
 * MSVC requires the installation of [Microsoft Visual C++ runtime](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist), if not already installed, which can require a restart to finish the install. If you have issues with the Microsoft Visual C++ runtimes, you should try the MSYS2 install
-* There have been times where MSVC has been known not to work sometimes while MSYS2 does
+* There have been reports where MSVC has not worked while MSYS2 does
 
 ---
 ### Android

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@
 Download the latest release from [Releases](https://github.com/Lime3DS/Lime3DS/releases).
 
 #### Windows Version Differences
-There is no emulation specific difference between the MSVC and MSYS2 versions of of Lime3DS, they are just two different compilers used to create a Lime3DS executable. However there are a few functional differences:
+There is no emulation specific difference between the MSVC and MSYS2 versions of Lime3DS, they are just two different compilers used to create a Lime3DS executable. However, there are a few functional differences:
 * MSVC generates a smaller file
-* [MSVC](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist) is created by Microsoft and is closed source while [MSYS2](https://www.msys2.org/) is open-source
-* MSVC requires that the [Microsoft Viscual C++ runtime](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist) be installed, which can require a restart to finish the install. If you have issues with the Microsoft Visual C++ runtimes, you should try the MSYS2 install
+* Microsoft developed [MSVC](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist) and is closed source while [MSYS2](https://www.msys2.org/) is open-source
+* MSVC requires the installation of [Microsoft Visual C++ runtime](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist), if not already installed, which can require a restart to finish the install. If you have issues with the Microsoft Visual C++ runtimes, you should try the MSYS2 install
 * There have been times where MSVC has been known not to work sometimes while MSYS2 does
 
 ---

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@
 Download the latest release from [Releases](https://github.com/Lime3DS/Lime3DS/releases).
 
 #### Windows Version Differences
-There is no functional difference between the msvc and msys2 versions of of Limed3DS, they are just two different compilers used to create a Lime3DS executable. MSVC typically generates a smaller file and is generally suggested to try first, and if it doesn't work, try the msys2 download.
+There is no emulation specific difference between the MSVC and MSYS2 versions of of Lime3DS, they are just two different compilers used to create a Lime3DS executable. However there are a few functional differences:
+* MSVC generates a smaller file
+* [MSVC](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist) is created by Microsoft and is closed source while [MSYS2](https://www.msys2.org/) is open-source
+* MSVC requires that the [Microsoft Viscual C++ runtime](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist) be installed, which can require a restart to finish the install. If you have issues with the MSVC runtimes, you should try the MSYS2 install
+* There have been times where MSVC has been known not to work sometimes while MSYS2 does
 
 ---
 ### Android

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Download the latest release from [Releases](https://github.com/Lime3DS/Lime3DS/r
 There is no emulation specific difference between the MSVC and MSYS2 versions of of Lime3DS, they are just two different compilers used to create a Lime3DS executable. However there are a few functional differences:
 * MSVC generates a smaller file
 * [MSVC](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist) is created by Microsoft and is closed source while [MSYS2](https://www.msys2.org/) is open-source
-* MSVC requires that the [Microsoft Viscual C++ runtime](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist) be installed, which can require a restart to finish the install. If you have issues with the MSVC runtimes, you should try the MSYS2 install
+* MSVC requires that the [Microsoft Viscual C++ runtime](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist) be installed, which can require a restart to finish the install. If you have issues with the Microsoft Visual C++ runtimes, you should try the MSYS2 install
 * There have been times where MSVC has been known not to work sometimes while MSYS2 does
 
 ---

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@
 
 Download the latest release from [Releases](https://github.com/Lime3DS/Lime3DS/releases).
 
+#### Windows Version Differences
+There is no functional difference between the msvc and msys2 versions of of Limed3DS, they are just two different compilers used to create a Lime3DS executable. MSVC typically generates a smaller file and is generally suggested to try first, and if it doesn't work, try the msys2 download.
+
 ---
 ### Android
 The recommended method of downloading Lime3DS on Android is via Obtainium:


### PR DESCRIPTION
**Is there an existing issue for this?**
> * [x]  I have searched the existing issues

**What feature are you suggesting?**
Adding some text to the ReadMe to clarify the difference between the two Windows versions.

**Why would this feature be useful?**
I got confused as to the differences, and I see on the Discord the question asked 33 times so far, and I am sure there are others who had the same questions and went to Discord/googled to find out. This should reduce confusion for Windows users as to which to download.