### PR TITLE
GSP_GPU: Do not always debug GXCommandProcessed on TriggerCmdReqQueue

### DIFF
--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -9,6 +9,7 @@
 #include <boost/serialization/shared_ptr.hpp>
 #include "common/archives.h"
 #include "common/bit_field.h"
+#include "common/settings.h"
 #include "core/core.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/shared_memory.h"
@@ -412,7 +413,9 @@ void GSP_GPU::TriggerCmdReqQueue(Kernel::HLERequestContext& ctx) {
     auto* command_buffer = GetCommandBuffer(active_thread_id);
     auto& gpu = system.GPU();
     for (u32 i = 0; i < command_buffer->number_commands; i++) {
-        gpu.Debugger().GXCommandProcessed(command_buffer->commands[i]);
+        if (Settings::values.renderer_debug) {
+            gpu.Debugger().GXCommandProcessed(command_buffer->commands[i]);
+        }
 
         // Decode and execute command
         gpu.Execute(command_buffer->commands[i]);


### PR DESCRIPTION
Seems like citra missed specify a debug part here for only use while debugging is on. I recommend merging because saves not needed debugging when not needed and might help on perf, but probably barely noticeable as well.