### PR TITLE
Refactor android code to use LargeScreen layout instead of MobileLandscape

### DIFF
--- a/src/android/app/src/main/java/io/github/lime3ds/android/display/ScreenAdjustmentUtil.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/display/ScreenAdjustmentUtil.kt
@@ -27,7 +27,7 @@ class ScreenAdjustmentUtil(
     }
     fun cycleLayouts() {
         // TODO: figure out how to pull these from R.array
-        val landscape_values = intArrayOf(6,1,3,4,0,5);
+        val landscape_values = intArrayOf(2,1,3,4,0,5);
         val portrait_values = intArrayOf(0,1);
         if (NativeLibrary.isPortraitMode) {
             val current_layout = IntSetting.PORTRAIT_SCREEN_LAYOUT.int

--- a/src/android/app/src/main/java/io/github/lime3ds/android/display/ScreenLayout.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/display/ScreenLayout.kt
@@ -11,13 +11,12 @@ enum class ScreenLayout(val int: Int) {
     LARGE_SCREEN(2),
     SIDE_SCREEN(3),
     HYBRID_SCREEN(4),
-    CUSTOM_LAYOUT(5),
-    MOBILE_LANDSCAPE(6);
+    CUSTOM_LAYOUT(5);
 
 
     companion object {
         fun from(int: Int): ScreenLayout {
-            return entries.firstOrNull { it.int == int } ?: MOBILE_LANDSCAPE
+            return entries.firstOrNull { it.int == int } ?: LARGE_SCREEN
         }
     }
 }

--- a/src/android/app/src/main/java/io/github/lime3ds/android/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/fragments/EmulationFragment.kt
@@ -806,14 +806,14 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
             ScreenLayout.CUSTOM_LAYOUT.int ->
                 R.id.menu_screen_layout_custom
 
-            else -> R.id.menu_screen_layout_landscape
+            else -> R.id.menu_screen_layout_largescreen
         }
         popupMenu.menu.findItem(layoutOptionMenuItem).setChecked(true)
 
         popupMenu.setOnMenuItemClickListener {
             when (it.itemId) {
-                R.id.menu_screen_layout_landscape -> {
-                    screenAdjustmentUtil.changeScreenOrientation(ScreenLayout.MOBILE_LANDSCAPE.int)
+                R.id.menu_screen_layout_largescreen -> {
+                    screenAdjustmentUtil.changeScreenOrientation(ScreenLayout.LARGE_SCREEN.int)
                     true
                 }
 

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -176,6 +176,8 @@ void Config::ReadValues() {
     // Layout
     Settings::values.layout_option = static_cast<Settings::LayoutOption>(sdl2_config->GetInteger(
         "Layout", "layout_option", static_cast<int>(Settings::LayoutOption::LargeScreen)));
+    Settings::values.large_screen_proportion =
+        static_cast<float>(sdl2_config->GetReal("Layout", "large_screen_proportion", 2.25));
     ReadSetting("Layout", Settings::values.custom_top_x);
     ReadSetting("Layout", Settings::values.custom_top_y);
     ReadSetting("Layout", Settings::values.custom_top_width);

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -182,10 +182,10 @@ void Config::ReadValues() {
         layoutInt = static_cast<int>(Settings::LayoutOption::LargeScreen);
     }
     Settings::values.layout_option = static_cast<Settings::LayoutOption>(layoutInt);
-    
+
     Settings::values.large_screen_proportion =
         static_cast<float>(sdl2_config->GetReal("Layout", "large_screen_proportion", 2.25));
-    
+
     ReadSetting("Layout", Settings::values.custom_top_x);
     ReadSetting("Layout", Settings::values.custom_top_y);
     ReadSetting("Layout", Settings::values.custom_top_width);

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -174,8 +174,14 @@ void Config::ReadValues() {
     ReadSetting("Renderer", Settings::values.bg_blue);
 
     // Layout
-    Settings::values.layout_option = static_cast<Settings::LayoutOption>(sdl2_config->GetInteger(
-        "Layout", "layout_option", static_cast<int>(Settings::LayoutOption::LargeScreen)));
+    // somewhat inelegant solution to ensure layout value is between 0 and 5 on read
+    // since older config files my have other values
+    int layoutInt = (int)sdl2_config->GetInteger(
+        "Layout", "layout_option", static_cast<int>(Settings::LayoutOption::LargeScreen));
+    if (layoutInt > 5 || layoutInt < 0) {
+        layoutInt = static_cast<int>(Settings::LayoutOption::LargeScreen);
+    }
+    Settings::values.layout_option = static_cast<Settings::LayoutOption>(layoutInt);
     Settings::values.large_screen_proportion =
         static_cast<float>(sdl2_config->GetReal("Layout", "large_screen_proportion", 2.25));
     ReadSetting("Layout", Settings::values.custom_top_x);

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -178,7 +178,7 @@ void Config::ReadValues() {
     // since older config files my have other values
     int layoutInt = (int)sdl2_config->GetInteger(
         "Layout", "layout_option", static_cast<int>(Settings::LayoutOption::LargeScreen));
-    if (layoutInt > 5 || layoutInt < 0) {
+    if (layoutInt < 0 || layoutInt > 5) {
         layoutInt = static_cast<int>(Settings::LayoutOption::LargeScreen);
     }
     Settings::values.layout_option = static_cast<Settings::LayoutOption>(layoutInt);

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -174,8 +174,8 @@ void Config::ReadValues() {
     ReadSetting("Renderer", Settings::values.bg_blue);
 
     // Layout
-    // somewhat inelegant solution to ensure layout value is between 0 and 5 on read
-    // since older config files my have other values
+    // Somewhat inelegant solution to ensure layout value is between 0 and 5 on read
+    // since older config files may have other values
     int layoutInt = (int)sdl2_config->GetInteger(
         "Layout", "layout_option", static_cast<int>(Settings::LayoutOption::LargeScreen));
     if (layoutInt < 0 || layoutInt > 5) {

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -182,8 +182,10 @@ void Config::ReadValues() {
         layoutInt = static_cast<int>(Settings::LayoutOption::LargeScreen);
     }
     Settings::values.layout_option = static_cast<Settings::LayoutOption>(layoutInt);
+    
     Settings::values.large_screen_proportion =
         static_cast<float>(sdl2_config->GetReal("Layout", "large_screen_proportion", 2.25));
+    
     ReadSetting("Layout", Settings::values.custom_top_x);
     ReadSetting("Layout", Settings::values.custom_top_y);
     ReadSetting("Layout", Settings::values.custom_top_width);

--- a/src/android/app/src/main/res/menu/menu_landscape_screen_layout.xml
+++ b/src/android/app/src/main/res/menu/menu_landscape_screen_layout.xml
@@ -4,8 +4,8 @@
     <group android:checkableBehavior="single">
 
         <item
-            android:id="@+id/menu_screen_layout_landscape"
-            android:title="@string/emulation_screen_layout_landscape" />
+            android:id="@+id/menu_screen_layout_largescreen"
+            android:title="@string/emulation_screen_layout_largescreen" />
 
         <item
             android:id="@+id/menu_screen_layout_single"

--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -12,19 +12,16 @@
     </integer-array>
 
     <string-array name="landscapeLayouts">
-        <item>@string/emulation_screen_layout_landscape</item>
+        <item>@string/emulation_screen_layout_largescreen</item>
         <item>@string/emulation_screen_layout_single</item>
         <item>@string/emulation_screen_layout_sidebyside</item>
         <item>@string/emulation_screen_layout_hybrid</item>
         <item>@string/emulation_screen_layout_original</item>
         <item>@string/emulation_screen_layout_custom</item>
     </string-array>
-    <!-- start with 6 because that is the MobileLandscape layout in cpp files
-       - skip 0 because top/bottom rarely makes sense in landscape
-       - skip 2 because that is "Large Screen" which the default replaces in mobile
-       -->
+    <!-- start with 2 because that is the Large Screen layout in cpp files -->
     <integer-array name="landscapeLayoutValues">
-        <item>6</item>
+        <item>2</item>
         <item>1</item>
         <item>3</item>
         <item>4</item>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -363,7 +363,7 @@
     <string name="emulation_open_cheats">Open Cheats</string>
     <string name="emulation_switch_screen_layout">Landscape Screen Layout</string>
     <string name="emulation_switch_portrait_layout">Portrait Screen Layout</string>
-    <string name="emulation_screen_layout_landscape">Default</string>
+    <string name="emulation_screen_layout_largescreen">Large Screen</string>
     <string name="emulation_screen_layout_portrait">Portrait</string>
     <string name="emulation_screen_layout_single">Single Screen</string>
     <string name="emulation_screen_layout_sidebyside">Side by Side Screens</string>

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -44,10 +44,6 @@ enum class LayoutOption : u32 {
 #endif
     HybridScreen,
     CustomLayout,
-
-    // Similiar to LargeScreen, but better for mobile devices in landscape mode. The screens are
-    // clamped to the top of the frame, and the bottom screen is a bit bigger.
-    MobileLandscape,
 };
 
 /** Defines the layout option for mobile portrait */

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -232,12 +232,6 @@ void EmuWindow::UpdateCurrentFramebufferLayout(u32 width, u32 height, bool is_po
                                                    Settings::values.upright_screen.GetValue());
             break;
 #endif
-        case Settings::LayoutOption::MobileLandscape:
-            layout =
-                Layout::LargeFrameLayout(width, height, Settings::values.swap_screen.GetValue(),
-                                         false, 2.25f, Layout::VerticalAlignment::Top);
-            break;
-
         case Settings::LayoutOption::Default:
         default:
             layout =

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -204,7 +204,9 @@ FramebufferLayout LargeFrameLayout(u32 width, u32 height, bool swapped, bool upr
                                    float scale_factor, VerticalAlignment vertical_alignment) {
     ASSERT(width > 0);
     ASSERT(height > 0);
-
+#ifdef ANDROID
+    vertical_alignment = VerticalAlignment::Top;
+#endif
     FramebufferLayout res{width, height, true, true, {}, {}, !upright};
     // Split the window into two parts. Give 4x width to the main screen and 1x width to the small
     // To do that, find the total emulation box and maximize that based on window size
@@ -512,23 +514,6 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
                                     Settings::values.upright_screen.GetValue(), 1,
                                     VerticalAlignment::Middle);
 
-        case Settings::LayoutOption::MobileLandscape: {
-            constexpr float large_screen_proportion = 2.25f;
-            if (Settings::values.swap_screen.GetValue()) {
-                width = (Core::kScreenBottomWidth +
-                         static_cast<int>(Core::kScreenTopWidth / large_screen_proportion)) *
-                        res_scale;
-                height = Core::kScreenBottomHeight * res_scale;
-            } else {
-                width = (Core::kScreenTopWidth +
-                         static_cast<int>(Core::kScreenBottomWidth / large_screen_proportion)) *
-                        res_scale;
-                height = Core::kScreenTopHeight * res_scale;
-            }
-            return LargeFrameLayout(width, height, Settings::values.swap_screen.GetValue(), false,
-                                    large_screen_proportion, VerticalAlignment::Top);
-        }
-
         case Settings::LayoutOption::Default:
         default:
             width = Core::kScreenTopWidth * res_scale;
@@ -579,10 +564,7 @@ FramebufferLayout GetCardboardSettings(const FramebufferLayout& layout) {
         }
     } else {
         switch (Settings::values.layout_option.GetValue()) {
-        case Settings::LayoutOption::MobileLandscape:
         case Settings::LayoutOption::SideScreen:
-            // If orientation is portrait, only use MobilePortrait
-
             cardboard_screen_width = top_screen_width + bottom_screen_width;
             cardboard_screen_height = is_swapped ? bottom_screen_height : top_screen_height;
             if (is_swapped)


### PR DESCRIPTION
This is a first step toward adding the Small Screen Position feature #332 . It removes the invisible internal "Mobile Landscape" layout and replaces it with "Large Screen Layout", but uses an #ifdef and new default proportion setting to modify it on Android so it looks identical to the old MobileLandscape layout.

This is necessary to eventually expose the small screen position and large screen proportion settings on android UI.

For now, the only user-facing change will be the menu saying "Large Screen" instead of "Default" for the layout on mobile. That can be changed back if desired.