### PR TITLE
Refactor Vulkan stream buffer memory type selection

### DIFF
--- a/src/video_core/renderer_vulkan/vk_stream_buffer.cpp
+++ b/src/video_core/renderer_vulkan/vk_stream_buffer.cpp
@@ -1,6 +1,9 @@
-// Copyright 2019 yuzu Emulator Project
+// Copyright Citra Emulator Project / Lime3DS Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
+
+// Copyright 2019 Yuzu Emulator Project
+// Licensed under GPLv2 or any later version
 
 #include <algorithm>
 #include <limits>
@@ -33,9 +36,11 @@ vk::MemoryPropertyFlags MakePropertyFlags(BufferType type) {
     case BufferType::Upload:
         return vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent;
     case BufferType::Download:
-        return vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent | vk::MemoryPropertyFlagBits::eHostCached;
+        return vk::MemoryPropertyFlagBits::eHostVisible |
+               vk::MemoryPropertyFlagBits::eHostCoherent | vk::MemoryPropertyFlagBits::eHostCached;
     case BufferType::Stream:
-        return vk::MemoryPropertyFlagBits::eDeviceLocal | vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent;
+        return vk::MemoryPropertyFlagBits::eDeviceLocal | vk::MemoryPropertyFlagBits::eHostVisible |
+               vk::MemoryPropertyFlagBits::eHostCoherent;
     default:
         UNREACHABLE_MSG("Unknown buffer type {}", type);
         return vk::MemoryPropertyFlagBits::eHostVisible;


### PR DESCRIPTION
This commit changes the `GetMemoryType` function by refining the Vulkan memory type selection process. The function now first looks for a memory type that meets all the requested flags. If it doesn't find a match, it progressively removes specific flags like `eDeviceLocal`, `eHostCached`, and `eHostCoherent` to find a suitable memory type. If no suitable type is found after these attempts, it defaults to using only the `eHostVisible` flag.

Note : This is my first commit at anything emulator related and this fixes the issue with Vulkan 1.1 and 1.2 crashes (Issue : #372), though it fixes the issue I really don't know if it makes other issues so tests are welcomed and thank you.