### PR TITLE
Store `frame_limit` config value as a double

### DIFF
--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -477,7 +477,7 @@ struct Values {
     SwitchableSetting<bool> use_vsync_new{true, "use_vsync_new"};
     Setting<bool> use_shader_jit{true, "use_shader_jit"};
     SwitchableSetting<u32, true> resolution_factor{1, 0, 10, "resolution_factor"};
-    SwitchableSetting<u16, true> frame_limit{100, 0, 1000, "frame_limit"};
+    SwitchableSetting<double, true> frame_limit{100, 0, 1000, "frame_limit"};
     SwitchableSetting<TextureFilter> texture_filter{TextureFilter::None, "texture_filter"};
     SwitchableSetting<TextureSampling> texture_sampling{TextureSampling::GameControlled,
                                                         "texture_sampling"};


### PR DESCRIPTION
This allows fractional values to be used for the game speed

Closes #122 