### PR TITLE
Basic implementation of AC::ScanAPs and NWM_INF::RecvBeaconBroadcastData

### DIFF
--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -180,7 +180,6 @@ void Module::Interface::GetStatus(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_AC, "(STUBBED) called");
 }
 
-
 void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     const u32 arg1 = rp.Pop();

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -209,14 +209,14 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     u32 mac2 = (mac[2] << 24) | (mac[3] << 16) | (mac[4] << 8) | (mac[5]);
 
     std::array<u32, IPC::COMMAND_BUFFER_LENGTH + 2 * IPC::MAX_STATIC_BUFFERS> cmd_buf;
-    cmd_buf[0] = 0x0006'03C4;
+    cmd_buf[0] = 0x000603C4;
     cmd_buf[1] = size;
     cmd_buf[2] = 0; // dummy data
     cmd_buf[3] = 0; // dummy data
     cmd_buf[4] = mac1;
     cmd_buf[5] = mac2;
     cmd_buf[16] = 0;
-    cmd_buf[17] = 0x0006;   // dummy value
+    cmd_buf[17] = 0;   // set to 0 to ignore it
     cmd_buf[18] = (size << 4) | 12; // should be considered correct for mapped buffer
     cmd_buf[19] = 0;    // if i interpreted the code correctly, this value won't matter
 

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -220,12 +220,15 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     cmd_buf[18] = (size << 4) | 12; // should be considered correct for mapped buffer
     cmd_buf[19] = 0;    // if i interpreted the code correctly, this value won't matter
 
+    LOG_WARNING(Service_AC, "Finished setting up command buffer");
     std::shared_ptr<Kernel::Thread> thread = ctx.ClientThread();
     auto current_process = thread->owner_process.lock();
+    LOG_WARNING(Service_AC, "Retrieved thread and process");
 
     auto context =
             std::make_shared<Kernel::HLERequestContext>(Core::System::GetInstance().Kernel(), 
                     ctx.Session(), thread);
+    LOG_WARNING(Service_AC, "Created context");
     context->PopulateFromIncomingCommandBuffer(cmd_buf.data(), current_process);
 
     LOG_WARNING(Service_AC, "Finished setting up context");

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -192,65 +192,68 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     // Arg 0 is Header code, which is ignored
     // Arg 1 is Size
     const u32 size = rp.Pop<u32>();
-    LOG_WARNING(Service_AC, "Size: {}", size);
     // Arg 2 is CallingPID value (PID Header)
     // Arg 3 is PID
     const u32 pid = rp.PopPID();
-    LOG_WARNING(Service_AC, "PID: {}", pid);
     
     std::shared_ptr<Kernel::Thread> thread = ctx.ClientThread();
     auto current_process = Core::System::GetInstance().Kernel().GetCurrentProcess();
     Memory::MemorySystem& memory = Core::System::GetInstance().Memory();
-    LOG_WARNING(Service_AC, "Retrieved thread, process and memory");
 
     // According to 3dbrew, the output structure pointer is located 0x100 bytes after the beginning
     // of cmd_buff
     VAddr cmd_addr = thread->GetCommandBufferAddress();
     VAddr buffer_vaddr = cmd_addr + 0x100;
     const u32 descr = memory.Read32(buffer_vaddr);
-    LOG_WARNING(Service_AC, "Buffer descriptor: 0x{:08X}, expected: 0x{:08X}", descr, (size << 14) | 2);
     ASSERT(descr == ((size << 14) | 2));    // preliminary check
     const VAddr output_buffer = memory.Read32(buffer_vaddr + 0x4); // address to output buffer
-    LOG_WARNING(Service_AC, "Buffer VAddr: 0x{:08X}", output_buffer);
 
+    // At this point, we have all the input given to us
+    // 3dbrew stated that AC:ScanAPs relies on NWM_INF:RecvBeaconBroadcastData to obtain
+    // info on all nearby APs
+    // Thus this method prepares to call that service
+    // Since I do not know the proper way, I copied various pieces of code that seemed to work
+    // MAC address gets split, but I am not sure this is the proper way to do so
     Network::MacAddress mac = Network::BroadcastMac;
     u32 mac1 = (mac[0] << 8) | (mac[1]);
     u32 mac2 = (mac[2] << 24) | (mac[3] << 16) | (mac[4] << 8) | (mac[5]);
 
     std::array<u32, IPC::COMMAND_BUFFER_LENGTH + 2 * IPC::MAX_STATIC_BUFFERS> cmd_buf;
-    cmd_buf[0] = 0x000603C4;
-    cmd_buf[1] = size;
+    cmd_buf[0] = 0x000603C4;    // Command header
+    cmd_buf[1] = size;  // size of buffer
     cmd_buf[2] = 0; // dummy data
     cmd_buf[3] = 0; // dummy data
     cmd_buf[4] = mac1;
     cmd_buf[5] = mac2;
-    cmd_buf[16] = 0;
-    cmd_buf[17] = 0;   // set to 0 to ignore it
+    cmd_buf[16] = 0;    // 0x0 handle header
+    cmd_buf[17] = 0;    // set to 0 to ignore it
     cmd_buf[18] = (size << 4) | 12; // should be considered correct for mapped buffer
-    cmd_buf[19] = output_buffer;
+    cmd_buf[19] = output_buffer;    // address of output buffer
 
-    LOG_WARNING(Service_AC, "Finished setting up command buffer");
-
+    // Create context for call to NWM_INF::RecvBeaconBroadcastData
     auto context =
             std::make_shared<Kernel::HLERequestContext>(Core::System::GetInstance().Kernel(), 
                     ctx.Session(), thread);
-    LOG_WARNING(Service_AC, "Created context");
     context->PopulateFromIncomingCommandBuffer(cmd_buf.data(), current_process);
 
-    LOG_WARNING(Service_AC, "Finished setting up context");
-
+    // Retrieve service from service manager
     auto nwm_inf = 
             Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_INF>("nwm::INF");    
     LOG_WARNING(Service_AC, "Calling NWM_INF::RecvBeaconBroadcastData");
+    // Perform delegated task
     nwm_inf->HandleSyncRequest(*context);
     LOG_WARNING(Service_AC, "Returned to AC::ScanAPs");
+
     // Response should be
     // 0: Header Code (ignored)
     // 1: Result Code (Success/Unknown/etc.)
     // 2: ¿Parsed? beacon data
+
+    // Since the way to parse is yet unknown, it is currently only passing on raw
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
     IPC::RequestParser rp2(*context);
     rb.Push(rp2.Pop<u32>());
+    // Mapped buffer at virtual address output_buffer 
     Kernel::MappedBuffer mapped_buffer = rp2.PopMappedBuffer();
     rb.PushMappedBuffer(mapped_buffer);
     LOG_WARNING(Service_AC, "(STUBBED) called, pid={}", pid);

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -207,10 +207,10 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     // of cmd_buff
     VAddr cmd_addr = thread->GetCommandBufferAddress();
     VAddr buffer_vaddr = cmd_addr + 0x100;
-    u32* buffer_info = static_cast<u32*>(memory.GetPointer(buffer_vaddr));
+    u8* buffer_info = memory.GetPointer(buffer_vaddr);
     const u32 descr = buffer_info[0];
     ASSERT(descr == ((size << 14) | 2));    // preliminary check
-    const VAddr output_buffer = buffer_info[1]; // address to output buffer
+    const VAddr output_buffer = buffer_info[4]; // address to output buffer
 
     Network::MacAddress mac = Network::BroadcastMac;
     u32 mac1 = (mac[0] << 8) | (mac[1]);

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -210,9 +210,9 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     cmd_buf[3] = 0; // dummy data
     cmd_buf[4] = mac;
     cmd_buf[16] = 0;
-    cmd_buf[17] = ...;
+    cmd_buf[17] = nullptr;
     cmd_buf[18] = (size << 4) | 12;
-    cmd_buf[19] = &buffer;
+    cmd_buf[19] = static_cast<u32>(&buffer);
     auto context =
             std::make_shared<Kernel::HLERequestContext>(kernel, SharedFrom(this), thread);
     context->PopulateFromIncomingCommandBuffer(cmd_buf.data(), current_process);

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -209,8 +209,10 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     VAddr buffer_vaddr = cmd_addr + 0x100;
     u8* buffer_info = memory.GetPointer(buffer_vaddr);
     const u32 descr = buffer_info[0];
+    LOG_WARNING(Service_AC, "Buffer descriptor: 0x{:08X}, expected: 0x{:08X}", descr, (size << 14) | 2);
     ASSERT(descr == ((size << 14) | 2));    // preliminary check
     const VAddr output_buffer = buffer_info[4]; // address to output buffer
+    LOG_WARNING(Service_AC, "Buffer VAddr: 0x{:08X}", output_buffer);
 
     Network::MacAddress mac = Network::BroadcastMac;
     u32 mac1 = (mac[0] << 8) | (mac[1]);

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -202,7 +202,7 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     const u32 unknown = rp.Pop<u32>();
     LOG_WARNING(Service_AC, "val4: {}", unknown);
 
-    // std::vector<u8> buffer(size);
+    std::vector<u8> buffer(size);
 
     Network::MacAddress mac = Network::BroadcastMac;
     u32 mac1 = (mac[0] << 8) | (mac[1]);
@@ -239,7 +239,9 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
     IPC::RequestParser rp2(*context);
     rb.Push(rp2.Pop<u32>());
-    rb.PushStaticBuffer(rp2.PopMappedBuffer(), 0);
+    Kernel::MappedBuffer mapped_buffer = rp2.PopMappedBuffer();
+    mapped_buffer.Read(buffer.data(), 0, buffer.size());
+    rb.PushStaticBuffer(buffer, 0);
     LOG_WARNING(Service_AC, "(STUBBED) called");
 }
 

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -207,11 +207,10 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     // of cmd_buff
     VAddr cmd_addr = thread->GetCommandBufferAddress();
     VAddr buffer_vaddr = cmd_addr + 0x100;
-    u8* buffer_info = memory.GetPointer(buffer_vaddr);
-    const u32 descr = buffer_info[0];
+    const u32 descr = memory.Read32(buffer_vaddr);
     LOG_WARNING(Service_AC, "Buffer descriptor: 0x{:08X}, expected: 0x{:08X}", descr, (size << 14) | 2);
     ASSERT(descr == ((size << 14) | 2));    // preliminary check
-    const VAddr output_buffer = buffer_info[4]; // address to output buffer
+    const VAddr output_buffer = memory.Read32(buffer_vaddr + 0x4); // address to output buffer
     LOG_WARNING(Service_AC, "Buffer VAddr: 0x{:08X}", output_buffer);
 
     Network::MacAddress mac = Network::BroadcastMac;

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -225,7 +225,7 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
 
     auto context =
             std::make_shared<Kernel::HLERequestContext>(Core::System::GetInstance().Kernel(), 
-                    SharedFrom(this), thread);
+                    ctx.Session(), thread);
     context->PopulateFromIncomingCommandBuffer(cmd_buf.data(), current_process);
 
     auto nwm_inf = 

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -218,7 +218,7 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     cmd_buf[18] = (size << 4) | 12;
     cmd_buf[19] = buffer_id;
 
-    Kernel::KernelSystem kernel = Core::System::GetInstance()::GetKernel();
+    Kernel::KernelSystem kernel = Core::System::GetInstance().GetKernel();
     std::shared_ptr<Kernel::Thread> thread = ctx.ClientThread();
     auto current_process = thread->owner_process.lock();
 

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -252,7 +252,7 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     rb.Push(rp2.Pop<u32>());
     Kernel::MappedBuffer mapped_buffer = rp2.PopMappedBuffer();
     rb.PushMappedBuffer(mapped_buffer);
-    LOG_WARNING(Service_AC, "(STUBBED) called, pid={}, unknown={}", pid, unknown);
+    LOG_WARNING(Service_AC, "(STUBBED) called, pid={}", pid);
 }
 
 void Module::Interface::GetInfraPriority(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -199,7 +199,7 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_AC, "PID: {}", pid);
     
     std::shared_ptr<Kernel::Thread> thread = ctx.ClientThread();
-    auto current_process = Core::System::GetInstance().GetCurrentProcess();
+    auto current_process = Core::System::GetInstance().Kernel().GetCurrentProcess();
     Memory::MemorySystem& memory = Core::System::GetInstance().Memory();
     LOG_WARNING(Service_AC, "Retrieved thread, process and memory");
 

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -228,10 +228,13 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
                     ctx.Session(), thread);
     context->PopulateFromIncomingCommandBuffer(cmd_buf.data(), current_process);
 
-    auto nwm_inf = 
-            Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_INF>("nwm::INF");
-    nwm_inf->HandleSyncRequest(*context);
+    LOG_WARNING(Service_AC, "Finished setting up context");
 
+    auto nwm_inf = 
+            Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_INF>("nwm::INF");    
+    LOG_WARNING(Service_AC, "Calling NWM_INF::RecvBeaconBroadcastData");
+    nwm_inf->HandleSyncRequest(*context);
+    LOG_WARNING(Service_AC, "Returned to AC::ScanAPs");
     // Response should be
     // 0: Header Code (ignored)
     // 1: Result Code (Success/Unknown/etc.)
@@ -242,7 +245,7 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     Kernel::MappedBuffer mapped_buffer = rp2.PopMappedBuffer();
     mapped_buffer.Read(buffer.data(), 0, buffer.size());
     rb.PushStaticBuffer(buffer, 0);
-    LOG_WARNING(Service_AC, "(STUBBED) called");
+    LOG_WARNING(Service_AC, "(STUBBED) called, pid={}, unknown={}", pid, unknown);
 }
 
 void Module::Interface::GetInfraPriority(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -219,7 +219,7 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     cmd_buf[19] = buffer_id;
 
     Kernel::KernelSystem kernel = ctx.kernel;
-    std::shared_ptr<Thread> thread = ctx.ClientThread();
+    std::shared_ptr<Kernel::Thread> thread = ctx.ClientThread();
     auto current_process = thread->owner_process.lock();
 
     auto context =

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -182,15 +182,15 @@ void Module::Interface::GetStatus(Kernel::HLERequestContext& ctx) {
 
 void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
-    const u32 arg1 = rp.Pop();
+    const u32 arg1 = rp.Pop<u32>();
     LOG_WARNING(Service_AC, "val1: {}", arg1);
-    const u32 arg2 = rp.Pop();
+    const u32 arg2 = rp.Pop<u32>();
     LOG_WARNING(Service_AC, "val2: {}", arg2);
-    const u32 arg3 = rp.Pop();
+    const u32 arg3 = rp.Pop<u32>();
     LOG_WARNING(Service_AC, "val3: {}", arg3);
-    const u32 arg4 = rp.Pop();
+    const u32 arg4 = rp.Pop<u32>();
     LOG_WARNING(Service_AC, "val4: {}", arg4);
-    const u32 arg5 = rp.Pop();
+    const u32 arg5 = rp.Pop<u32>();
     LOG_WARNING(Service_AC, "val5: {}", arg5);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -218,7 +218,7 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     cmd_buf[18] = (size << 4) | 12;
     cmd_buf[19] = buffer_id;
 
-    Kernel::KernelSystem kernel = ctx.kernel;
+    Kernel::KernelSystem kernel = Core::System::GetInstance()::GetKernel();
     std::shared_ptr<Kernel::Thread> thread = ctx.ClientThread();
     auto current_process = thread->owner_process.lock();
 

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -219,12 +219,12 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     cmd_buf[18] = (size << 4) | 12;
     cmd_buf[19] = buffer_id;
 
-    Kernel::KernelSystem kernel = Core::System::GetInstance().Kernel();
     std::shared_ptr<Kernel::Thread> thread = ctx.ClientThread();
     auto current_process = thread->owner_process.lock();
 
     auto context =
-            std::make_shared<Kernel::HLERequestContext>(kernel, SharedFrom(this), thread);
+            std::make_shared<Kernel::HLERequestContext>(Core::System::GetInstance().Kernel(), 
+                    SharedFrom(this), thread);
     context->PopulateFromIncomingCommandBuffer(cmd_buf.data(), current_process);
 
     auto nwm_inf = 

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -197,12 +197,12 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     // Arg 3 is PID
     const u32 pid = rp.PopPID();
     LOG_WARNING(Service_AC, "PID: {}", pid);
-    // // Likely time transpired between consecutive calls of this method.
-    // // First call has value 0 or 1. Second call has value 0xFFFF0000.
-    // const u32 unknown = rp.Pop<u32>();
-    // LOG_WARNING(Service_AC, "val4: {}", unknown);
-    auto buffer = rp.PopMappedBuffer();
-    u32 buffer_id = buffer.GetId();
+    // Likely time transpired between consecutive calls of this method.
+    // First call has value 0 or 1. Second call has value 0xFFFF0000.
+    const u32 unknown = rp.Pop<u32>();
+    LOG_WARNING(Service_AC, "val4: {}", unknown);
+
+    // std::vector<u8> buffer(size);
 
     Network::MacAddress mac = Network::BroadcastMac;
     u32 mac1 = (mac[0] << 8) | (mac[1]);
@@ -217,8 +217,8 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     cmd_buf[5] = mac2;
     cmd_buf[16] = 0;
     cmd_buf[17] = 0x0006;   // dummy value
-    cmd_buf[18] = (size << 4) | 12;
-    cmd_buf[19] = buffer_id;
+    cmd_buf[18] = (size << 4) | 12; // should be considered correct for mapped buffer
+    cmd_buf[19] = 0;    // if i interpreted the code correctly, this value won't matter
 
     std::shared_ptr<Kernel::Thread> thread = ctx.ClientThread();
     auto current_process = thread->owner_process.lock();
@@ -239,7 +239,7 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
     IPC::RequestParser rp2(*context);
     rb.Push(rp2.Pop<u32>());
-    rb.PushMappedBuffer(rp2.PopMappedBuffer());
+    rb.PushStaticBuffer(rp2.PopMappedBuffer(), 0);
     LOG_WARNING(Service_AC, "(STUBBED) called");
 }
 

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -215,16 +215,13 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     // Since I do not know the proper way, I copied various pieces of code that seemed to work
     // MAC address gets split, but I am not sure this is the proper way to do so
     Network::MacAddress mac = Network::BroadcastMac;
-    u32 mac1 = (mac[0] << 8) | (mac[1]);
-    u32 mac2 = (mac[2] << 24) | (mac[3] << 16) | (mac[4] << 8) | (mac[5]);
 
     std::array<u32, IPC::COMMAND_BUFFER_LENGTH + 2 * IPC::MAX_STATIC_BUFFERS> cmd_buf;
     cmd_buf[0] = 0x000603C4;    // Command header
     cmd_buf[1] = size;  // size of buffer
     cmd_buf[2] = 0; // dummy data
     cmd_buf[3] = 0; // dummy data
-    cmd_buf[4] = mac1;
-    cmd_buf[5] = mac2;
+    std::memcpy(cmd_buf.data() + 4, mac.data(), sizeof(Network::MacAddress));
     cmd_buf[16] = 0;    // 0x0 handle header
     cmd_buf[17] = 0;    // set to 0 to ignore it
     cmd_buf[18] = (size << 4) | 12; // should be considered correct for mapped buffer

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -200,7 +200,7 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     // const u32 unknown = rp.Pop<u32>();
     // LOG_WARNING(Service_AC, "val4: {}", unknown);
     auto buffer = rp.PopMappedBuffer();
-    u32 buffer_id = buffer.GetID();
+    u32 buffer_id = buffer.GetId();
 
     MacAddress mac = Network::BroadcastMac;
     u32 mac1 = (mac[0] << 8) | (mac[1]);

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -180,6 +180,25 @@ void Module::Interface::GetStatus(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_AC, "(STUBBED) called");
 }
 
+
+void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp(ctx);
+    const u32 arg1 = rp.Pop();
+    LOG_WARNING(Service_AC, "val1: {}", arg1);
+    const u32 arg2 = rp.Pop();
+    LOG_WARNING(Service_AC, "val2: {}", arg2);
+    const u32 arg3 = rp.Pop();
+    LOG_WARNING(Service_AC, "val3: {}", arg3);
+    const u32 arg4 = rp.Pop();
+    LOG_WARNING(Service_AC, "val4: {}", arg4);
+    const u32 arg5 = rp.Pop();
+    LOG_WARNING(Service_AC, "val5: {}", arg5);
+
+    IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
+    rb.Push(ResultUnknown);
+    LOG_WARNING(Service_AC, "(STUBBED) called");
+}
+
 void Module::Interface::GetInfraPriority(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     [[maybe_unused]] const std::vector<u8>& ac_config = rp.PopStaticBuffer();

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -207,7 +207,7 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     // of cmd_buff
     VAddr cmd_addr = thread->GetCommandBufferAddress();
     VAddr buffer_vaddr = cmd_addr + 0x100;
-    u32* buffer_info = static_cast<u32*>(memory.GetPointer());
+    u32* buffer_info = static_cast<u32*>(memory.GetPointer(buffer_vaddr));
     const u32 descr = buffer_info[0];
     ASSERT(descr == ((size << 14) | 2));    // preliminary check
     const VAddr output_buffer = buffer_info[1]; // address to output buffer

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -203,7 +203,7 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     auto buffer = rp.PopMappedBuffer();
     u32 buffer_id = buffer.GetId();
 
-    MacAddress mac = Network::BroadcastMac;
+    Network::MacAddress mac = Network::BroadcastMac;
     u32 mac1 = (mac[0] << 8) | (mac[1]);
     u32 mac2 = (mac[2] << 24) | (mac[3] << 16) | (mac[4] << 8) | (mac[5]);
 

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -234,11 +234,9 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
 
     // Retrieve service from service manager
     auto nwm_inf = 
-        Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_INF>("nwm::INF");    
-    LOG_WARNING(Service_AC, "Calling NWM_INF::RecvBeaconBroadcastData");
+        Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_INF>("nwm::INF");
     // Perform delegated task
     nwm_inf->HandleSyncRequest(*context);
-    LOG_WARNING(Service_AC, "Returned to AC::ScanAPs");
 
     // Response should be
     // 0: Header Code (ignored)

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <vector>
+#include <boost/serialization/shared_ptr.hpp>
 #include "common/archives.h"
 #include "common/common_types.h"
 #include "common/logging/log.h"

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -209,7 +209,7 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     u32 mac2 = (mac[2] << 24) | (mac[3] << 16) | (mac[4] << 8) | (mac[5]);
 
     std::array<u32, IPC::COMMAND_BUFFER_LENGTH + 2 * IPC::MAX_STATIC_BUFFERS> cmd_buf;
-    cmd_buf[0] = 0x0006;
+    cmd_buf[0] = 0x0006'03C4;
     cmd_buf[1] = size;
     cmd_buf[2] = 0; // dummy data
     cmd_buf[3] = 0; // dummy data

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -229,14 +229,14 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
 
     auto nwm_inf = 
             Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_INF>("nwm::INF");
-    nwm_inf->HandleSyncRequest(context);
+    nwm_inf->HandleSyncRequest(*context);
 
     // Response should be
     // 0: Header Code (ignored)
     // 1: Result Code (Success/Unknown/etc.)
     // 2: ¿Parsed? beacon data
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    IPC::RequestParser rp2(context);
+    IPC::RequestParser rp2(*context);
     rb.Push(rp2.Pop<u32>());
     rb.PushMappedBuffer(rp2.PopMappedBuffer());
     LOG_WARNING(Service_AC, "(STUBBED) called");

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -219,7 +219,7 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     cmd_buf[18] = (size << 4) | 12;
     cmd_buf[19] = buffer_id;
 
-    Kernel::KernelSystem kernel = Core::System::GetInstance().GetKernel();
+    Kernel::KernelSystem kernel = Core::System::GetInstance().Kernel();
     std::shared_ptr<Kernel::Thread> thread = ctx.ClientThread();
     auto current_process = thread->owner_process.lock();
 

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -228,12 +228,12 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     cmd_buf[19] = output_buffer;    // address of output buffer
 
     // Create context for call to NWM_INF::RecvBeaconBroadcastData
-    auto context = std::make_shared<Kernel::HLERequestContext>(Core::System::GetInstance().Kernel(), 
+    auto context = std::make_shared<Kernel::HLERequestContext>(Core::System::GetInstance().Kernel(),
                                                                ctx.Session(), thread);
     context->PopulateFromIncomingCommandBuffer(cmd_buf.data(), current_process);
 
     // Retrieve service from service manager
-    auto nwm_inf = 
+    auto nwm_inf =
         Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_INF>("nwm::INF");
     // Perform delegated task
     nwm_inf->HandleSyncRequest(*context);

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -229,15 +229,16 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
 
     auto nwm_inf = 
             Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_INF>("nwm::INF");
-    Result res = nwm_inf->HandleSyncRequest(context);
+    nwm_inf->HandleSyncRequest(context);
 
     // Response should be
     // 0: Header Code (ignored)
     // 1: Result Code (Success/Unknown/etc.)
     // 2: ¿Parsed? beacon data
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(res);
-    // rb.PushStaticBuffer(buffer, 0);
+    IPC::RequestParser rp2(context);
+    rb.Push(rp2.Pop<u32>());
+    rb.PushMappedBuffer(rp2.PopMappedBuffer());
     LOG_WARNING(Service_AC, "(STUBBED) called");
 }
 

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -199,8 +199,8 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_AC, "PID: {}", pid);
     
     std::shared_ptr<Kernel::Thread> thread = ctx.ClientThread();
-    auto current_process = thread->owner_process.lock();
-    Memory::MemorySystem& memory = ctx->kernel.memory;
+    auto current_process = Core::System::GetInstance().GetCurrentProcess();
+    Memory::MemorySystem& memory = Core::System::GetInstance().Memory();
     LOG_WARNING(Service_AC, "Retrieved thread, process and memory");
 
     // According to 3dbrew, the output structure pointer is located 0x100 bytes after the beginning

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -200,15 +200,19 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     // const u32 unknown = rp.Pop<u32>();
     // LOG_WARNING(Service_AC, "val4: {}", unknown);
     auto buffer = rp.PopMappedBuffer();
-    u32 buffer_id = rp.GetID();
+    u32 buffer_id = buffer.GetID();
 
+    MacAddress mac = Network::BroadcastMac;
+    u32 mac1 = (mac[0] << 8) | (mac[1]);
+    u32 mac2 = (mac[2] << 24) | (mac[3] << 16) | (mac[4] << 8) | (mac[5]);
 
     std::array<u32, IPC::COMMAND_BUFFER_LENGTH + 2 * IPC::MAX_STATIC_BUFFERS> cmd_buf;
     cmd_buf[0] = 0x0006;
     cmd_buf[1] = size;
     cmd_buf[2] = 0; // dummy data
     cmd_buf[3] = 0; // dummy data
-    cmd_buf[4] = Network::BroadcastMac;
+    cmd_buf[4] = mac1;
+    cmd_buf[5] = mac2;
     cmd_buf[16] = 0;
     cmd_buf[17] = 0x0006;   // dummy value
     cmd_buf[18] = (size << 4) | 12;

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -21,9 +21,9 @@
 #include "core/hle/service/ac/ac_u.h"
 #include "core/hle/service/nwm/nwm_inf.h"
 #include "core/hle/service/soc/soc_u.h"
+#include "core/memory.h"
 #include "network/network.h"
 #include "network/room.h"
-#include "core/memory.h"
 
 SERIALIZE_EXPORT_IMPL(Service::AC::Module)
 SERVICE_CONSTRUCT_IMPL(Service::AC::Module)
@@ -195,7 +195,7 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     // Arg 2 is CallingPID value (PID Header)
     // Arg 3 is PID
     const u32 pid = rp.PopPID();
-    
+
     std::shared_ptr<Kernel::Thread> thread = ctx.ClientThread();
     auto current_process = Core::System::GetInstance().Kernel().GetCurrentProcess();
     Memory::MemorySystem& memory = Core::System::GetInstance().Memory();
@@ -205,7 +205,7 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     VAddr cmd_addr = thread->GetCommandBufferAddress();
     VAddr buffer_vaddr = cmd_addr + 0x100;
     const u32 descr = memory.Read32(buffer_vaddr);
-    ASSERT(descr == ((size << 14) | 2));    // preliminary check
+    ASSERT(descr == ((size << 14) | 2));                           // preliminary check
     const VAddr output_buffer = memory.Read32(buffer_vaddr + 0x4); // address to output buffer
 
     // At this point, we have all the input given to us
@@ -217,25 +217,24 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     Network::MacAddress mac = Network::BroadcastMac;
 
     std::array<u32, IPC::COMMAND_BUFFER_LENGTH + 2 * IPC::MAX_STATIC_BUFFERS> cmd_buf;
-    cmd_buf[0] = 0x000603C4;    // Command header
-    cmd_buf[1] = size;  // size of buffer
-    cmd_buf[2] = 0; // dummy data
-    cmd_buf[3] = 0; // dummy data
+    cmd_buf[0] = 0x000603C4; // Command header
+    cmd_buf[1] = size;       // size of buffer
+    cmd_buf[2] = 0;          // dummy data
+    cmd_buf[3] = 0;          // dummy data
     std::memcpy(cmd_buf.data() + 4, mac.data(), sizeof(Network::MacAddress));
-    cmd_buf[16] = 0;    // 0x0 handle header
-    cmd_buf[17] = 0;    // set to 0 to ignore it
+    cmd_buf[16] = 0;                // 0x0 handle header
+    cmd_buf[17] = 0;                // set to 0 to ignore it
     cmd_buf[18] = (size << 4) | 12; // should be considered correct for mapped buffer
     cmd_buf[19] = output_buffer;    // address of output buffer
 
     // Create context for call to NWM_INF::RecvBeaconBroadcastData
-    auto context =
-            std::make_shared<Kernel::HLERequestContext>(Core::System::GetInstance().Kernel(), 
-                    ctx.Session(), thread);
+    auto context = std::make_shared<Kernel::HLERequestContext>(Core::System::GetInstance().Kernel(), 
+                                                               ctx.Session(), thread);
     context->PopulateFromIncomingCommandBuffer(cmd_buf.data(), current_process);
 
     // Retrieve service from service manager
     auto nwm_inf = 
-            Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_INF>("nwm::INF");    
+        Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_INF>("nwm::INF");    
     LOG_WARNING(Service_AC, "Calling NWM_INF::RecvBeaconBroadcastData");
     // Perform delegated task
     nwm_inf->HandleSyncRequest(*context);
@@ -250,7 +249,7 @@ void Module::Interface::ScanAPs(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
     IPC::RequestParser rp2(*context);
     rb.Push(rp2.Pop<u32>());
-    // Mapped buffer at virtual address output_buffer 
+    // Mapped buffer at virtual address output_buffer
     Kernel::MappedBuffer mapped_buffer = rp2.PopMappedBuffer();
     rb.PushMappedBuffer(mapped_buffer);
     LOG_WARNING(Service_AC, "(STUBBED) called, pid={}", pid);

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -21,6 +21,7 @@
 #include "core/hle/service/nwm/nwm_inf.h"
 #include "core/hle/service/soc/soc_u.h"
 #include "network/network.h"
+#include "network/room.h"
 #include "core/memory.h"
 
 SERIALIZE_EXPORT_IMPL(Service::AC::Module)

--- a/src/core/hle/service/ac/ac.h
+++ b/src/core/hle/service/ac/ac.h
@@ -123,6 +123,15 @@ public:
         void GetConnectingInfraPriority(Kernel::HLERequestContext& ctx);
 
         /**
+         * AC::ScanAPs service function
+         *  Inputs:
+         *      ?
+         *  Outputs:
+         *      ?
+         */
+        void ScanAPs(Kernel::HLERequestContext& ctx);
+        
+        /**
          * AC::GetInfraPriority service function
          *  Inputs:
          *      1 : ACConfig size << 14 | 2

--- a/src/core/hle/service/ac/ac.h
+++ b/src/core/hle/service/ac/ac.h
@@ -125,9 +125,13 @@ public:
         /**
          * AC::ScanAPs service function
          *  Inputs:
-         *      ?
+         *      1 : Size
+         *      2-3 : ProcessID
+         *      64: (Size << 14) | 2
+         *      65: Pointer to output structure
          *  Outputs:
-         *      ?
+         *      1 : Result of function, 0 on success, otherwise error code
+         *      2 : ?
          */
         void ScanAPs(Kernel::HLERequestContext& ctx);
 

--- a/src/core/hle/service/ac/ac.h
+++ b/src/core/hle/service/ac/ac.h
@@ -130,7 +130,7 @@ public:
          *      ?
          */
         void ScanAPs(Kernel::HLERequestContext& ctx);
-        
+
         /**
          * AC::GetInfraPriority service function
          *  Inputs:

--- a/src/core/hle/service/ac/ac_i.cpp
+++ b/src/core/hle/service/ac/ac_i.cpp
@@ -23,7 +23,7 @@ AC_I::AC_I(std::shared_ptr<Module> ac) : Module::Interface(std::move(ac), "ac:i"
         {0x000F, &AC_I::GetConnectingInfraPriority, "GetConnectingInfraPriority"},
         {0x0010, nullptr, "GetCurrentNZoneInfo"},
         {0x0011, nullptr, "GetNZoneApNumService"},
-        {0x001D, nullptr, "ScanAPs"},
+        {0x001D, &AC_I::ScanAPs, "ScanAPs"},
         {0x0024, nullptr, "AddDenyApType"},
         {0x0027, &AC_I::GetInfraPriority, "GetInfraPriority"},
         {0x002C, &AC_I::SetFromApplication, "SetFromApplication"},

--- a/src/core/hle/service/ac/ac_u.cpp
+++ b/src/core/hle/service/ac/ac_u.cpp
@@ -23,7 +23,7 @@ AC_U::AC_U(std::shared_ptr<Module> ac) : Module::Interface(std::move(ac), "ac:u"
         {0x000F, &AC_U::GetConnectingInfraPriority, "GetConnectingInfraPriority"},
         {0x0010, nullptr, "GetCurrentNZoneInfo"},
         {0x0011, nullptr, "GetNZoneApNumService"},
-        {0x001D, nullptr, "ScanAPs"},
+        {0x001D, &AC_U::ScanAPs, "ScanAPs"},
         {0x0024, nullptr, "AddDenyApType"},
         {0x0027, &AC_U::GetInfraPriority, "GetInfraPriority"},
         {0x002C, &AC_U::SetFromApplication, "SetFromApplication"},

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -23,8 +23,9 @@ void NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
 
     // adding in extra context value for transition from INF to UDS
     std::array<u32, IPC::COMMAND_BUFFER_LENGTH + 2 * IPC::MAX_STATIC_BUFFERS> cmd_buf;
+    cmd_buf[0] = 0x000F0404;
     int i;
-    for (i = 0; i < 15; i++) {
+    for (i = 1; i < 15; i++) {
         cmd_buf[i] = rp.Pop<u32>();
     }
     rp.Pop<u32>();

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -26,8 +26,12 @@ void NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
     for (i = 17; i <= 20; i++) {
         cmd_buf[i] = ctx_data[i - 1];
     }
+
+    Kernel::KernelSystem kernel = ctx.kernel;
+    std::shared_ptr<Thread> thread = ctx.ClientThread();
+    auto current_process = thread->owner_process.lock();
     auto context =
-            std::make_shared<Kernel::HLERequestContext>(kernel, SharedFrom(this), thread);
+            std::make_shared<Kernel::HLERequestContext>(kernel, SharedFrom(this), /* TODO */);
     context->PopulateFromIncomingCommandBuffer(cmd_buf.data(), current_process);
 
     auto nwm_uds = Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_UDS>("nwm::UDS");

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -36,9 +36,9 @@ void NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
     context->PopulateFromIncomingCommandBuffer(cmd_buf.data(), current_process);
 
     auto nwm_uds = Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_UDS>("nwm::UDS");
-    nwm_uds->HandleSyncRequest(context);
+    nwm_uds->HandleSyncRequest(*context);
 
-    IPC::RequestParser rp2(context);
+    IPC::RequestParser rp2(*context);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
     rb.Push(rp2.Pop<u32>());

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -49,9 +49,7 @@ void NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
 
     auto nwm_uds = 
         Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_UDS>("nwm::UDS");
-    LOG_WARNING(Service_NWM, "Calling NWM_UDS::RecvBeaconBroadcastData");
     nwm_uds->HandleSyncRequest(*context);
-    LOG_WARNING(Service_NWM, "Returned to NWM_INF::RecvBeaconBroadcastData");
 
     // Push results of delegated call to caller
     IPC::RequestParser rp2(*context);

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -19,7 +19,7 @@ void NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
 NWM_INF::NWM_INF() : ServiceFramework("nwm::INF") {
     static const FunctionInfo functions[] = {
         // clang-format off
-        {0x0006, NWM_INF::RecvBeaconBroadcastData, "RecvBeaconBroadcastData"},
+        {0x0006, RecvBeaconBroadcastData, "RecvBeaconBroadcastData"},
         {0x0007, nullptr, "ConnectToEncryptedAP"},
         {0x0008, nullptr, "ConnectToAP"},
         // clang-format on

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -27,11 +27,11 @@ void NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
         cmd_buf[i] = ctx_data[i - 1];
     }
 
-    Kernel::KernelSystem kernel = Core::System::GetInstance().Kernel();
     std::shared_ptr<Kernel::Thread> thread = ctx.ClientThread();
     auto current_process = thread->owner_process.lock();
     auto context =
-            std::make_shared<Kernel::HLERequestContext>(kernel, SharedFrom(this), thread);
+            std::make_shared<Kernel::HLERequestContext>(Core::System::GetInstance().Kernel(), 
+                    SharedFrom(this), thread);
     context->PopulateFromIncomingCommandBuffer(cmd_buf.data(), current_process);
 
     auto nwm_uds = Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_UDS>("nwm::UDS");

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -34,8 +34,8 @@ void NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
         cmd_buf[i] = rp.Pop<u32>();
     }
     rp.Pop<u32>();
-    cmd_buf[15] = 0;    // dummy wlan_comm_id
-    cmd_buf[16] = 0;    // dummy id
+    cmd_buf[15] = 0; // dummy wlan_comm_id
+    cmd_buf[16] = 0; // dummy id
     for (i = 17; i <= 20; i++) {
         cmd_buf[i] = rp.Pop<u32>();
     }
@@ -43,12 +43,12 @@ void NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
     // Prepare for call to NWM_UDS
     std::shared_ptr<Kernel::Thread> thread = ctx.ClientThread();
     auto current_process = thread->owner_process.lock();
-    auto context =
-            std::make_shared<Kernel::HLERequestContext>(Core::System::GetInstance().Kernel(), 
-                    ctx.Session(), thread);
+    auto context = std::make_shared<Kernel::HLERequestContext>(Core::System::GetInstance().Kernel(), 
+                                                               ctx.Session(), thread);
     context->PopulateFromIncomingCommandBuffer(cmd_buf.data(), current_process);
 
-    auto nwm_uds = Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_UDS>("nwm::UDS");
+    auto nwm_uds = 
+        Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_UDS>("nwm::UDS");
     LOG_WARNING(Service_NWM, "Calling NWM_UDS::RecvBeaconBroadcastData");
     nwm_uds->HandleSyncRequest(*context);
     LOG_WARNING(Service_NWM, "Returned to NWM_INF::RecvBeaconBroadcastData");

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -43,11 +43,11 @@ void NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
     // Prepare for call to NWM_UDS
     std::shared_ptr<Kernel::Thread> thread = ctx.ClientThread();
     auto current_process = thread->owner_process.lock();
-    auto context = std::make_shared<Kernel::HLERequestContext>(Core::System::GetInstance().Kernel(), 
+    auto context = std::make_shared<Kernel::HLERequestContext>(Core::System::GetInstance().Kernel(),
                                                                ctx.Session(), thread);
     context->PopulateFromIncomingCommandBuffer(cmd_buf.data(), current_process);
 
-    auto nwm_uds = 
+    auto nwm_uds =
         Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_UDS>("nwm::UDS");
     nwm_uds->HandleSyncRequest(*context);
 

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -4,6 +4,7 @@
 
 #include <boost/serialization/shared_ptr.hpp>
 #include "common/archives.h"
+#include "common/logging/log.h"
 #include "core/core.h"
 #include "core/hle/ipc.h"
 #include "core/hle/ipc_helpers.h"
@@ -17,6 +18,8 @@ namespace Service::NWM {
 void NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     // TODO(PTR) Update implementation to cover differences between NWM_INF and NWM_UDS
+
+    LOG_WARNING(Service_NWM, "Started NWM_INF::RecvBeaconBroadcastData");
 
     // adding in extra context value for transition from INF to UDS
     std::array<u32, IPC::COMMAND_BUFFER_LENGTH + 2 * IPC::MAX_STATIC_BUFFERS> cmd_buf;
@@ -37,9 +40,13 @@ void NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
             std::make_shared<Kernel::HLERequestContext>(Core::System::GetInstance().Kernel(), 
                     ctx.Session(), thread);
     context->PopulateFromIncomingCommandBuffer(cmd_buf.data(), current_process);
+    LOG_WARNING(Service_NWM, "Finished converting context");
 
     auto nwm_uds = Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_UDS>("nwm::UDS");
+    
+    LOG_WARNING(Service_NWM, "Calling NWM_UDS::RecvBeaconBroadcastData");
     nwm_uds->HandleSyncRequest(*context);
+    LOG_WARNING(Service_NWM, "Returned to NWM_INF::RecvBeaconBroadcastData");
 
     IPC::RequestParser rp2(*context);
 
@@ -47,6 +54,7 @@ void NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
     rb.Push(rp2.Pop<u32>());
     rb.PushMappedBuffer(rp2.PopMappedBuffer());
 
+    LOG_WARNING(Service_NWM, "Finished NWM_INF::RecvBeaconBroadcastData");
 }
 
 NWM_INF::NWM_INF() : ServiceFramework("nwm::INF") {

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -28,7 +28,7 @@ void NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
     }
 
     Kernel::KernelSystem kernel = ctx.kernel;
-    std::shared_ptr<Thread> thread = ctx.ClientThread();
+    std::shared_ptr<Kernel::Thread> thread = ctx.ClientThread();
     auto current_process = thread->owner_process.lock();
     auto context =
             std::make_shared<Kernel::HLERequestContext>(kernel, SharedFrom(this), thread);

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -3,8 +3,8 @@
 // Refer to the license.txt file included.
 
 #include "common/archives.h"
+#include "core/core.h"
 #include "core/hle/service/nwm/nwm_inf.h"
-#include "core/hle/service/nwm/nwm_uds.h"
 
 SERIALIZE_EXPORT_IMPL(Service::NWM::NWM_INF)
 

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -31,7 +31,7 @@ void NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
     std::shared_ptr<Thread> thread = ctx.ClientThread();
     auto current_process = thread->owner_process.lock();
     auto context =
-            std::make_shared<Kernel::HLERequestContext>(kernel, SharedFrom(this), /* TODO */);
+            std::make_shared<Kernel::HLERequestContext>(kernel, SharedFrom(this), thread);
     context->PopulateFromIncomingCommandBuffer(cmd_buf.data(), current_process);
 
     auto nwm_uds = Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_UDS>("nwm::UDS");

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -20,7 +20,7 @@ void NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
 NWM_INF::NWM_INF() : ServiceFramework("nwm::INF") {
     static const FunctionInfo functions[] = {
         // clang-format off
-        {0x0006, RecvBeaconBroadcastData, "RecvBeaconBroadcastData"},
+        {0x0006, &NWM_INF::RecvBeaconBroadcastData, "RecvBeaconBroadcastData"},
         {0x0007, nullptr, "ConnectToEncryptedAP"},
         {0x0008, nullptr, "ConnectToAP"},
         // clang-format on

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -21,67 +21,43 @@ namespace Service::NWM {
 void NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
-    u32 out_buffer_size = rp.Pop<u32>();
-    u32 unk1 = rp.Pop<u32>();
-    u32 unk2 = rp.Pop<u32>();
+    LOG_WARNING(Service_NWM, "Started NWM_INF::RecvBeaconBroadcastData");
 
-    MacAddress mac_address;
-    rp.PopRaw(mac_address);
-
-    rp.Skip(9, false);
-
-    u32 unk3 = rp.Pop<u32>();
-    // From 3dbrew:
-    // 'Official user processes create a new event handle which is then passed to this command.
-    // However, those user processes don't save that handle anywhere afterwards.'
-    // So we don't save/use that event too.
-    std::shared_ptr<Kernel::Event> input_event = rp.PopObject<Kernel::Event>();
-
-    Kernel::MappedBuffer out_buffer = rp.PopMappedBuffer();
-    ASSERT(out_buffer.GetSize() == out_buffer_size);
-
-    std::size_t cur_buffer_size = sizeof(BeaconDataReplyHeader);
-
-    // Retrieve all beacon frames that were received from the desired mac address.
-    auto nwm_uds = 
-            Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_UDS>("nwm::UDS");
-    auto beacons = nwm_uds->GetReceivedBeacons(mac_address);
-
-    BeaconDataReplyHeader data_reply_header{};
-    data_reply_header.total_entries = static_cast<u32>(beacons.size());
-    data_reply_header.max_output_size = out_buffer_size;
-
-    // Write each of the received beacons into the buffer
-    for (const auto& beacon : beacons) {
-        BeaconEntryHeader entry{};
-        // TODO(Subv): Figure out what this size is used for.
-        entry.unk_size = static_cast<u32>(sizeof(BeaconEntryHeader) + beacon.data.size());
-        entry.total_size = static_cast<u32>(sizeof(BeaconEntryHeader) + beacon.data.size());
-        entry.wifi_channel = beacon.channel;
-        entry.header_size = sizeof(BeaconEntryHeader);
-        entry.mac_address = beacon.transmitter_address;
-
-        ASSERT(cur_buffer_size < out_buffer_size);
-
-        out_buffer.Write(&entry, cur_buffer_size, sizeof(BeaconEntryHeader));
-        cur_buffer_size += sizeof(BeaconEntryHeader);
-        const unsigned char* beacon_data = beacon.data.data();
-        out_buffer.Write(beacon_data, cur_buffer_size, beacon.data.size());
-        cur_buffer_size += beacon.data.size();
+    // adding in extra context value for transition from INF to UDS
+    std::array<u32, IPC::COMMAND_BUFFER_LENGTH + 2 * IPC::MAX_STATIC_BUFFERS> cmd_buf;
+    cmd_buf[0] = 0x000F0404;
+    int i;
+    for (i = 1; i < 15; i++) {
+        cmd_buf[i] = rp.Pop<u32>();
+    }
+    rp.Pop<u32>();
+    cmd_buf[15] = 0;    // dummy wlan_comm_id
+    cmd_buf[16] = 0;    // dummy id
+    for (i = 17; i <= 20; i++) {
+        cmd_buf[i] = rp.Pop<u32>();
     }
 
-    // Update the total size in the structure and write it to the buffer again.
-    data_reply_header.total_size = static_cast<u32>(cur_buffer_size);
-    out_buffer.Write(&data_reply_header, 0, sizeof(BeaconDataReplyHeader));
+    std::shared_ptr<Kernel::Thread> thread = ctx.ClientThread();
+    auto current_process = thread->owner_process.lock();
+    auto context =
+            std::make_shared<Kernel::HLERequestContext>(Core::System::GetInstance().Kernel(), 
+                    ctx.Session(), thread);
+    context->PopulateFromIncomingCommandBuffer(cmd_buf.data(), current_process);
+    LOG_WARNING(Service_NWM, "Finished converting context");
+
+    auto nwm_uds = Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_UDS>("nwm::UDS");
+    
+    LOG_WARNING(Service_NWM, "Calling NWM_UDS::RecvBeaconBroadcastData");
+    nwm_uds->HandleSyncRequest(*context);
+    LOG_WARNING(Service_NWM, "Returned to NWM_INF::RecvBeaconBroadcastData");
+
+    IPC::RequestParser rp2(*context);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(ResultSuccess);
-    rb.PushMappedBuffer(out_buffer);
+    rb.Push(rp2.Pop<u32>());
+    rb.PushMappedBuffer(rp2.PopMappedBuffer());
 
-    LOG_DEBUG(Service_NWM,
-              "called out_buffer_size=0x{:08X},"
-              "unk1=0x{:08X}, unk2=0x{:08X}, unk3=0x{:08X} offset={}",
-              out_buffer_size, unk1, unk2, unk3, cur_buffer_size);
+    LOG_WARNING(Service_NWM, "Finished NWM_INF::RecvBeaconBroadcastData");
 }
 
 NWM_INF::NWM_INF() : ServiceFramework("nwm::INF") {

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -27,7 +27,7 @@ void NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
         cmd_buf[i] = ctx_data[i - 1];
     }
 
-    Kernel::KernelSystem kernel = Core::System::GetInstance()::GetKernel();
+    Kernel::KernelSystem kernel = Core::System::GetInstance().GetKernel();
     std::shared_ptr<Kernel::Thread> thread = ctx.ClientThread();
     auto current_process = thread->owner_process.lock();
     auto context =

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -12,13 +12,14 @@ namespace Service::NWM {
 
 NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
     // TODO(PTR) Update implementation to cover differences between NWM_INF and NWM_UDS
-    NWM_UDS::RecvBeaconBroadcastData(ctx);
+    auto nwm_uds = Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_UDS>("nwm::UDS");
+    nwm_uds->HandleSyncRequest(ctx);
 }
 
 NWM_INF::NWM_INF() : ServiceFramework("nwm::INF") {
     static const FunctionInfo functions[] = {
         // clang-format off
-        {0x0006, nullptr, "RecvBeaconBroadcastData"},
+        {0x0006, NWM_INF::RecvBeaconBroadcastData, "RecvBeaconBroadcastData"},
         {0x0007, nullptr, "ConnectToEncryptedAP"},
         {0x0008, nullptr, "ConnectToAP"},
         // clang-format on

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -5,6 +5,8 @@
 #include <boost/serialization/shared_ptr.hpp>
 #include "common/archives.h"
 #include "core/core.h"
+#include "core/hle/ipc.h"
+#include "core/hle/ipc_helpers.h"
 #include "core/hle/service/nwm/nwm_inf.h"
 #include "core/hle/service/nwm/nwm_uds.h"
 

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -27,7 +27,7 @@ void NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
         cmd_buf[i] = ctx_data[i - 1];
     }
 
-    Kernel::KernelSystem kernel = ctx.kernel;
+    Kernel::KernelSystem kernel = Core::System::GetInstance()::GetKernel();
     std::shared_ptr<Kernel::Thread> thread = ctx.ClientThread();
     auto current_process = thread->owner_process.lock();
     auto context =

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -77,9 +77,9 @@ void NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
     rb.PushMappedBuffer(out_buffer);
 
     LOG_DEBUG(Service_NWM,
-              "called out_buffer_size=0x{:08X}, wlan_comm_id=0x{:08X}, id=0x{:08X},"
+              "called out_buffer_size=0x{:08X},"
               "unk1=0x{:08X}, unk2=0x{:08X}, unk3=0x{:08X} offset={}",
-              out_buffer_size, wlan_comm_id, id, unk1, unk2, unk3, cur_buffer_size);
+              out_buffer_size, unk1, unk2, unk3, cur_buffer_size);
 }
 
 NWM_INF::NWM_INF() : ServiceFramework("nwm::INF") {

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -5,6 +5,7 @@
 #include "common/archives.h"
 #include "core/core.h"
 #include "core/hle/service/nwm/nwm_inf.h"
+#include "core/hle/service/nwm/nwm_uds.h"
 
 SERIALIZE_EXPORT_IMPL(Service::NWM::NWM_INF)
 

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <boost/serialization/shared_ptr.hpp>
 #include "common/archives.h"
 #include "core/core.h"
 #include "core/hle/service/nwm/nwm_inf.h"

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -33,7 +33,7 @@ void NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
     auto current_process = thread->owner_process.lock();
     auto context =
             std::make_shared<Kernel::HLERequestContext>(Core::System::GetInstance().Kernel(), 
-                    SharedFrom(this), thread);
+                    ctx.Session(), thread);
     context->PopulateFromIncomingCommandBuffer(cmd_buf.data(), current_process);
 
     auto nwm_uds = Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_UDS>("nwm::UDS");

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -10,6 +10,9 @@
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/service/nwm/nwm_inf.h"
 #include "core/hle/service/nwm/nwm_uds.h"
+#include "core/hle/service/nwm/uds_beacon.h"
+#include "core/hle/service/nwm/uds_connection.h"
+#include "core/hle/service/nwm/uds_data.h"
 
 SERIALIZE_EXPORT_IMPL(Service::NWM::NWM_INF)
 

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -10,7 +10,7 @@ SERIALIZE_EXPORT_IMPL(Service::NWM::NWM_INF)
 
 namespace Service::NWM {
 
-NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
+void NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
     // TODO(PTR) Update implementation to cover differences between NWM_INF and NWM_UDS
     auto nwm_uds = Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_UDS>("nwm::UDS");
     nwm_uds->HandleSyncRequest(ctx);

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -43,7 +43,9 @@ void NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
     std::size_t cur_buffer_size = sizeof(BeaconDataReplyHeader);
 
     // Retrieve all beacon frames that were received from the desired mac address.
-    auto beacons = GetReceivedBeacons(mac_address);
+    auto nwm_uds = 
+            Core::System::GetInstance().ServiceManager().GetService<Service::NWM::NWM_UDS>("nwm::UDS");
+    auto beacons = nwm_uds->GetReceivedBeacons(mac_address);
 
     BeaconDataReplyHeader data_reply_header{};
     data_reply_header.total_entries = static_cast<u32>(beacons.size());

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -27,7 +27,7 @@ void NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
         cmd_buf[i] = ctx_data[i - 1];
     }
 
-    Kernel::KernelSystem kernel = Core::System::GetInstance().GetKernel();
+    Kernel::KernelSystem kernel = Core::System::GetInstance().Kernel();
     std::shared_ptr<Kernel::Thread> thread = ctx.ClientThread();
     auto current_process = thread->owner_process.lock();
     auto context =

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -4,10 +4,16 @@
 
 #include "common/archives.h"
 #include "core/hle/service/nwm/nwm_inf.h"
+#include "core/hle/service/nwm/nwm_uds.h"
 
 SERIALIZE_EXPORT_IMPL(Service::NWM::NWM_INF)
 
 namespace Service::NWM {
+
+NWM_INF::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
+    // TODO(PTR) Update implementation to cover differences between NWM_INF and NWM_UDS
+    NWM_UDS::RecvBeaconBroadcastData(ctx);
+}
 
 NWM_INF::NWM_INF() : ServiceFramework("nwm::INF") {
     static const FunctionInfo functions[] = {

--- a/src/core/hle/service/nwm/nwm_inf.h
+++ b/src/core/hle/service/nwm/nwm_inf.h
@@ -12,6 +12,21 @@ class NWM_INF final : public ServiceFramework<NWM_INF> {
 public:
     NWM_INF();
 
+    /**
+     * NWM::RecvBeaconBroadcastData service function
+     *  Inputs:
+     *      1 : Output buffer max size
+     *      2-14 : Input ScanInputStruct.
+     *      15 : u32, unknown
+     *      16 : Value 0x0
+     *      17 : Input handle
+     *      18 : (Size<<4) | 12
+     *      19 : Output BeaconDataReply buffer ptr
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx);
+
 private:
     SERVICE_SERIALIZATION_SIMPLE
 };

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -594,9 +594,6 @@ void NWM_UDS::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
 
     MacAddress mac_address;
     rp.PopRaw(mac_address);
-    LOG_WARNING(Service_NWM, "MAC: {:02X}.{:02X}.{:02X}.{:02X}.{:02X}.{:02X}", 
-            mac_address[0], mac_address[1], mac_address[2], 
-            mac_address[3], mac_address[4], mac_address[5]);
 
     rp.Skip(9, false);
 
@@ -632,18 +629,15 @@ void NWM_UDS::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
 
         ASSERT(cur_buffer_size < out_buffer_size);
 
-        LOG_WARNING(Service_NWM, "Writing entry header to buffer");
         out_buffer.Write(&entry, cur_buffer_size, sizeof(BeaconEntryHeader));
         cur_buffer_size += sizeof(BeaconEntryHeader);
         const unsigned char* beacon_data = beacon.data.data();
-        LOG_WARNING(Service_NWM, "Writing entry data to buffer");
         out_buffer.Write(beacon_data, cur_buffer_size, beacon.data.size());
         cur_buffer_size += beacon.data.size();
     }
 
     // Update the total size in the structure and write it to the buffer again.
     data_reply_header.total_size = static_cast<u32>(cur_buffer_size);
-    LOG_WARNING(Service_NWM, "Writing beacon reply header to buffer");
     out_buffer.Write(&data_reply_header, 0, sizeof(BeaconDataReplyHeader));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -594,7 +594,9 @@ void NWM_UDS::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
 
     MacAddress mac_address;
     rp.PopRaw(mac_address);
-    LOG_WARNING(Service_NWM, "MAC: {}", mac_address);
+    LOG_WARNING(Service_NWM, "MAC: {02X}.{02X}.{02X}.{02X}.{02X}.{02X}", 
+            mac_address[0], mac_address[1], mac_address[2], 
+            mac_address[3], mac_address[4], mac_address[5]);
 
     rp.Skip(9, false);
 

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -594,7 +594,7 @@ void NWM_UDS::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
 
     MacAddress mac_address;
     rp.PopRaw(mac_address);
-    LOG_WARNING(Service_NWM, "MAC: {}", std::string str(std::begin(mac_address), std::end(mac_address)));
+    LOG_WARNING(Service_NWM, "MAC: {}", mac_address);
 
     rp.Skip(9, false);
 

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -629,9 +629,11 @@ void NWM_UDS::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
 
         ASSERT(cur_buffer_size < out_buffer_size);
 
+        LOG_WARNING(Service_NWM, "Writing entry header to buffer");
         out_buffer.Write(&entry, cur_buffer_size, sizeof(BeaconEntryHeader));
         cur_buffer_size += sizeof(BeaconEntryHeader);
         const unsigned char* beacon_data = beacon.data.data();
+        LOG_WARNING(Service_NWM, "Writing entry data to buffer");
         out_buffer.Write(beacon_data, cur_buffer_size, beacon.data.size());
         cur_buffer_size += beacon.data.size();
     }

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -594,6 +594,7 @@ void NWM_UDS::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
 
     MacAddress mac_address;
     rp.PopRaw(mac_address);
+    LOG_WARNING(Service_NWM, "MAC: {}", std::string str(std::begin(mac_address), std::end(mac_address)));
 
     rp.Skip(9, false);
 

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -625,6 +625,7 @@ void NWM_UDS::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
         entry.total_size = static_cast<u32>(sizeof(BeaconEntryHeader) + beacon.data.size());
         entry.wifi_channel = beacon.channel;
         entry.header_size = sizeof(BeaconEntryHeader);
+        ASSERT(entry.header_size == 0x1C);  // Sanity check
         entry.mac_address = beacon.transmitter_address;
 
         ASSERT(cur_buffer_size < out_buffer_size);

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -14,7 +14,6 @@
 #include "core/core_timing.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/event.h"
-#include "core/hle/kernel/handle_table.h"
 #include "core/hle/kernel/shared_memory.h"
 #include "core/hle/kernel/shared_page.h"
 #include "core/hle/result.h"

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -594,7 +594,7 @@ void NWM_UDS::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
 
     MacAddress mac_address;
     rp.PopRaw(mac_address);
-    LOG_WARNING(Service_NWM, "MAC: {02X}.{02X}.{02X}.{02X}.{02X}.{02X}", 
+    LOG_WARNING(Service_NWM, "MAC: {:02X}.{:02X}.{:02X}.{:02X}.{:02X}.{:02X}", 
             mac_address[0], mac_address[1], mac_address[2], 
             mac_address[3], mac_address[4], mac_address[5]);
 

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -641,6 +641,7 @@ void NWM_UDS::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
 
     // Update the total size in the structure and write it to the buffer again.
     data_reply_header.total_size = static_cast<u32>(cur_buffer_size);
+    LOG_WARNING(Service_NWM, "Writing beacon reply header to buffer");
     out_buffer.Write(&data_reply_header, 0, sizeof(BeaconDataReplyHeader));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -628,7 +628,6 @@ void NWM_UDS::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
         entry.total_size = static_cast<u32>(sizeof(BeaconEntryHeader) + beacon.data.size());
         entry.wifi_channel = beacon.channel;
         entry.header_size = sizeof(BeaconEntryHeader);
-        ASSERT(entry.header_size == 0x1C);  // Sanity check
         entry.mac_address = beacon.transmitter_address;
 
         ASSERT(cur_buffer_size < out_buffer_size);

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -14,6 +14,7 @@
 #include "core/core_timing.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/event.h"
+#include "core/hle/kernel/handle_table.h"
 #include "core/hle/kernel/shared_memory.h"
 #include "core/hle/kernel/shared_page.h"
 #include "core/hle/result.h"


### PR DESCRIPTION
**What:** This is a basic implementation of the unimplemented methods `ScanAPs` and `RecvBeaconBroadcastData` from `Service::AC::Module::Interface` and `Service::NWM::NWM_INF` respectively. It is as of yet not fully finished, but I hope it will serve as a foundation for later modifications. The purpose of `ScanAPs` is to give a list of data on nearby networks to the game.

**Why:** The reason I tried implementing `ScanAPs` was because it is a feature a few games rely on to function properly. Most notably, the Denpa Men games rely on this to discover nearby networks. Without this method, you would need a save file editor or a pre-existing save file to even play the game, which takes most of the fun away from it.

**How:** I mostly went on what little information is available on this method on [3dbrew.org](3dbrew.org). Based on that, I tried to construct `ScanAPs` so that it would first call `NWM_INF::RecvBeaconBroadcastData` and pass on the raw beacon data to its own caller, as the parsing method is yet unknown. Since `NWM_INF::RecvBeaconBroadcastData` was also unimplemented and had a nearly identical use as `NWM_UDS::RecvBeaconBroadcastData`, I had it delegate the task to `NWM_UDS::RecvBeaconBroadcastData` by reconstructing the command buffer again. I did attempt to do an independent implementation, but it required adding an additional private method to `NWM_INF`` that was not mentioned in the header file or anywhere else, so I decided to discard the idea for now.

**Result:** In the release version, entering the Denpa tower would result in the main Denpa telling you no radio waves could be found. After this change, this does not differ. However, the log now indicates that it might be an issue with writing to the MappedBuffer instance during the `NWM_UDS::RecvBeaconBroadcastData`, instead of telling you that the method is unimplemented. This could imply that in the way I called the other services, something goes wrong with the mapped buffer or the mapped buffer is not properly retrieved during `ScanAPs`.

**Efficiency:** Since this is all in a `Service` method that is usually not called, normal gameplay should not suffer any slowdowns from it. When I ran this build on my PC (which by all standards is not great but still good enough for 100% speed on most games I have played) and opened The Denpa Men and entered the tower, no noticeable slowdown was present during the scan compared to the release build. This might of course differ once the writing to the MappedBuffer works correctly, but for now no lag should be caused by it.

The code I used for calling the services is based on various snippets found in other files. I do not know if this is the proper approach as it is a lot of files to spit through and I am still largely unfamiliar with C++ syntax. If there is an easier way to do all of this, please tell me.

My pc is also not good enough to build any sizeable C++ project in reasonable time, hence why I relied on the Github Actions and also why so many commits have been made. This made checking for compilation errors more difficult as well, which only served to further increase the amount of unbuildable commits. 

This is the first time I created a pull request for a public open source repository, so please explain if I should have done something another way.

**TODO:**
- [ ] Implement `NWM_INF::RecvBeaconBroadcastData` independently of `NWM_UDS::RecvBeaconBroadcastData`
- [ ] Fix `unmapped WriteBlock` error when `ScanAPs` is called by a game
- [ ] Change approach of calling `NWM_INF::RecvBeaconBroadcastData` in `ScanAPs`