### PR TITLE
Fix `hotkey_groups` shortcuts not being assigned correctly

### DIFF
--- a/src/lime_qt/hotkeys.cpp
+++ b/src/lime_qt/hotkeys.cpp
@@ -44,13 +44,13 @@ void HotkeyRegistry::LoadHotkeys() {
 
 QShortcut* HotkeyRegistry::GetHotkey(const QString& group, const QString& action, QObject* widget) {
     Hotkey& hk = hotkey_groups[group][action];
-    QShortcut* shortcut = hk.shortcuts[widget->objectName()];
+    const auto widget_name = widget->objectName();
 
-    if (!shortcut) {
-        shortcut = new QShortcut(hk.keyseq, widget, nullptr, nullptr, hk.context);
+    if (!hk.shortcuts[widget_name]) {
+        hk.shortcuts[widget_name] = new QShortcut(hk.keyseq, widget, nullptr, nullptr, hk.context);
     }
 
-    return shortcut;
+    return hk.shortcuts[widget_name];
 }
 
 QKeySequence HotkeyRegistry::GetKeySequence(const QString& group, const QString& action) {


### PR DESCRIPTION
Closes #364

Due to a mistake in some previously committed code, the shortcuts in the `hotkey_groups` map were not being assigned after new shortcuts were created. This was due to the code in question being written with the assumption that `shortcut` was a `QShortcut&`, when it was in fact a `QShortcut*`.