### PR TITLE
Distribute MacOS build as a zip archive

### DIFF
--- a/.ci/pack.sh
+++ b/.ci/pack.sh
@@ -38,7 +38,7 @@ function pack_artifacts() {
     if [ "$OS" = "windows" ]; then
         ARCHIVE_FULL_NAME="$ARCHIVE_NAME.zip"
         powershell Compress-Archive "$REV_NAME" "$ARCHIVE_FULL_NAME"
-    elif [ "$OS" = "android" ]; then
+    elif [ "$OS" = "android" ] || [ "$OS" = "macos" ]; then
         ARCHIVE_FULL_NAME="$ARCHIVE_NAME.zip"
         zip -r "$ARCHIVE_FULL_NAME" "$REV_NAME"
     else


### PR DESCRIPTION
`tar.gz` files are not common for distributing programs in the MacOS space, so this simple change in archive format will hopefully make the installation experience slightly more familiar.