### PR TITLE
lime_qt: Build fixes for QT 6.8

### DIFF
--- a/src/lime_qt/configuration/configure_camera.cpp
+++ b/src/lime_qt/configuration/configure_camera.cpp
@@ -9,6 +9,7 @@
 #include <QMediaDevices>
 #include <QMessageBox>
 #include <QWidget>
+#include <QtGlobal>
 #include "common/settings.h"
 #include "core/frontend/camera/factory.h"
 #include "core/hle/service/cam/cam.h"
@@ -86,7 +87,11 @@ void ConfigureCamera::ConnectEvents() {
     });
     connect(ui->toolButton, &QToolButton::clicked, this, &ConfigureCamera::OnToolButtonClicked);
     connect(ui->preview_button, &QPushButton::clicked, this, [this] { StartPreviewing(); });
+#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
+    connect(ui->prompt_before_load, &QCheckBox::stateChanged, this, [this](int state) {
+#else
     connect(ui->prompt_before_load, &QCheckBox::checkStateChanged, this, [this](int state) {
+#endif
         ui->camera_file->setDisabled(state == Qt::Checked);
         ui->toolButton->setDisabled(state == Qt::Checked);
         if (state == Qt::Checked) {

--- a/src/lime_qt/configuration/configure_camera.cpp
+++ b/src/lime_qt/configuration/configure_camera.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Citra Emulator Project
+// Copyright Citra Emulator Project / Lime3DS Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -86,7 +86,7 @@ void ConfigureCamera::ConnectEvents() {
     });
     connect(ui->toolButton, &QToolButton::clicked, this, &ConfigureCamera::OnToolButtonClicked);
     connect(ui->preview_button, &QPushButton::clicked, this, [this] { StartPreviewing(); });
-    connect(ui->prompt_before_load, &QCheckBox::stateChanged, this, [this](int state) {
+    connect(ui->prompt_before_load, &QCheckBox::checkStateChanged, this, [this](int state) {
         ui->camera_file->setDisabled(state == Qt::Checked);
         ui->toolButton->setDisabled(state == Qt::Checked);
         if (state == Qt::Checked) {

--- a/src/lime_qt/configuration/configure_cheats.cpp
+++ b/src/lime_qt/configuration/configure_cheats.cpp
@@ -5,6 +5,7 @@
 #include <QCheckBox>
 #include <QMessageBox>
 #include <QTableWidgetItem>
+#include <QtGlobal>
 #include "configure_cheats.h"
 #include "core/cheats/cheat_base.h"
 #include "core/cheats/cheats.h"
@@ -59,7 +60,11 @@ void ConfigureCheats::LoadCheats() {
             i, 2, new QTableWidgetItem(QString::fromStdString(cheats[i]->GetType())));
         enabled->setProperty("row", static_cast<int>(i));
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
+        connect(enabled, &QCheckBox::stateChanged, this, &ConfigureCheats::OnCheckChanged);
+#else
         connect(enabled, &QCheckBox::checkStateChanged, this, &ConfigureCheats::OnCheckChanged);
+#endif
     }
 }
 

--- a/src/lime_qt/configuration/configure_cheats.cpp
+++ b/src/lime_qt/configuration/configure_cheats.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Citra Emulator Project
+// Copyright Citra Emulator Project / Lime3DS Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -59,7 +59,7 @@ void ConfigureCheats::LoadCheats() {
             i, 2, new QTableWidgetItem(QString::fromStdString(cheats[i]->GetType())));
         enabled->setProperty("row", static_cast<int>(i));
 
-        connect(enabled, &QCheckBox::stateChanged, this, &ConfigureCheats::OnCheckChanged);
+        connect(enabled, &QCheckBox::checkStateChanged, this, &ConfigureCheats::OnCheckChanged);
     }
 }
 

--- a/src/lime_qt/configuration/configure_layout.cpp
+++ b/src/lime_qt/configuration/configure_layout.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Citra Emulator Project
+// Copyright Citra Emulator Project / Lime3DS Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -48,24 +48,20 @@ ConfigureLayout::ConfigureLayout(QWidget* parent)
             });
 
     ui->screen_top_leftright_padding->setEnabled(Settings::values.screen_top_stretch.GetValue());
-    connect(ui->screen_top_stretch, static_cast<void (QCheckBox::*)(int)>(&QCheckBox::stateChanged),
-            this,
+    connect(ui->screen_top_stretch, &QCheckBox::checkStateChanged, this,
             [this](bool checkState) { ui->screen_top_leftright_padding->setEnabled(checkState); });
     ui->screen_top_topbottom_padding->setEnabled(Settings::values.screen_top_stretch.GetValue());
-    connect(ui->screen_top_stretch, static_cast<void (QCheckBox::*)(int)>(&QCheckBox::stateChanged),
-            this,
+    connect(ui->screen_top_stretch, &QCheckBox::checkStateChanged, this,
             [this](bool checkState) { ui->screen_top_topbottom_padding->setEnabled(checkState); });
     ui->screen_bottom_leftright_padding->setEnabled(
         Settings::values.screen_bottom_topbottom_padding.GetValue());
     connect(
-        ui->screen_bottom_stretch, static_cast<void (QCheckBox::*)(int)>(&QCheckBox::stateChanged),
-        this,
+        ui->screen_bottom_stretch, &QCheckBox::checkStateChanged, this,
         [this](bool checkState) { ui->screen_bottom_leftright_padding->setEnabled(checkState); });
     ui->screen_bottom_topbottom_padding->setEnabled(
         Settings::values.screen_bottom_topbottom_padding.GetValue());
     connect(
-        ui->screen_bottom_stretch, static_cast<void (QCheckBox::*)(int)>(&QCheckBox::stateChanged),
-        this,
+        ui->screen_bottom_stretch, &QCheckBox::checkStateChanged, this,
         [this](bool checkState) { ui->screen_bottom_topbottom_padding->setEnabled(checkState); });
 
     connect(ui->bg_button, &QPushButton::clicked, this, [this] {

--- a/src/lime_qt/configuration/configure_layout.cpp
+++ b/src/lime_qt/configuration/configure_layout.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <QColorDialog>
+#include <QtGlobal>
 #include "common/settings.h"
 #include "lime_qt/configuration/configuration_shared.h"
 #include "lime_qt/configuration/configure_layout.h"
@@ -48,22 +49,47 @@ ConfigureLayout::ConfigureLayout(QWidget* parent)
             });
 
     ui->screen_top_leftright_padding->setEnabled(Settings::values.screen_top_stretch.GetValue());
+#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
+    connect(ui->screen_top_stretch, static_cast<void (QCheckBox::*)(int)>(&QCheckBox::stateChanged),
+            this,
+            [this](bool checkState) { ui->screen_top_leftright_padding->setEnabled(checkState); });
+#else
     connect(ui->screen_top_stretch, &QCheckBox::checkStateChanged, this,
             [this](bool checkState) { ui->screen_top_leftright_padding->setEnabled(checkState); });
+#endif
     ui->screen_top_topbottom_padding->setEnabled(Settings::values.screen_top_stretch.GetValue());
+#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
+    connect(ui->screen_top_stretch, static_cast<void (QCheckBox::*)(int)>(&QCheckBox::stateChanged),
+            this,
+            [this](bool checkState) { ui->screen_top_topbottom_padding->setEnabled(checkState); });
+#else
     connect(ui->screen_top_stretch, &QCheckBox::checkStateChanged, this,
             [this](bool checkState) { ui->screen_top_topbottom_padding->setEnabled(checkState); });
+#endif
     ui->screen_bottom_leftright_padding->setEnabled(
         Settings::values.screen_bottom_topbottom_padding.GetValue());
+#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
+    connect(
+        ui->screen_bottom_stretch, static_cast<void (QCheckBox::*)(int)>(&QCheckBox::stateChanged),
+        this,
+        [this](bool checkState) { ui->screen_bottom_leftright_padding->setEnabled(checkState); });
+#else
     connect(
         ui->screen_bottom_stretch, &QCheckBox::checkStateChanged, this,
         [this](bool checkState) { ui->screen_bottom_leftright_padding->setEnabled(checkState); });
+#endif
     ui->screen_bottom_topbottom_padding->setEnabled(
         Settings::values.screen_bottom_topbottom_padding.GetValue());
+#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
+    connect(
+        ui->screen_bottom_stretch, static_cast<void (QCheckBox::*)(int)>(&QCheckBox::stateChanged),
+        this,
+        [this](bool checkState) { ui->screen_bottom_topbottom_padding->setEnabled(checkState); });
+#else
     connect(
         ui->screen_bottom_stretch, &QCheckBox::checkStateChanged, this,
         [this](bool checkState) { ui->screen_bottom_topbottom_padding->setEnabled(checkState); });
-
+#endif
     connect(ui->bg_button, &QPushButton::clicked, this, [this] {
         const QColor new_bg_color = QColorDialog::getColor(bg_color);
         if (!new_bg_color.isValid()) {

--- a/src/lime_qt/configuration/configure_layout.cpp
+++ b/src/lime_qt/configuration/configure_layout.cpp
@@ -49,47 +49,45 @@ ConfigureLayout::ConfigureLayout(QWidget* parent)
             });
 
     ui->screen_top_leftright_padding->setEnabled(Settings::values.screen_top_stretch.GetValue());
+
 #if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
     connect(ui->screen_top_stretch, static_cast<void (QCheckBox::*)(int)>(&QCheckBox::stateChanged),
             this,
             [this](bool checkState) { ui->screen_top_leftright_padding->setEnabled(checkState); });
-#else
-    connect(ui->screen_top_stretch, &QCheckBox::checkStateChanged, this,
-            [this](bool checkState) { ui->screen_top_leftright_padding->setEnabled(checkState); });
-#endif
     ui->screen_top_topbottom_padding->setEnabled(Settings::values.screen_top_stretch.GetValue());
-#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
     connect(ui->screen_top_stretch, static_cast<void (QCheckBox::*)(int)>(&QCheckBox::stateChanged),
             this,
             [this](bool checkState) { ui->screen_top_topbottom_padding->setEnabled(checkState); });
-#else
-    connect(ui->screen_top_stretch, &QCheckBox::checkStateChanged, this,
-            [this](bool checkState) { ui->screen_top_topbottom_padding->setEnabled(checkState); });
-#endif
     ui->screen_bottom_leftright_padding->setEnabled(
         Settings::values.screen_bottom_topbottom_padding.GetValue());
-#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
     connect(
         ui->screen_bottom_stretch, static_cast<void (QCheckBox::*)(int)>(&QCheckBox::stateChanged),
         this,
         [this](bool checkState) { ui->screen_bottom_leftright_padding->setEnabled(checkState); });
-#else
-    connect(
-        ui->screen_bottom_stretch, &QCheckBox::checkStateChanged, this,
-        [this](bool checkState) { ui->screen_bottom_leftright_padding->setEnabled(checkState); });
-#endif
     ui->screen_bottom_topbottom_padding->setEnabled(
         Settings::values.screen_bottom_topbottom_padding.GetValue());
-#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
     connect(
         ui->screen_bottom_stretch, static_cast<void (QCheckBox::*)(int)>(&QCheckBox::stateChanged),
         this,
         [this](bool checkState) { ui->screen_bottom_topbottom_padding->setEnabled(checkState); });
 #else
+    connect(ui->screen_top_stretch, &QCheckBox::checkStateChanged, this,
+            [this](bool checkState) { ui->screen_top_leftright_padding->setEnabled(checkState); });
+    ui->screen_top_topbottom_padding->setEnabled(Settings::values.screen_top_stretch.GetValue());
+    connect(ui->screen_top_stretch, &QCheckBox::checkStateChanged, this,
+            [this](bool checkState) { ui->screen_top_topbottom_padding->setEnabled(checkState); });
+    ui->screen_bottom_leftright_padding->setEnabled(
+        Settings::values.screen_bottom_topbottom_padding.GetValue());
+    connect(
+        ui->screen_bottom_stretch, &QCheckBox::checkStateChanged, this,
+        [this](bool checkState) { ui->screen_bottom_leftright_padding->setEnabled(checkState); });
+    ui->screen_bottom_topbottom_padding->setEnabled(
+        Settings::values.screen_bottom_topbottom_padding.GetValue());
     connect(
         ui->screen_bottom_stretch, &QCheckBox::checkStateChanged, this,
         [this](bool checkState) { ui->screen_bottom_topbottom_padding->setEnabled(checkState); });
 #endif
+
     connect(ui->bg_button, &QPushButton::clicked, this, [this] {
         const QColor new_bg_color = QColorDialog::getColor(bg_color);
         if (!new_bg_color.isValid()) {

--- a/src/lime_qt/debugger/ipc/recorder.cpp
+++ b/src/lime_qt/debugger/ipc/recorder.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Citra Emulator Project
+// Copyright Citra Emulator Project / Lime3DS Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -22,7 +22,7 @@ IPCRecorderWidget::IPCRecorderWidget(Core::System& system_, QWidget* parent)
     ui->setupUi(this);
     qRegisterMetaType<IPCDebugger::RequestRecord>();
 
-    connect(ui->enabled, &QCheckBox::stateChanged, this,
+    connect(ui->enabled, &QCheckBox::checkStateChanged, this,
             [this](int new_state) { SetEnabled(new_state == Qt::Checked); });
     connect(ui->clearButton, &QPushButton::clicked, this, &IPCRecorderWidget::Clear);
     connect(ui->filter, &QLineEdit::textChanged, this, &IPCRecorderWidget::ApplyFilterToAll);

--- a/src/lime_qt/debugger/ipc/recorder.cpp
+++ b/src/lime_qt/debugger/ipc/recorder.cpp
@@ -5,6 +5,7 @@
 #include <QBrush>
 #include <QString>
 #include <QTreeWidgetItem>
+#include <QtGlobal>
 #include <fmt/format.h>
 #include "common/assert.h"
 #include "common/string_util.h"
@@ -22,8 +23,13 @@ IPCRecorderWidget::IPCRecorderWidget(Core::System& system_, QWidget* parent)
     ui->setupUi(this);
     qRegisterMetaType<IPCDebugger::RequestRecord>();
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
+    connect(ui->enabled, &QCheckBox::stateChanged, this,
+            [this](int new_state) { SetEnabled(new_state == Qt::Checked); });
+#else
     connect(ui->enabled, &QCheckBox::checkStateChanged, this,
             [this](int new_state) { SetEnabled(new_state == Qt::Checked); });
+#endif
     connect(ui->clearButton, &QPushButton::clicked, this, &IPCRecorderWidget::Clear);
     connect(ui->filter, &QLineEdit::textChanged, this, &IPCRecorderWidget::ApplyFilterToAll);
     connect(ui->main, &QTreeWidget::itemDoubleClicked, this, &IPCRecorderWidget::OpenRecordDialog);


### PR DESCRIPTION
With QT 6.8 scheduled for the end of the month/beginning of next, this set of changes should make Lime3DS compatible with it. It replaces the deprecated `stateChanged` function with `checkStateChanged` that was first introduced in QT 6.7.

The thing is, while this change is backwards compatible with QT 6.7, it won't work with older versions (ex. like the Linux build runner which I think runs QT 6.4).

So either:
* The Lime3DS Linux docker image needs to get updated with QT 6.7 first (aqtinstall will do it; I've been using it on my personal fork with Ubuntu 22.04 and it's been working fine in X11 and Wayland according to some people) and the minimum requirement for Lime3DS becomes QT 6.7 going forward.
* Don't merge this in and freeze Lime3DS's max compatibility at 6.7.3.
* Add in a conditional check at each change that looks at QT version (kind of like a #ifdef check, if such a thing for QT is even possible? Haven't looked into it...).

The problem I see is that eventually Windows msys2 will start building with QT 6.8 and not give the option for an older version so a decision going forward will eventually have to be made in a few months when that happens.