### PR TITLE
lime_qt: Fix order of Texture Filter drop-down menu

### DIFF
--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -227,7 +227,7 @@
     <string name="linear_filtering">Linear Filtering</string>
     <string name="linear_filtering_description">Enables linear filtering, which causes game visuals to appear smoother.</string>
     <string name="texture_filter_name">Texture Filter</string>
-    <string name="texture_filter_description">Enhances the visuals of games by applying a filter to textures. The supported filters are Anime4K Ultrafast, Bicubic, ScaleForce, and xBRZ freescale.</string>
+    <string name="texture_filter_description">Enhances the visuals of games by applying a filter to textures. The supported filters are Anime4K Ultrafast, Bicubic, ScaleForce, xBRZ freescale, and MMPX.</string>
     <string name="hw_shaders">Enable Hardware Shader</string>
     <string name="hw_shaders_description">Uses hardware to emulate 3DS shaders. When enabled, game performance will be significantly improved.</string>
     <string name="shaders_accurate_mul">Accurate Multiplication</string>

--- a/src/lime_qt/configuration/configure_enhancements.ui
+++ b/src/lime_qt/configuration/configure_enhancements.ui
@@ -176,7 +176,7 @@
            </item>
            <item>
             <property name="text">
-             <string>Anime4K</string>
+             <string>Anime4K Ultrafast</string>
             </property>
            </item>
            <item>
@@ -186,17 +186,17 @@
            </item>
            <item>
             <property name="text">
-             <string>Nearest Neighbor</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
              <string>ScaleForce</string>
             </property>
            </item>
            <item>
             <property name="text">
-             <string>xBRZ</string>
+             <string>xBRZ Freescale</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>MMPX</string>
             </property>
            </item>
           </widget>

--- a/src/lime_qt/configuration/configure_enhancements.ui
+++ b/src/lime_qt/configuration/configure_enhancements.ui
@@ -176,7 +176,7 @@
            </item>
            <item>
             <property name="text">
-             <string>Anime4K Ultrafast</string>
+             <string>Anime4K</string>
             </property>
            </item>
            <item>
@@ -191,7 +191,7 @@
            </item>
            <item>
             <property name="text">
-             <string>xBRZ Freescale</string>
+             <string>xBRZ</string>
             </property>
            </item>
            <item>


### PR DESCRIPTION
Make the front end match the order of the back end. Fixes #450 

New screenshot:
![texturefilter](https://github.com/user-attachments/assets/f8fa96d5-8976-42c7-a96b-697e90b60b2e)
