### PR TITLE
D-pad descriptions

### DIFF
--- a/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/model/view/HeaderSetting.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/model/view/HeaderSetting.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Lime3DS Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/model/view/HeaderSetting.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/model/view/HeaderSetting.kt
@@ -4,6 +4,6 @@
 
 package io.github.lime3ds.android.features.settings.model.view
 
-class HeaderSetting(titleId: Int,descId: Int = 0) : SettingsItem(null, titleId, descId) {
+class HeaderSetting(titleId: Int, descId: Int = 0) : SettingsItem(null, titleId, descId) {
     override val type = TYPE_HEADER
 }

--- a/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/model/view/HeaderSetting.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/model/view/HeaderSetting.kt
@@ -4,6 +4,6 @@
 
 package io.github.lime3ds.android.features.settings.model.view
 
-class HeaderSetting(titleId: Int) : SettingsItem(null, titleId, 0) {
+class HeaderSetting(titleId: Int,descId: Int = 0) : SettingsItem(null, titleId, descId) {
     override val type = TYPE_HEADER
 }

--- a/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/ui/SettingsFragmentPresenter.kt
@@ -650,14 +650,12 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                 add(InputBindingSetting(button, Settings.axisTitles[i]))
             }
 
-            // TODO: Improve the integration of the two dpad types to be
-            //       less user-facingly hacky
-            add(HeaderSetting(R.string.controller_dpad_axis))
+            add(HeaderSetting(R.string.controller_dpad_axis,R.string.controller_dpad_axis_description))
             Settings.dPadAxisKeys.forEachIndexed { i: Int, key: String ->
                 val button = getInputObject(key)
                 add(InputBindingSetting(button, Settings.axisTitles[i]))
             }
-            add(HeaderSetting(R.string.controller_dpad_button))
+            add(HeaderSetting(R.string.controller_dpad_button,R.string.controller_dpad_button_description))
             Settings.dPadButtonKeys.forEachIndexed { i: Int, key: String ->
                 val button = getInputObject(key)
                 add(InputBindingSetting(button, Settings.dpadTitles[i]))

--- a/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/ui/viewholder/HeaderViewHolder.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/ui/viewholder/HeaderViewHolder.kt
@@ -18,6 +18,12 @@ class HeaderViewHolder(val binding: ListItemSettingsHeaderBinding, adapter: Sett
 
     override fun bind(item: SettingsItem) {
         binding.textHeaderName.setText(item.nameId)
+        if (item.descriptionId != 0) {
+            binding.textHeaderDescription.visibility = View.VISIBLE
+            binding.textHeaderDescription.setText(item.descriptionId)
+        }else {
+            binding.textHeaderDescription.visibility = View.GONE
+        }
     }
 
     override fun onClick(clicked: View) {

--- a/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/ui/viewholder/HeaderViewHolder.kt
+++ b/src/android/app/src/main/java/io/github/lime3ds/android/features/settings/ui/viewholder/HeaderViewHolder.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Lime3DS Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/android/app/src/main/res/layout/list_item_settings_header.xml
+++ b/src/android/app/src/main/res/layout/list_item_settings_header.xml
@@ -1,16 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.material.textview.MaterialTextView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:focusable="false"
+    android:clickable="false"
+    android:paddingVertical="16dp"
+        >
+
+<com.google.android.material.textview.MaterialTextView
+
     android:id="@+id/text_header_name"
     style="@style/TextAppearance.Material3.TitleSmall"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_gravity="start|center_vertical"
-    android:paddingHorizontal="@dimen/spacing_large"
-    android:paddingVertical="16dp"
-    android:focusable="false"
-    android:clickable="false"
     android:textAlignment="viewStart"
     android:textColor="?attr/colorPrimary"
     android:textStyle="bold"
     tools:text="CPU Settings" />
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/text_header_description"
+        style="@style/TextAppearance.Material3.BodySmall"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_small"
+        android:textAlignment="viewStart"
+        tools:text="@string/app_disclaimer" />
+</LinearLayout>

--- a/src/android/app/src/main/res/layout/list_item_settings_header.xml
+++ b/src/android/app/src/main/res/layout/list_item_settings_header.xml
@@ -8,7 +8,7 @@
     android:orientation="vertical"
     android:focusable="false"
     android:clickable="false"
-    android:paddingVertical="16dp"
+    android:padding="16dp"
         >
 
 <com.google.android.material.textview.MaterialTextView

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -112,9 +112,9 @@
     <string name="controller_trigger">Trigger</string>
     <string name="controller_dpad">D-Pad</string>
     <string name="controller_dpad_axis">D-Pad (Axis)</string>
-    <string name="controller_dpad_axis_description">Some controllers may not be able to map their D-pad as an axis. If that's the case, use the D-Pad (buttons) section.</string>
+    <string name="controller_dpad_axis_description">Some controllers may not be able to map their D-pad as an axis. If that\'s the case, use the D-Pad (buttons) section.</string>
     <string name="controller_dpad_button">D-Pad (Button)</string>
-    <string name="controller_dpad_button_description">Only map the D-pad to these if you're facing issues with the D-Pad (Axis) button mappings.</string>
+    <string name="controller_dpad_button_description">Only map the D-pad to these if you\'re facing issues with the D-Pad (Axis) button mappings.</string>
     <string name="controller_axis_vertical">Up/Down Axis</string>
     <string name="controller_axis_horizontal">Left/Right Axis</string>
     <string name="direction_up">Up</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -114,7 +114,7 @@
     <string name="controller_dpad_axis">D-Pad (Axis)</string>
     <string name="controller_dpad_axis_description">Some controllers may not be able to map their D-pad as an axis. If that's the case, use the D-Pad (buttons) section.</string>
     <string name="controller_dpad_button">D-Pad (Button)</string>
-    <string name="controller_dpad_button_description">Only map these buttons as the D-pad if you're facing issues with the  D-Pad (Axis) button mappings.</string>
+    <string name="controller_dpad_button_description">Only map the D-pad to these if you're facing issues with the D-Pad (Axis) button mappings.</string>
     <string name="controller_axis_vertical">Up/Down Axis</string>
     <string name="controller_axis_horizontal">Left/Right Axis</string>
     <string name="direction_up">Up</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -114,7 +114,7 @@
     <string name="controller_dpad_axis">D-Pad (Axis)</string>
     <string name="controller_dpad_axis_description">Some controllers may not be able to map their D-pad as an axis. If that's the case, use the D-Pad (buttons) section.</string>
     <string name="controller_dpad_button">D-Pad (Button)</string>
-    <string name="controller_dpad_button_description">Only map these buttons if the D-Pad (Axis) settings above do not work with your controller.</string>
+    <string name="controller_dpad_button_description">Only map these buttons as the D-pad if you're facing issues with the  D-Pad (Axis) button mappings.</string>
     <string name="controller_axis_vertical">Up/Down Axis</string>
     <string name="controller_axis_horizontal">Left/Right Axis</string>
     <string name="direction_up">Up</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -112,7 +112,9 @@
     <string name="controller_trigger">Trigger</string>
     <string name="controller_dpad">D-Pad</string>
     <string name="controller_dpad_axis">D-Pad (Axis)</string>
+    <string name="controller_dpad_axis_description">Some controllers will not be able to map their dpad as an axis. In that case, use the D-Pad (buttons) section below instead.</string>
     <string name="controller_dpad_button">D-Pad (Button)</string>
+    <string name="controller_dpad_button_description">Only map these buttons if the D-Pad (Axis) settings above do not work with your controller.</string>
     <string name="controller_axis_vertical">Up/Down Axis</string>
     <string name="controller_axis_horizontal">Left/Right Axis</string>
     <string name="direction_up">Up</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -112,7 +112,7 @@
     <string name="controller_trigger">Trigger</string>
     <string name="controller_dpad">D-Pad</string>
     <string name="controller_dpad_axis">D-Pad (Axis)</string>
-    <string name="controller_dpad_axis_description">Some controllers will not be able to map their dpad as an axis. In that case, use the D-Pad (buttons) section below instead.</string>
+    <string name="controller_dpad_axis_description">Some controllers may not be able to map their D-pad as an axis. If that's the case, use the D-Pad (buttons) section.</string>
     <string name="controller_dpad_button">D-Pad (Button)</string>
     <string name="controller_dpad_button_description">Only map these buttons if the D-Pad (Axis) settings above do not work with your controller.</string>
     <string name="controller_axis_vertical">Up/Down Axis</string>


### PR DESCRIPTION
Add descriptions for the two D-pad options to make it clear only one should be used by most users. 

Re-write header settings in android to support optional descriptions. This should make it quite easy to add other similar notes if it is decided they are needed.