### PR TITLE
gl_driver.cpp: Minimum OpenGLES version is actually 3.2

### DIFF
--- a/src/video_core/renderer_opengl/gl_driver.cpp
+++ b/src/video_core/renderer_opengl/gl_driver.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Citra Emulator Project
+// Copyright Citra Emulator Project / Lime3DS Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -177,7 +177,7 @@ void Driver::CheckExtensionSupport() {
     nv_fragment_shader_interlock = GLAD_GL_NV_fragment_shader_interlock;
     intel_fragment_shader_ordering = GLAD_GL_INTEL_fragment_shader_ordering;
     blend_minmax_factor = GLAD_GL_AMD_blend_minmax_factor || GLAD_GL_NV_blend_minmax_factor;
-    is_suitable = GLAD_GL_VERSION_4_3 || GLAD_GL_ES_VERSION_3_1;
+    is_suitable = GLAD_GL_VERSION_4_3 || GLAD_GL_ES_VERSION_3_2;
 }
 
 void Driver::FindBugs() {


### PR DESCRIPTION
Was playing around with the video stuff and found this little nitpick.

Functionally, I don't think changing it does much, but technically, the emulator's current minimum requirements according to the project's [`glad`](https://github.com/Lime3DS/Lime3DS/blob/master/externals/glad/Readme.md) and [`bootmanager.cpp`](https://github.com/Lime3DS/Lime3DS/blob/master/src/lime_qt/bootmanager.cpp) is OpenGL 4.3 and OpenGLES 3.2, not OpenGLES 3.1.