### PR TITLE
Port command line options from SDL executable [SDL PR 1/2]

### DIFF
--- a/src/lime_qt/CMakeLists.txt
+++ b/src/lime_qt/CMakeLists.txt
@@ -294,6 +294,9 @@ create_target_directory_groups(lime-qt)
 
 target_link_libraries(lime-qt PRIVATE audio_core lime_common lime_core input_common network video_core)
 target_link_libraries(lime-qt PRIVATE Boost::boost nihstro-headers Qt6::Widgets Qt6::Multimedia Qt6::Concurrent)
+if (MSVC)
+    target_link_libraries(lime-qt PRIVATE getopt)
+endif()
 target_link_libraries(lime-qt PRIVATE ${PLATFORM_LIBRARIES} Threads::Threads)
 
 if (ENABLE_OPENGL)

--- a/src/lime_qt/CMakeLists.txt
+++ b/src/lime_qt/CMakeLists.txt
@@ -285,6 +285,11 @@ elseif(WIN32)
     endif()
 endif()
 
+if(ENABLE_SDL2)
+    target_link_libraries(lime-qt PRIVATE SDL2::SDL2)
+    target_compile_definitions(lime-qt PRIVATE HAVE_SDL2)
+endif()
+
 create_target_directory_groups(lime-qt)
 
 target_link_libraries(lime-qt PRIVATE audio_core lime_common lime_core input_common network video_core)

--- a/src/lime_qt/CMakeLists.txt
+++ b/src/lime_qt/CMakeLists.txt
@@ -294,9 +294,6 @@ create_target_directory_groups(lime-qt)
 
 target_link_libraries(lime-qt PRIVATE audio_core lime_common lime_core input_common network video_core)
 target_link_libraries(lime-qt PRIVATE Boost::boost nihstro-headers Qt6::Widgets Qt6::Multimedia Qt6::Concurrent)
-if (MSVC)
-    target_link_libraries(lime-qt PRIVATE getopt)
-endif()
 target_link_libraries(lime-qt PRIVATE ${PLATFORM_LIBRARIES} Threads::Threads)
 
 if (ENABLE_OPENGL)

--- a/src/lime_qt/main.cpp
+++ b/src/lime_qt/main.cpp
@@ -17,6 +17,8 @@
 #include <QtWidgets>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#undef _UNICODE
+#include <getopt.h>
 #ifdef __APPLE__
 #include <unistd.h> // for chdir
 #endif

--- a/src/lime_qt/main.cpp
+++ b/src/lime_qt/main.cpp
@@ -317,6 +317,16 @@ GMainWindow::GMainWindow(Core::System& system_)
             continue;
         }
 
+        // Enable GDB stub
+        if (args[i] == QStringLiteral("-g")) {
+            if (i >= args.size() - 1 || args[i + 1].startsWith(QChar::fromLatin1('-'))) {
+                continue;
+            }
+            Settings::values.use_gdbstub = true;
+            Settings::values.gdbstub_port = strtoul(args[++i].toLatin1(), NULL, 0);
+            continue;
+        }
+
         if (args[i] == QStringLiteral("-p")) {
             if (i >= args.size() - 1 || args[i + 1].startsWith(QChar::fromLatin1('-'))) {
                 continue;
@@ -3645,6 +3655,7 @@ static void PrintHelp(const char* argv0) {
     std::cout << "Usage: " << argv0
               << " [options] <file path>\n"
                  "-d [path]    Dump video recording of emulator playback to the given file path\n"
+                 "-g [port]    Enable gdb stub on the given port\n"
                  "-f           Start in fullscreen mode\n"
                  "-h           Display this help and exit\n"
                  "-i [path]    Install a CIA file at the given path\n"

--- a/src/lime_qt/main.cpp
+++ b/src/lime_qt/main.cpp
@@ -308,6 +308,25 @@ GMainWindow::GMainWindow(Core::System& system_)
                 continue;
             }
             game_path = args[++i];
+            continue;
+        }
+
+        if (args[i] == QStringLiteral("-p")) {
+            if (i >= args.size() - 1 || args[i + 1].startsWith(QChar::fromLatin1('-'))) {
+                continue;
+            }
+            movie_playback_path = args[++i];
+            movie_playback_on_start = true;
+            continue;
+        }
+
+        if (args[i] == QStringLiteral("-r")) {
+            if (i >= args.size() - 1 || args[i + 1].startsWith(QChar::fromLatin1('-'))) {
+                continue;
+            }
+            movie_record_path = args[++i];
+            movie_record_on_start = true;
+            continue;
         }
 
         // Launch game in windowed mode
@@ -3611,9 +3630,11 @@ static void PrintHelp(const char* argv0) {
     std::cout << "Usage: " << argv0
               << " [options] <filename>\n"
                  "-f           Start in fullscreen mode\n"
-                 "-g [path]    Start game at path\n"
+                 "-g [path]    Start a game file located at the given path\n"
                  "-h           Display this help and exit\n"
-                 "-i [path]    Installs the CIA file at the given path\n"
+                 "-i [path]    Install a CIA file at the given path\n"
+                 "-p [path]    Play a TAS movie located at the given path\n"
+                 "-r [path]    Record a TAS movie to the given file path\n"
                  "-v           Output version information and exit\n";
 }
 
@@ -3623,7 +3644,7 @@ static void PrintVersion() {
 
 int main(int argc, char* argv[]) {
     while (optind < argc) {
-        int arg = getopt(argc, argv, "fg:hi:v");
+        int arg = getopt(argc, argv, "fg:hi:r:v");
         if (arg != -1) {
             switch (static_cast<char>(arg)) {
             case 'h':

--- a/src/lime_qt/main.cpp
+++ b/src/lime_qt/main.cpp
@@ -302,23 +302,18 @@ GMainWindow::GMainWindow(Core::System& system_)
             continue;
         }
 
+        // Launch game at path
+        if (args[i] == QStringLiteral("-g")) {
+            if (i >= args.size() - 1 || args[i + 1].startsWith(QChar::fromLatin1('-'))) {
+                continue;
+            }
+            game_path = args[++i];
+        }
+
         // Launch game in windowed mode
         if (args[i] == QStringLiteral("-w")) {
             ui->action_Fullscreen->setChecked(false);
             continue;
-        }
-
-        // Launch game at path
-        if (args[i] == QStringLiteral("-g")) {
-            if (i >= args.size() - 1) {
-                continue;
-            }
-
-            if (args[i + 1].startsWith(QChar::fromLatin1('-'))) {
-                continue;
-            }
-
-            game_path = args[++i];
         }
     }
 

--- a/src/lime_qt/main.cpp
+++ b/src/lime_qt/main.cpp
@@ -354,8 +354,9 @@ GMainWindow::GMainWindow(Core::System& system_)
         }
 
         // Launch game at path
-        if (i == args.size() - 1 && !args[i + 1].startsWith(QChar::fromLatin1('-'))) {
-            game_path = args[++i];
+        if (i == args.size() - 1 && !args[i].startsWith(QChar::fromLatin1('-'))) {
+            game_path = args[i];
+            continue;
         }
     }
 

--- a/src/lime_qt/main.cpp
+++ b/src/lime_qt/main.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <clocale>
+#include <iostream>
 #include <memory>
 #include <thread>
 #include <QFileDialog>
@@ -3611,7 +3612,36 @@ static Qt::HighDpiScaleFactorRoundingPolicy GetHighDpiRoundingPolicy() {
 #endif
 }
 
+static void PrintHelp(const char* argv0) {
+    std::cout << "Usage: " << argv0
+              << " [options] <filename>\n"
+                 "-g [path]    Start game at path\n"
+                 "-f           Start in fullscreen mode\n"
+                 "-h           Display this help and exit\n"
+                 "-v           Output version information and exit\n";
+}
+
+static void PrintVersion() {
+    std::cout << "Lime3DS " << Common::g_scm_branch << " " << Common::g_scm_desc << std::endl;
+}
+
 int main(int argc, char* argv[]) {
+    while (optind < argc) {
+        int arg = getopt(argc, argv, "g:fhv");
+        if (arg != -1) {
+            switch (static_cast<char>(arg)) {
+            case 'h':
+                PrintHelp(argv[0]);
+                return 0;
+            case 'v':
+                PrintVersion();
+                return 0;
+            }
+        } else {
+            optind++;
+        }
+    }
+
     Common::DetachedTasks detached_tasks;
     MicroProfileOnThreadCreate("Frontend");
     SCOPE_EXIT({ MicroProfileShutdown(); });

--- a/src/lime_qt/main.cpp
+++ b/src/lime_qt/main.cpp
@@ -317,15 +317,6 @@ GMainWindow::GMainWindow(Core::System& system_)
             continue;
         }
 
-        // Launch game at path
-        if (args[i] == QStringLiteral("-g")) {
-            if (i >= args.size() - 1 || args[i + 1].startsWith(QChar::fromLatin1('-'))) {
-                continue;
-            }
-            game_path = args[++i];
-            continue;
-        }
-
         if (args[i] == QStringLiteral("-p")) {
             if (i >= args.size() - 1 || args[i + 1].startsWith(QChar::fromLatin1('-'))) {
                 continue;
@@ -348,6 +339,11 @@ GMainWindow::GMainWindow(Core::System& system_)
         if (args[i] == QStringLiteral("-w")) {
             ui->action_Fullscreen->setChecked(false);
             continue;
+        }
+
+        // Launch game at path
+        if (i == args.size() - 1 && !args[i + 1].startsWith(QChar::fromLatin1('-'))) {
+            game_path = args[++i];
         }
     }
 
@@ -3647,10 +3643,9 @@ static Qt::HighDpiScaleFactorRoundingPolicy GetHighDpiRoundingPolicy() {
 
 static void PrintHelp(const char* argv0) {
     std::cout << "Usage: " << argv0
-              << " [options] <filename>\n"
+              << " [options] <file path>\n"
                  "-d [path]    Dump video recording of emulator playback to the given file path\n"
                  "-f           Start in fullscreen mode\n"
-                 "-g [path]    Start a game file located at the given path\n"
                  "-h           Display this help and exit\n"
                  "-i [path]    Install a CIA file at the given path\n"
                  "-p [path]    Play a TAS movie located at the given path\n"

--- a/src/lime_qt/main.cpp
+++ b/src/lime_qt/main.cpp
@@ -360,6 +360,7 @@ GMainWindow::GMainWindow(Core::System& system_)
     if (fullscreen_override) {
         ui->action_Fullscreen->setChecked(*fullscreen_override);
     }
+    ui->action_Close_Movie->setEnabled(movie_playback_on_start || movie_record_on_start);
 
     ConnectAppEvents();
     ConnectMenuEvents();

--- a/src/lime_qt/main.h
+++ b/src/lime_qt/main.h
@@ -222,6 +222,7 @@ private:
                             const std::string& keywords, const std::string& name,
                             const bool& skip_tryexec);
 
+    void ShowCommandOutput(std::string title, std::string message);
     void ShowFFmpegErrorMessage();
 
 private slots:

--- a/src/lime_qt/main.h
+++ b/src/lime_qt/main.h
@@ -222,6 +222,8 @@ private:
                             const std::string& keywords, const std::string& name,
                             const bool& skip_tryexec);
 
+    void ShowFFmpegErrorMessage();
+
 private slots:
     void OnStartGame();
     void OnRestartGame();

--- a/src/lime_qt/main.ui
+++ b/src/lime_qt/main.ui
@@ -377,6 +377,9 @@
    <property name="text">
     <string>Close</string>
    </property>
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
   </action>
   <action name="action_Save_Movie">
    <property name="enabled">


### PR DESCRIPTION
Closes #462

This is the first of two PRs which will port functionality from the old SDL executable and merge it with the Qt executable.
This one focuses on porting the command line options which are available via the SDL executable.

This list keeps track of the options as they are implemented:
- [x] Dump video `-d`
- [x] GDB port functionality `-g`
  - [x] Remove old `-g` option, allow for a file to be provided at the end of the command
- [x] Show help `-h`
- [x] Install CIA from the command line `-i`
- [x] Play TAS movie `-p`
- [x] Record TAS movie `-r`
- [x] Show version `-v`