### PR TITLE
lime_qt: Fixed desktop shortcuts incorrectly including `-g` argument

### DIFF
--- a/src/lime_qt/lime_qt.cpp
+++ b/src/lime_qt/lime_qt.cpp
@@ -2121,7 +2121,7 @@ void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& ga
     }
 #endif // __linux__
     // Create shortcut
-    std::string arguments = fmt::format("-g \"{:s}\"", game_path);
+    std::string arguments = fmt::format("\"{:s}\"", game_path);
     if (CreateShortcutMessagesGUI(this, CREATE_SHORTCUT_MSGBOX_FULLSCREEN_PROMPT, qt_game_title)) {
         arguments = "-f " + arguments;
     }


### PR DESCRIPTION
This argument has a new meaning since the frontend merge, and is no longer needed in this instance.

Shortcuts created prior to this commit will not work for any build since the frontend merge.