### PR TITLE
otp.h - Fix Missing Braces error

### DIFF
--- a/src/core/file_sys/otp.h
+++ b/src/core/file_sys/otp.h
@@ -84,6 +84,6 @@ public:
     }
 
 private:
-    OTPBin otp = {0};
+    OTPBin otp = {{0}};
 };
 } // namespace FileSys


### PR DESCRIPTION
Fixes the following error when compiling with Clang (macOS/arm64)

```
/azahar/src/./core/file_sys/otp.h:87:19: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
   87 |     OTPBin otp = {0};
```