### PR TITLE
citra_qt.cpp: Fix remaining instance of "game" language

### DIFF
--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -1009,7 +1009,7 @@ const QStringList GameList::supported_file_extensions = {
 
 void GameList::RefreshGameDirectory() {
     if (!UISettings::values.game_dirs.isEmpty() && current_worker != nullptr) {
-        LOG_INFO(Frontend, "Change detected in the applications directory. Reloading game list.");
+        LOG_INFO(Frontend, "Change detected in the applications directory. Reloading app list.");
         PopulateAsync(UISettings::values.game_dirs);
     }
 }


### PR DESCRIPTION
Saw there was a remaining instance of the old language being used.