### PR TITLE
Fix CreateFullPath not working with windows paths

### DIFF
--- a/src/common/common_paths.h
+++ b/src/common/common_paths.h
@@ -1,4 +1,8 @@
-// Copyright 2013 Dolphin Emulator Project / 2014 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+// Copyright 2013 Dolphin Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -7,6 +11,7 @@
 // Directory separators, do we need this?
 #define DIR_SEP "/"
 #define DIR_SEP_CHR '/'
+#define DIR_SEP_CHR_WIN '\\'
 
 #ifndef MAX_PATH
 #define MAX_PATH 260

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -255,8 +255,14 @@ bool CreateFullPath(const std::string& fullPath) {
 
     std::size_t position = 0;
     while (true) {
+        std::size_t prev_pos = position;
         // Find next sub path
-        position = fullPath.find(DIR_SEP_CHR, position);
+        position = fullPath.find(DIR_SEP_CHR, prev_pos);
+
+#ifdef _WIN32
+        if (position == fullPath.npos)
+            position = fullPath.find(DIR_SEP_CHR_WIN, prev_pos);
+#endif
 
         // we're done, yay!
         if (position == fullPath.npos)


### PR DESCRIPTION
Takes in mind the windows directory separator when creating paths: `\`

Fixes #574 