### PR TITLE
Update discord rich presence to use Azahar application

### DIFF
--- a/src/citra_qt/discord_impl.cpp
+++ b/src/citra_qt/discord_impl.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -18,7 +18,7 @@ DiscordImpl::DiscordImpl(const Core::System& system_) : system{system_} {
 
     // The number is the client ID for Citra, it's used for images and the
     // application name
-    Discord_Initialize("719647875465871400", &handlers, 1, nullptr);
+    Discord_Initialize("1345366770436800533", &handlers, 1, nullptr);
 }
 
 DiscordImpl::~DiscordImpl() {
@@ -41,8 +41,8 @@ void DiscordImpl::Update() {
     }
 
     DiscordRichPresence presence{};
-    presence.largeImageKey = "citra";
-    presence.largeImageText = "Azahar is an emulator for the Nintendo 3DS";
+    presence.largeImageKey = "logo";
+    presence.largeImageText = "An open source emulator for the Nintendo 3DS";
     if (is_powered_on) {
         presence.state = title.c_str();
         presence.details = "Currently in game";


### PR DESCRIPTION
Fixes the discord rich presence showing the old citra application.
![Discord_w94vG66whf](https://github.com/user-attachments/assets/27c5bbd9-6e08-49ef-bd7e-dcd3fd1e64b2)
