### PR TITLE
android: Disable 'Disable Right Eye Render' option by default

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
@@ -64,7 +64,7 @@ enum class IntSetting(
     DELAY_RENDER_THREAD_US("delay_game_render_thread_us", Settings.SECTION_RENDERER, 0),
     USE_ARTIC_BASE_CONTROLLER("use_artic_base_controller", Settings.SECTION_CONTROLS, 0),
     ORIENTATION_OPTION("screen_orientation", Settings.SECTION_LAYOUT, 2),
-    DISABLE_RIGHT_EYE_RENDER("disable_right_eye_render", Settings.SECTION_RENDERER, 1);
+    DISABLE_RIGHT_EYE_RENDER("disable_right_eye_render", Settings.SECTION_RENDERER, 0);
     override var int: Int = defaultValue
 
     override val valueAsString: String

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -184,7 +184,7 @@ delay_game_render_thread_us =
 
 # Disables rendering the right eye image.
 # Greatly improves performance in some games, but can cause flickering in others.
-# 0: Enable right eye rendering, 1 (default): Disable right eye rendering
+# 0 (default): Enable right eye rendering, 1: Disable right eye rendering
 disable_right_eye_render =
 
 [Layout]


### PR DESCRIPTION
Closes #594