### PR TITLE
qt: Switch to GetUserDefaultUILanguage to fetch active display language on Windows

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -3541,7 +3541,6 @@ void GMainWindow::LoadTranslation() {
 
     if (language.isEmpty()) {
 #ifdef _WIN32
-        // Use Windows API to get the active display language
         LANGID lang_id = GetUserDefaultUILanguage();
         wchar_t locale_name[LOCALE_NAME_MAX_LENGTH];
 
@@ -3559,7 +3558,7 @@ void GMainWindow::LoadTranslation() {
 #endif
     }
 
-    // Replace dashes with underscores for compatibility with translation files
+    // For compatibility with translation files
     language.replace(QLatin1Char('-'), QLatin1Char('_'));
 
     bool loaded = translator.load(language, QStringLiteral(":/languages/"));

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -3537,16 +3537,32 @@ void GMainWindow::LoadTranslation() {
         return;
     }
 
-    bool loaded;
+    QString language = UISettings::values.language;
 
-    if (UISettings::values.language.isEmpty()) {
-        // Use the system's default locale
-        loaded = translator.load(QLocale::system(), {}, {}, QStringLiteral(":/languages/"));
-    } else {
-        // Otherwise load from the specified file
-        loaded = translator.load(UISettings::values.language, QStringLiteral(":/languages/"));
+    if (language.isEmpty()) {
+#ifdef _WIN32
+        // Use Windows API to get the active display language
+        LANGID lang_id = GetUserDefaultUILanguage();
+        wchar_t locale_name[LOCALE_NAME_MAX_LENGTH];
+
+        if (LCIDToLocaleName(MAKELCID(lang_id, SORT_DEFAULT), locale_name, LOCALE_NAME_MAX_LENGTH,
+                             0)) {
+            char locale_name_str[LOCALE_NAME_MAX_LENGTH];
+            WideCharToMultiByte(CP_UTF8, 0, locale_name, -1, locale_name_str,
+                                LOCALE_NAME_MAX_LENGTH, nullptr, nullptr);
+            language = QString::fromUtf8(locale_name_str);
+        } else {
+            language = QLocale::system().name();
+        }
+#else
+        language = QLocale::system().name();
+#endif
     }
 
+    // Replace dashes with underscores for compatibility with translation files
+    language.replace(QLatin1Char('-'), QLatin1Char('_'));
+
+    bool loaded = translator.load(language, QStringLiteral(":/languages/"));
     if (loaded) {
         qApp->installTranslator(&translator);
     } else {

--- a/src/citra_qt/citra_qt.h
+++ b/src/citra_qt/citra_qt.h
@@ -327,6 +327,9 @@ private:
     GameListPlaceholder* game_list_placeholder;
     LoadingScreen* loading_screen;
 
+    // General
+    QString current_language;
+
     // Status bar elements
     QProgressBar* progress_bar = nullptr;
     QLabel* message_label = nullptr;

--- a/src/citra_qt/citra_qt.h
+++ b/src/citra_qt/citra_qt.h
@@ -327,9 +327,6 @@ private:
     GameListPlaceholder* game_list_placeholder;
     LoadingScreen* loading_screen;
 
-    // General
-    QString current_language;
-
     // Status bar elements
     QProgressBar* progress_bar = nullptr;
     QLabel* message_label = nullptr;


### PR DESCRIPTION
Rebased from #521 by @kleidis

> Use `GetUserDefaultUILanguage` instead of `QLocale` on Windows platforms 
> This fixes the language mismatch if the language settings key is empty as on first boot of the emulator or when the user selects `System` for their language 
> 
> I've heard this issue might accur on MacOS and i got no clue but from what i could find online it;s mostly Windows having these issues with `QLocale`
> 
> Closes https://github.com/Lime3DS/Lime3DS/issues/242 
> However to make sure its actually fixed, I’m leaving it up as a draft and for people to test it