### PR TITLE
SendKey & SendSignal over rpc server

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -499,6 +499,10 @@ target_link_libraries(citra_core PUBLIC citra_common PRIVATE audio_core network 
 target_link_libraries(citra_core PRIVATE Boost::boost Boost::serialization Boost::iostreams httplib)
 target_link_libraries(citra_core PUBLIC dds-ktx PRIVATE cryptopp fmt lodepng open_source_archives)
 
+if (NOT ANDROID)
+    target_link_libraries(citra_core PUBLIC input_common)
+endif()
+
 if (ENABLE_WEB_SERVICE)
     target_link_libraries(citra_core PRIVATE web_service)
 endif()

--- a/src/core/rpc/packet.h
+++ b/src/core/rpc/packet.h
@@ -1,4 +1,4 @@
-// Copyright 2018 Citra Emulator Project
+// Copyright Citra Emulator Project / Lime3DS Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/core/rpc/packet.h
+++ b/src/core/rpc/packet.h
@@ -15,6 +15,8 @@ enum class PacketType : u32 {
     Undefined = 0,
     ReadMemory = 1,
     WriteMemory = 2,
+    SendKey = 3,
+    SendSignal = 4
 };
 
 struct PacketHeader {
@@ -69,9 +71,6 @@ public:
     }
 
 private:
-    void HandleReadMemory(u32 address, u32 data_size);
-    void HandleWriteMemory(u32 address, std::span<const u8> data);
-
     struct PacketHeader header;
     std::array<u8, MAX_PACKET_DATA_SIZE> packet_data;
 

--- a/src/core/rpc/rpc_server.cpp
+++ b/src/core/rpc/rpc_server.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Citra Emulator Project
+// Copyright Citra Emulator Project / Lime3DS Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -50,13 +50,12 @@ void RPCServer::HandleWriteMemory(Packet& packet, u32 address, std::span<const u
 void RPCServer::HandleSendKey(Packet& packet, u32 key_code, u8 state) {
     if (state == 0) {
         InputCommon::GetKeyboard()->ReleaseKey(key_code);
-    } else if(state == 1) {
+    } else if (state == 1) {
         InputCommon::GetKeyboard()->PressKey(key_code);
     }
     packet.SetPacketDataSize(0);
     packet.SendReply();
 }
-
 
 void RPCServer::HandleSendSignal(Packet& packet, u32 signal_code, u32 signal_parameter) {
     system.SendSignal(static_cast<Core::System::Signal>(signal_code), signal_parameter);
@@ -127,7 +126,8 @@ void RPCServer::HandleSingleRequest(std::unique_ptr<Packet> request_packet) {
             break;
         case PacketType::SendSignal:
             std::memcpy(&signal_code, packet_data.data(), sizeof(signal_code));
-            std::memcpy(&signal_parameter, packet_data.data() + sizeof(signal_code), sizeof(signal_parameter));
+            std::memcpy(&signal_parameter, packet_data.data() + sizeof(signal_code),
+                        sizeof(signal_parameter));
             HandleSendSignal(*request_packet, signal_code, signal_parameter);
             break;
         default:

--- a/src/core/rpc/rpc_server.h
+++ b/src/core/rpc/rpc_server.h
@@ -1,4 +1,4 @@
-// Copyright 2018 Citra Emulator Project
+// Copyright Citra Emulator Project / Lime3DS Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/core/rpc/rpc_server.h
+++ b/src/core/rpc/rpc_server.h
@@ -29,6 +29,8 @@ public:
 private:
     void HandleReadMemory(Packet& packet, u32 address, u32 data_size);
     void HandleWriteMemory(Packet& packet, u32 address, std::span<const u8> data);
+    void HandleSendKey(Packet& packet, u32 key_code, u8 state);
+    void HandleSendSignal(Packet& packet, u32 signal_code, u32 signal_parameter);
     bool ValidatePacket(const PacketHeader& packet_header);
     void HandleSingleRequest(std::unique_ptr<Packet> request);
     void HandleRequestsLoop(std::stop_token stop_token);

--- a/src/core/rpc/rpc_server.h
+++ b/src/core/rpc/rpc_server.h
@@ -29,8 +29,12 @@ public:
 private:
     void HandleReadMemory(Packet& packet, u32 address, u32 data_size);
     void HandleWriteMemory(Packet& packet, u32 address, std::span<const u8> data);
+
+#ifndef ANDROID
     void HandleSendKey(Packet& packet, u32 key_code, u8 state);
     void HandleSendSignal(Packet& packet, u32 signal_code, u32 signal_parameter);
+#endif
+
     bool ValidatePacket(const PacketHeader& packet_header);
     void HandleSingleRequest(std::unique_ptr<Packet> request);
     void HandleRequestsLoop(std::stop_token stop_token);


### PR DESCRIPTION
Rebased from #375 by @ProH4Ck

> Hi,
> I added two methods to rpc server:
> 
> - `SendKey`: emulate a key press
> - `SendSignal`: call `system.SendSignal` to control system state. This is needed to reset the game.
> 
> I developed these features for a bot I'm building.
> Sorry for the bad c++ but I works mainly with C# 😊

Marked as a draft because of issues raised in the original thread