### PR TITLE
Stereoscopic 3D Enhancements

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -868,7 +868,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     R.string.factor3d,
                     R.string.factor3d_description,
                     0,
-                    100,
+                    255,
                     "%",
                     IntSetting.STEREOSCOPIC_3D_DEPTH.key,
                     IntSetting.STEREOSCOPIC_3D_DEPTH.defaultValue.toFloat()

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -162,7 +162,7 @@ bg_green =
 render_3d =
 
 # Change 3D Intensity
-# 0 - 100: Intensity. 0 (default)
+# 0 - 255: Intensity. 0 (default)
 factor_3d =
 
 # The name of the post processing shader to apply.

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -254,7 +254,7 @@
     <string name="stereoscopy">Stereoscopy</string>
     <string name="render3d">Stereoscopic 3D Mode</string>
     <string name="factor3d">Depth</string>
-    <string name="factor3d_description">Specifies the value of the 3D slider. This should be set to higher than 0% when Stereoscopic 3D is enabled.</string>
+    <string name="factor3d_description">Specifies the value of the 3D slider. This should be set to higher than 0% when Stereoscopic 3D is enabled.\nNote: Depth values over 100% are not possible on real hardware and may cause graphical issues</string>
     <string name="cardboard_vr">Cardboard VR</string>
     <string name="cardboard_screen_size">Cardboard Screen Size</string>
     <string name="cardboard_screen_size_description">Scales the screen to a percentage of its original size.</string>

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -836,7 +836,7 @@ void GMainWindow::InitializeHotkeys() {
     });
     connect_shortcut(QStringLiteral("Increase 3D Factor"), [this] {
         const auto factor_3d = Settings::values.factor_3d.GetValue();
-        if (factor_3d < 100) {
+        if (factor_3d < 255) {
             if (factor_3d % FACTOR_3D_STEP != 0) {
                 Settings::values.factor_3d =
                     factor_3d + FACTOR_3D_STEP - (factor_3d % FACTOR_3D_STEP);

--- a/src/citra_qt/configuration/configure_enhancements.ui
+++ b/src/citra_qt/configuration/configure_enhancements.ui
@@ -276,7 +276,7 @@
            <number>0</number>
           </property>
           <property name="maximum">
-           <number>100</number>
+           <number>255</number>
           </property>
           <property name="value">
            <number>0</number>

--- a/src/citra_qt/configuration/configure_enhancements.ui
+++ b/src/citra_qt/configuration/configure_enhancements.ui
@@ -286,6 +286,13 @@
        </layout>
       </item>
       <item>
+       <widget class="QLabel" name="excessive_depth_warning_label">
+        <property name="text">
+         <string>Note: Depth values over 100% are not possible on real hardware and may cause graphical issues</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <layout class="QHBoxLayout" name="horizontalLayout_6">
         <item>
          <widget class="QLabel" name="label_6">

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -94,17 +94,24 @@ bool EmuWindow::IsWithinTouchscreen(const Layout::FramebufferLayout& layout, uns
 
 std::tuple<unsigned, unsigned> EmuWindow::ClipToTouchScreen(unsigned new_x, unsigned new_y) const {
     Settings::StereoRenderOption render_3d_mode = Settings::values.render_3d.GetValue();
+    bool separate_win = false;
+#ifndef ANDROID
+    separate_win =
+        (Settings::values.layout_option.GetValue() == Settings::LayoutOption::SeparateWindows);
+#endif
 
     if (new_x >= framebuffer_layout.width / 2) {
-        if (render_3d_mode == Settings::StereoRenderOption::SideBySide ||
-            render_3d_mode == Settings::StereoRenderOption::ReverseSideBySide)
+        if ((render_3d_mode == Settings::StereoRenderOption::SideBySide ||
+             render_3d_mode == Settings::StereoRenderOption::ReverseSideBySide) &&
+            !separate_win)
             new_x -= framebuffer_layout.width / 2;
         else if (render_3d_mode == Settings::StereoRenderOption::CardboardVR)
             new_x -=
                 (framebuffer_layout.width / 2) - (framebuffer_layout.cardboard.user_x_shift * 2);
     }
-    if (render_3d_mode == Settings::StereoRenderOption::SideBySide ||
-        render_3d_mode == Settings::StereoRenderOption::ReverseSideBySide) {
+    if ((render_3d_mode == Settings::StereoRenderOption::SideBySide ||
+         render_3d_mode == Settings::StereoRenderOption::ReverseSideBySide) &&
+        !separate_win) {
         new_x = std::max(new_x, framebuffer_layout.bottom_screen.left / 2);
         new_x = std::min(new_x, framebuffer_layout.bottom_screen.right / 2 - 1);
     } else {
@@ -130,21 +137,28 @@ void EmuWindow::CreateTouchState() {
 
 bool EmuWindow::TouchPressed(unsigned framebuffer_x, unsigned framebuffer_y) {
     Settings::StereoRenderOption render_3d_mode = Settings::values.render_3d.GetValue();
+    bool separate_win = false;
+#ifndef ANDROID
+    separate_win =
+        (Settings::values.layout_option.GetValue() == Settings::LayoutOption::SeparateWindows);
+#endif
 
     if (!IsWithinTouchscreen(framebuffer_layout, framebuffer_x, framebuffer_y))
         return false;
 
     if (framebuffer_x >= framebuffer_layout.width / 2) {
-        if (render_3d_mode == Settings::StereoRenderOption::SideBySide ||
-            render_3d_mode == Settings::StereoRenderOption::ReverseSideBySide)
+        if ((render_3d_mode == Settings::StereoRenderOption::SideBySide ||
+             render_3d_mode == Settings::StereoRenderOption::ReverseSideBySide) &&
+            !separate_win)
             framebuffer_x -= framebuffer_layout.width / 2;
         else if (render_3d_mode == Settings::StereoRenderOption::CardboardVR)
             framebuffer_x -=
                 (framebuffer_layout.width / 2) - (framebuffer_layout.cardboard.user_x_shift * 2);
     }
     std::scoped_lock guard(touch_state->mutex);
-    if (render_3d_mode == Settings::StereoRenderOption::SideBySide ||
-        render_3d_mode == Settings::StereoRenderOption::ReverseSideBySide) {
+    if ((render_3d_mode == Settings::StereoRenderOption::SideBySide ||
+         render_3d_mode == Settings::StereoRenderOption::ReverseSideBySide) &&
+        !separate_win) {
         touch_state->touch_x =
             static_cast<float>(framebuffer_x - framebuffer_layout.bottom_screen.left / 2) /
             (framebuffer_layout.bottom_screen.right / 2 -

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -793,6 +793,12 @@ void RendererOpenGL::DrawBottomScreen(const Layout::FramebufferLayout& layout,
     const auto orientation = layout.is_rotated ? Layout::DisplayOrientation::Landscape
                                                : Layout::DisplayOrientation::Portrait;
 
+    bool separate_win = false;
+#ifndef ANDROID
+    separate_win =
+        (Settings::values.layout_option.GetValue() == Settings::LayoutOption::SeparateWindows);
+#endif
+
     switch (Settings::values.render_3d.GetValue()) {
     case Settings::StereoRenderOption::Off: {
         DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
@@ -801,12 +807,17 @@ void RendererOpenGL::DrawBottomScreen(const Layout::FramebufferLayout& layout,
     }
     case Settings::StereoRenderOption::SideBySide: // Bottom screen is identical on both sides
     case Settings::StereoRenderOption::ReverseSideBySide: {
-        DrawSingleScreen(screen_infos[2], bottom_screen_left / 2, bottom_screen_top,
-                         bottom_screen_width / 2, bottom_screen_height, orientation);
-        glUniform1i(uniform_layer, 1);
-        DrawSingleScreen(
-            screen_infos[2], static_cast<float>((bottom_screen_left / 2) + (layout.width / 2)),
-            bottom_screen_top, bottom_screen_width / 2, bottom_screen_height, orientation);
+        if (separate_win) {
+            DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
+                             bottom_screen_width, bottom_screen_height, orientation);
+        } else {
+            DrawSingleScreen(screen_infos[2], bottom_screen_left / 2, bottom_screen_top,
+                             bottom_screen_width / 2, bottom_screen_height, orientation);
+            glUniform1i(uniform_layer, 1);
+            DrawSingleScreen(
+                screen_infos[2], static_cast<float>((bottom_screen_left / 2) + (layout.width / 2)),
+                bottom_screen_top, bottom_screen_width / 2, bottom_screen_height, orientation);
+        }
         break;
     }
     case Settings::StereoRenderOption::CardboardVR: {
@@ -822,9 +833,14 @@ void RendererOpenGL::DrawBottomScreen(const Layout::FramebufferLayout& layout,
     case Settings::StereoRenderOption::Anaglyph:
     case Settings::StereoRenderOption::Interlaced:
     case Settings::StereoRenderOption::ReverseInterlaced: {
-        DrawSingleScreenStereo(screen_infos[2], screen_infos[2], bottom_screen_left,
-                               bottom_screen_top, bottom_screen_width, bottom_screen_height,
-                               orientation);
+        if (separate_win) {
+            DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
+                             bottom_screen_width, bottom_screen_height, orientation);
+        } else {
+            DrawSingleScreenStereo(screen_infos[2], screen_infos[2], bottom_screen_left,
+                                   bottom_screen_top, bottom_screen_width, bottom_screen_height,
+                                   orientation);
+        }
         break;
     }
     }

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -836,8 +836,8 @@ void RendererOpenGL::DrawBottomScreen(const Layout::FramebufferLayout& layout,
         DrawSingleScreenStereo(screen_infos[2], screen_infos[2], bottom_screen_left,
                                bottom_screen_top, bottom_screen_width, bottom_screen_height,
                                orientation);
-        }
         break;
+    }
     }
 }
 

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -833,16 +833,11 @@ void RendererOpenGL::DrawBottomScreen(const Layout::FramebufferLayout& layout,
     case Settings::StereoRenderOption::Anaglyph:
     case Settings::StereoRenderOption::Interlaced:
     case Settings::StereoRenderOption::ReverseInterlaced: {
-        if (separate_win) {
-            DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
-                             bottom_screen_width, bottom_screen_height, orientation);
-        } else {
-            DrawSingleScreenStereo(screen_infos[2], screen_infos[2], bottom_screen_left,
-                                   bottom_screen_top, bottom_screen_width, bottom_screen_height,
-                                   orientation);
+        DrawSingleScreenStereo(screen_infos[2], screen_infos[2], bottom_screen_left,
+                               bottom_screen_top, bottom_screen_width, bottom_screen_height,
+                               orientation);
         }
         break;
-    }
     }
 }
 

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -1,4 +1,4 @@
-// Copyright Citra Emulator Project / Lime3DS Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -739,6 +739,12 @@ void RendererVulkan::DrawBottomScreen(const Layout::FramebufferLayout& layout,
     const auto orientation = layout.is_rotated ? Layout::DisplayOrientation::Landscape
                                                : Layout::DisplayOrientation::Portrait;
 
+    bool separate_win = false;
+#ifndef ANDROID
+    separate_win =
+        (Settings::values.layout_option.GetValue() == Settings::LayoutOption::SeparateWindows);
+#endif
+
     switch (Settings::values.render_3d.GetValue()) {
     case Settings::StereoRenderOption::Off: {
         DrawSingleScreen(2, bottom_screen_left, bottom_screen_top, bottom_screen_width,
@@ -747,12 +753,17 @@ void RendererVulkan::DrawBottomScreen(const Layout::FramebufferLayout& layout,
     }
     case Settings::StereoRenderOption::SideBySide: // Bottom screen is identical on both sides
     case Settings::StereoRenderOption::ReverseSideBySide: {
-        DrawSingleScreen(2, bottom_screen_left / 2, bottom_screen_top, bottom_screen_width / 2,
-                         bottom_screen_height, orientation);
-        draw_info.layer = 1;
-        DrawSingleScreen(2, static_cast<float>((bottom_screen_left / 2) + (layout.width / 2)),
-                         bottom_screen_top, bottom_screen_width / 2, bottom_screen_height,
-                         orientation);
+        if (separate_win) {
+            DrawSingleScreen(2, bottom_screen_left, bottom_screen_top, bottom_screen_width,
+                             bottom_screen_height, orientation);
+        } else {
+            DrawSingleScreen(2, bottom_screen_left / 2, bottom_screen_top, bottom_screen_width / 2,
+                             bottom_screen_height, orientation);
+            draw_info.layer = 1;
+            DrawSingleScreen(2, static_cast<float>((bottom_screen_left / 2) + (layout.width / 2)),
+                             bottom_screen_top, bottom_screen_width / 2, bottom_screen_height,
+                             orientation);
+        }
         break;
     }
     case Settings::StereoRenderOption::CardboardVR: {
@@ -767,8 +778,13 @@ void RendererVulkan::DrawBottomScreen(const Layout::FramebufferLayout& layout,
     case Settings::StereoRenderOption::Anaglyph:
     case Settings::StereoRenderOption::Interlaced:
     case Settings::StereoRenderOption::ReverseInterlaced: {
-        DrawSingleScreenStereo(2, 2, bottom_screen_left, bottom_screen_top, bottom_screen_width,
-                               bottom_screen_height, orientation);
+        if (separate_win) {
+            DrawSingleScreen(2, bottom_screen_left, bottom_screen_top, bottom_screen_width,
+                             bottom_screen_height, orientation);
+        } else {
+            DrawSingleScreenStereo(2, 2, bottom_screen_left, bottom_screen_top, bottom_screen_width,
+                                   bottom_screen_height, orientation);
+        }
         break;
     }
     }


### PR DESCRIPTION
Rebased from #405 by @oneup03 

> The purpose of this PR is to improve several of the stereoscopic 3D features of Lime.
> - Increase maximum depth to 255%. Many later 3DS games have weak 3D. Increasing the 3D setting beyond 100% alleviates this problem. The 3DVision community experimentally found the limit when getting Citra working with 3DVision: https://helixmod.blogspot.com/2019/08/citra-nintendo-3ds-emulator-sbs-to-3d.html
> - In the Separate Windows layout, it doesn't make sense for the touchscreen to render twice for 3D. All the 3D modes that Lime supports require the main window to be fullscreen. The touchscreen logically would go on a separate 2D physical screen. See this video for example: https://www.youtube.com/watch?v=H_8xT0oCZKg&t=270s

I have updated both the commit and the quoted description to remove an incorrectly applied translation change