### PR TITLE
Add Side By Side Full stereo setting + Swap Eyes setting

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
@@ -15,7 +15,8 @@ enum class BooleanSetting(
     ALLOW_PLUGIN_LOADER("allow_plugin_loader", Settings.SECTION_SYSTEM, true),
     SWAP_SCREEN("swap_screen", Settings.SECTION_LAYOUT, false),
     INSTANT_DEBUG_LOG("instant_debug_log", Settings.SECTION_DEBUG, false),
-    CUSTOM_LAYOUT("custom_layout",Settings.SECTION_LAYOUT,false);
+    CUSTOM_LAYOUT("custom_layout",Settings.SECTION_LAYOUT,false),
+    SWAP_EYES_3D("swap_eyes_3d",Settings.SECTION_RENDERER,false);
 
     override var boolean: Boolean = defaultValue
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -845,6 +845,16 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                 )
             )
 
+            add(
+                SwitchSetting(
+                    BooleanSetting.SWAP_EYES_3D,
+                    R.string.swap_eyes_3d,
+                    R.string.swap_eyes_3d_description,
+                    BooleanSetting.SWAP_EYES_3D.key,
+                    BooleanSetting.SWAP_EYES_3D.defaultValue
+                )
+            )
+
             add(HeaderSetting(R.string.cardboard_vr))
             add(
                 SliderSetting(

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -173,6 +173,7 @@ void Config::ReadValues() {
     ReadSetting("Renderer", Settings::values.bg_blue);
     ReadSetting("Renderer", Settings::values.delay_game_render_thread_us);
     ReadSetting("Renderer", Settings::values.disable_right_eye_render);
+    ReadSetting("Renderer", Settings::values.swap_eyes_3d);
 
     // Layout
     // Somewhat inelegant solution to ensure layout value is between 0 and 5 on read

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -165,6 +165,10 @@ render_3d =
 # 0 - 100: Intensity. 0 (default)
 factor_3d =
 
+# Swap Eyes in 3d
+# true or false (default)
+swap_eyes_3d =
+
 # The name of the post processing shader to apply.
 # Loaded from shaders if render_3d is off or side by side.
 pp_shader_name =

--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -188,7 +188,7 @@
     <string-array name="render3dModes">
         <item>@string/off</item>
         <item>@string/side_by_side</item>
-        <item>@string/reverse_side_by_side</item>
+        <item>@string/side_by_side_full</item>
         <item>@string/anaglyph</item>
         <item>@string/interlaced</item>
         <item>@string/reverse_interlaced</item>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -259,6 +259,8 @@
     <string name="render3d">Stereoscopic 3D Mode</string>
     <string name="factor3d">Depth</string>
     <string name="factor3d_description">Specifies the value of the 3D slider. This should be set to higher than 0% when Stereoscopic 3D is enabled.</string>
+    <string name="swap_eyes_3d">Swap Eyes</string>
+    <string name="swap_eyes_3d_description">Swaps which eye is shown where. Combine with Side by Side mode and cross your eyes to see 3D with no equipment!</string>
     <string name="cardboard_vr">Cardboard VR</string>
     <string name="cardboard_screen_size">Cardboard Screen Size</string>
     <string name="cardboard_screen_size_description">Scales the screen to a percentage of its original size.</string>
@@ -586,7 +588,7 @@
 
     <!-- Render 3D modes -->
     <string name="side_by_side">Side by Side</string>
-    <string name="reverse_side_by_side">Reverse Side by Side</string>
+    <string name="side_by_side_full">Side by Side Full Width</string>
     <string name="anaglyph">Anaglyph</string>
     <string name="interlaced">Interlaced</string>
     <string name="reverse_interlaced">Reverse Interlaced</string>

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -512,6 +512,7 @@ void QtConfig::ReadLayoutValues() {
 
     ReadGlobalSetting(Settings::values.render_3d);
     ReadGlobalSetting(Settings::values.factor_3d);
+    ReadGlobalSetting(Settings::values.swap_eyes_3d);
     ReadGlobalSetting(Settings::values.filter_mode);
     ReadGlobalSetting(Settings::values.pp_shader_name);
     ReadGlobalSetting(Settings::values.anaglyph_shader_name);
@@ -1078,6 +1079,7 @@ void QtConfig::SaveLayoutValues() {
 
     WriteGlobalSetting(Settings::values.render_3d);
     WriteGlobalSetting(Settings::values.factor_3d);
+    WriteGlobalSetting(Settings::values.swap_eyes_3d);
     WriteGlobalSetting(Settings::values.filter_mode);
     WriteGlobalSetting(Settings::values.pp_shader_name);
     WriteGlobalSetting(Settings::values.anaglyph_shader_name);

--- a/src/citra_qt/configuration/configure_enhancements.cpp
+++ b/src/citra_qt/configuration/configure_enhancements.cpp
@@ -57,6 +57,7 @@ void ConfigureEnhancements::SetConfiguration() {
 
     ui->render_3d_combobox->setCurrentIndex(
         static_cast<int>(Settings::values.render_3d.GetValue()));
+    ui->swap_eyes_3d->setChecked(Settings::values.swap_eyes_3d.GetValue());
     ui->factor_3d->setValue(Settings::values.factor_3d.GetValue());
     ui->mono_rendering_eye->setCurrentIndex(
         static_cast<int>(Settings::values.mono_render_option.GetValue()));
@@ -111,6 +112,7 @@ void ConfigureEnhancements::ApplyConfiguration() {
                                              ui->resolution_factor_combobox);
     Settings::values.render_3d =
         static_cast<Settings::StereoRenderOption>(ui->render_3d_combobox->currentIndex());
+    Settings::values.swap_eyes_3d = ui->swap_eyes_3d->isChecked();
     Settings::values.factor_3d = ui->factor_3d->value();
     Settings::values.mono_render_option =
         static_cast<Settings::MonoRenderOption>(ui->mono_rendering_eye->currentIndex());

--- a/src/citra_qt/configuration/configure_enhancements.ui
+++ b/src/citra_qt/configuration/configure_enhancements.ui
@@ -319,6 +319,8 @@
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Disable Right Eye Rendering&lt;/p&gt;&lt;p&gt;Disables rendering the right eye image when not using stereoscopic mode. Greatly improves performance in some applications, but can cause flickering in others.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="swap_eyes_3d">
         <property name="text">
          <string>Swap Eyes</string>

--- a/src/citra_qt/configuration/configure_enhancements.ui
+++ b/src/citra_qt/configuration/configure_enhancements.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>440</width>
-    <height>950</height>
+    <height>891</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -236,7 +236,7 @@
           </item>
           <item>
            <property name="text">
-            <string>Reverse Side by Side</string>
+            <string>Side by Side Full Width</string>
            </property>
           </item>
           <item>
@@ -311,14 +311,19 @@
        </layout>
       </item>
       <item>
-        <widget class="QCheckBox" name="disable_right_eye_render">
-          <property name="text">
-            <string>Disable Right Eye Rendering</string>
-          </property>
-          <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Disable Right Eye Rendering&lt;/p&gt;&lt;p&gt;Disables rendering the right eye image when not using stereoscopic mode. Greatly improves performance in some applications, but can cause flickering in others.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-        </widget>
+       <widget class="QCheckBox" name="disable_right_eye_render">
+        <property name="text">
+         <string>Disable Right Eye Rendering</string>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Disable Right Eye Rendering&lt;/p&gt;&lt;p&gt;Disables rendering the right eye image when not using stereoscopic mode. Greatly improves performance in some applications, but can cause flickering in others.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+       <widget class="QCheckBox" name="swap_eyes_3d">
+        <property name="text">
+         <string>Swap Eyes</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/citra_sdl/default_ini.h
+++ b/src/citra_sdl/default_ini.h
@@ -163,6 +163,10 @@ render_3d =
 # 0 - 100: Intensity. 0 (default)
 factor_3d =
 
+# Swap Eyes in 3D
+# true or false (default)
+swap_eyes_3d =
+
 # Change Default Eye to Render When in Monoscopic Mode
 # 0 (default): Left, 1: Right
 mono_render_option =

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -105,6 +105,7 @@ void LogSettings() {
     log_setting("Renderer_DisableRightEyeRender", values.disable_right_eye_render.GetValue());
     log_setting("Stereoscopy_Render3d", values.render_3d.GetValue());
     log_setting("Stereoscopy_Factor3d", values.factor_3d.GetValue());
+    log_setting("Stereoscopy_Swap_Eyes",values.swap_eyes_3d.GetValue());
     log_setting("Stereoscopy_MonoRenderOption", values.mono_render_option.GetValue());
     if (values.render_3d.GetValue() == StereoRenderOption::Anaglyph) {
         log_setting("Renderer_AnaglyphShader", values.anaglyph_shader_name.GetValue());
@@ -211,6 +212,7 @@ void RestoreGlobalState(bool is_powered_on) {
     values.bg_green.SetGlobal(true);
     values.bg_blue.SetGlobal(true);
     values.render_3d.SetGlobal(true);
+    values.swap_eyes_3d.SetGlobal(true);
     values.factor_3d.SetGlobal(true);
     values.filter_mode.SetGlobal(true);
     values.pp_shader_name.SetGlobal(true);

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -105,7 +105,7 @@ void LogSettings() {
     log_setting("Renderer_DisableRightEyeRender", values.disable_right_eye_render.GetValue());
     log_setting("Stereoscopy_Render3d", values.render_3d.GetValue());
     log_setting("Stereoscopy_Factor3d", values.factor_3d.GetValue());
-    log_setting("Stereoscopy_Swap_Eyes",values.swap_eyes_3d.GetValue());
+    log_setting("Stereoscopy_Swap_Eyes", values.swap_eyes_3d.GetValue());
     log_setting("Stereoscopy_MonoRenderOption", values.mono_render_option.GetValue());
     if (values.render_3d.GetValue() == StereoRenderOption::Anaglyph) {
         log_setting("Renderer_AnaglyphShader", values.anaglyph_shader_name.GetValue());

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -541,7 +541,7 @@ struct Values {
 
     SwitchableSetting<StereoRenderOption> render_3d{StereoRenderOption::Off, "render_3d"};
     SwitchableSetting<u32> factor_3d{0, "factor_3d"};
-    SwitchableSetting<bool> swap_eyes_3d{false, "swap_eyes"};
+    SwitchableSetting<bool> swap_eyes_3d{false, "swap_eyes_3d"};
     SwitchableSetting<MonoRenderOption> mono_render_option{MonoRenderOption::LeftEye,
                                                            "mono_render_option"};
 

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -70,11 +70,11 @@ enum class SmallScreenPosition : u32 {
 enum class StereoRenderOption : u32 {
     Off = 0,
     SideBySide = 1,
-    ReverseSideBySide = 2,
-    Anaglyph = 3,
-    Interlaced = 4,
-    ReverseInterlaced = 5,
-    CardboardVR = 6
+    SideBySideFull = 2,
+    Anaglyph = 4,
+    Interlaced = 5,
+    ReverseInterlaced = 6,
+    CardboardVR = 7
 };
 
 // Which eye to render when 3d is off. 800px wide mode could be added here in the future, when
@@ -541,6 +541,7 @@ struct Values {
 
     SwitchableSetting<StereoRenderOption> render_3d{StereoRenderOption::Off, "render_3d"};
     SwitchableSetting<u32> factor_3d{0, "factor_3d"};
+    SwitchableSetting<bool> swap_eyes_3d{false, "swap_eyes"};
     SwitchableSetting<MonoRenderOption> mono_render_option{MonoRenderOption::LeftEye,
                                                            "mono_render_option"};
 

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -726,6 +726,9 @@ void RendererOpenGL::DrawTopScreen(const Layout::FramebufferLayout& layout,
     if (!layout.top_screen_enabled) {
         return;
     }
+    int leftside, rightside;
+    leftside = Settings::values.swap_eyes_3d.GetValue() ? 0 : 1;
+    rightside = Settings::values.swap_eyes_3d.GetValue() ? 1 : 0;
 
     const float top_screen_left = static_cast<float>(top_screen.left);
     const float top_screen_top = static_cast<float>(top_screen.top);
@@ -742,29 +745,29 @@ void RendererOpenGL::DrawTopScreen(const Layout::FramebufferLayout& layout,
         break;
     }
     case Settings::StereoRenderOption::SideBySide: {
-        DrawSingleScreen(screen_infos[0], top_screen_left / 2, top_screen_top, top_screen_width / 2,
-                         top_screen_height, orientation);
+        DrawSingleScreen(screen_infos[leftside], top_screen_left / 2, top_screen_top,
+                         top_screen_width / 2, top_screen_height, orientation);
         glUniform1i(uniform_layer, 1);
-        DrawSingleScreen(screen_infos[1],
+        DrawSingleScreen(screen_infos[rightside],
                          static_cast<float>((top_screen_left / 2) + (layout.width / 2)),
                          top_screen_top, top_screen_width / 2, top_screen_height, orientation);
         break;
     }
-    case Settings::StereoRenderOption::ReverseSideBySide: {
-        DrawSingleScreen(screen_infos[1], top_screen_left / 2, top_screen_top, top_screen_width / 2,
+    case Settings::StereoRenderOption::SideBySideFull: {
+        DrawSingleScreen(screen_infos[leftside], top_screen_left, top_screen_top, top_screen_width,
                          top_screen_height, orientation);
         glUniform1i(uniform_layer, 1);
-        DrawSingleScreen(screen_infos[0],
-                         static_cast<float>((top_screen_left / 2) + (layout.width / 2)),
-                         top_screen_top, top_screen_width / 2, top_screen_height, orientation);
+        // DrawSingleScreen(screen_infos[rightside],
+        //                  static_cast<float>(top_screen_left + layout.width),
+        //                  top_screen_top, top_screen_width, top_screen_height, orientation);
         break;
     }
     case Settings::StereoRenderOption::CardboardVR: {
-        DrawSingleScreen(screen_infos[0], top_screen_left, top_screen_top, top_screen_width,
+        DrawSingleScreen(screen_infos[leftside], top_screen_left, top_screen_top, top_screen_width,
                          top_screen_height, orientation);
         glUniform1i(uniform_layer, 1);
         DrawSingleScreen(
-            screen_infos[1],
+            screen_infos[rightside],
             static_cast<float>(layout.cardboard.top_screen_right_eye + (layout.width / 2)),
             top_screen_top, top_screen_width, top_screen_height, orientation);
         break;
@@ -772,8 +775,8 @@ void RendererOpenGL::DrawTopScreen(const Layout::FramebufferLayout& layout,
     case Settings::StereoRenderOption::Anaglyph:
     case Settings::StereoRenderOption::Interlaced:
     case Settings::StereoRenderOption::ReverseInterlaced: {
-        DrawSingleScreenStereo(screen_infos[0], screen_infos[1], top_screen_left, top_screen_top,
-                               top_screen_width, top_screen_height, orientation);
+        DrawSingleScreenStereo(screen_infos[leftside], screen_infos[rightside], top_screen_left,
+                               top_screen_top, top_screen_width, top_screen_height, orientation);
         break;
     }
     }
@@ -800,13 +803,22 @@ void RendererOpenGL::DrawBottomScreen(const Layout::FramebufferLayout& layout,
         break;
     }
     case Settings::StereoRenderOption::SideBySide: // Bottom screen is identical on both sides
-    case Settings::StereoRenderOption::ReverseSideBySide: {
+    {
         DrawSingleScreen(screen_infos[2], bottom_screen_left / 2, bottom_screen_top,
                          bottom_screen_width / 2, bottom_screen_height, orientation);
         glUniform1i(uniform_layer, 1);
         DrawSingleScreen(
             screen_infos[2], static_cast<float>((bottom_screen_left / 2) + (layout.width / 2)),
             bottom_screen_top, bottom_screen_width / 2, bottom_screen_height, orientation);
+        break;
+    }
+    case Settings::StereoRenderOption::SideBySideFull: {
+        DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
+                         bottom_screen_width, bottom_screen_height, orientation);
+        // glUniform1i(uniform_layer, 1);
+        // DrawSingleScreen(
+        //     screen_infos[2], static_cast<float>(bottom_screen_left + layout.width),
+        //     bottom_screen_top, bottom_screen_width, bottom_screen_height, orientation);
         break;
     }
     case Settings::StereoRenderOption::CardboardVR: {

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -727,8 +727,8 @@ void RendererOpenGL::DrawTopScreen(const Layout::FramebufferLayout& layout,
         return;
     }
     int leftside, rightside;
-    leftside = Settings::values.swap_eyes_3d.GetValue() ? 0 : 1;
-    rightside = Settings::values.swap_eyes_3d.GetValue() ? 1 : 0;
+    leftside = Settings::values.swap_eyes_3d.GetValue() ? 1 : 0;
+    rightside = Settings::values.swap_eyes_3d.GetValue() ? 0 : 1;
 
     const float top_screen_left = static_cast<float>(top_screen.left);
     const float top_screen_top = static_cast<float>(top_screen.top);

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -815,10 +815,9 @@ void RendererOpenGL::DrawBottomScreen(const Layout::FramebufferLayout& layout,
     case Settings::StereoRenderOption::SideBySideFull: {
         DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
                          bottom_screen_width, bottom_screen_height, orientation);
-         glUniform1i(uniform_layer, 1);
-         DrawSingleScreen(
-             screen_infos[2], bottom_screen_left + layout.width / 2,
-             bottom_screen_top, bottom_screen_width, bottom_screen_height, orientation);
+        glUniform1i(uniform_layer, 1);
+        DrawSingleScreen(screen_infos[2], bottom_screen_left + layout.width / 2, bottom_screen_top,
+                         bottom_screen_width, bottom_screen_height, orientation);
         break;
     }
     case Settings::StereoRenderOption::CardboardVR: {

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -757,9 +757,9 @@ void RendererOpenGL::DrawTopScreen(const Layout::FramebufferLayout& layout,
         DrawSingleScreen(screen_infos[leftside], top_screen_left, top_screen_top, top_screen_width,
                          top_screen_height, orientation);
         glUniform1i(uniform_layer, 1);
-        // DrawSingleScreen(screen_infos[rightside],
-        //                  static_cast<float>(top_screen_left + layout.width),
-        //                  top_screen_top, top_screen_width, top_screen_height, orientation);
+        DrawSingleScreen(screen_infos[rightside],
+                         static_cast<float>(top_screen_left + layout.width / 2), top_screen_top,
+                         top_screen_width, top_screen_height, orientation);
         break;
     }
     case Settings::StereoRenderOption::CardboardVR: {
@@ -815,10 +815,10 @@ void RendererOpenGL::DrawBottomScreen(const Layout::FramebufferLayout& layout,
     case Settings::StereoRenderOption::SideBySideFull: {
         DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
                          bottom_screen_width, bottom_screen_height, orientation);
-        // glUniform1i(uniform_layer, 1);
-        // DrawSingleScreen(
-        //     screen_infos[2], static_cast<float>(bottom_screen_left + layout.width),
-        //     bottom_screen_top, bottom_screen_width, bottom_screen_height, orientation);
+         glUniform1i(uniform_layer, 1);
+         DrawSingleScreen(
+             screen_infos[2], bottom_screen_left + layout.width / 2,
+             bottom_screen_top, bottom_screen_width, bottom_screen_height, orientation);
         break;
     }
     case Settings::StereoRenderOption::CardboardVR: {

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -675,7 +675,9 @@ void RendererVulkan::DrawTopScreen(const Layout::FramebufferLayout& layout,
     if (!layout.top_screen_enabled) {
         return;
     }
-
+    int leftside, rightside;
+    leftside = Settings::values.swap_eyes_3d.GetValue() ? 0 : 1;
+    rightside = Settings::values.swap_eyes_3d.GetValue() ? 1 : 0;
     const float top_screen_left = static_cast<float>(top_screen.left);
     const float top_screen_top = static_cast<float>(top_screen.top);
     const float top_screen_width = static_cast<float>(top_screen.GetWidth());
@@ -691,35 +693,36 @@ void RendererVulkan::DrawTopScreen(const Layout::FramebufferLayout& layout,
         break;
     }
     case Settings::StereoRenderOption::SideBySide: {
-        DrawSingleScreen(0, top_screen_left / 2, top_screen_top, top_screen_width / 2,
+        DrawSingleScreen(leftside, top_screen_left / 2, top_screen_top, top_screen_width / 2,
                          top_screen_height, orientation);
         draw_info.layer = 1;
-        DrawSingleScreen(1, static_cast<float>((top_screen_left / 2) + (layout.width / 2)),
+        DrawSingleScreen(rightside, static_cast<float>((top_screen_left / 2) + (layout.width / 2)),
                          top_screen_top, top_screen_width / 2, top_screen_height, orientation);
         break;
     }
-    case Settings::StereoRenderOption::ReverseSideBySide: {
-        DrawSingleScreen(1, top_screen_left / 2, top_screen_top, top_screen_width / 2,
+    case Settings::StereoRenderOption::SideBySideFull: {
+        DrawSingleScreen(leftside, top_screen_left, top_screen_top, top_screen_width,
                          top_screen_height, orientation);
         draw_info.layer = 1;
-        DrawSingleScreen(0, static_cast<float>((top_screen_left / 2) + (layout.width / 2)),
-                         top_screen_top, top_screen_width / 2, top_screen_height, orientation);
+        DrawSingleScreen(rightside, top_screen_left + layout.width / 2, top_screen_top,
+                         top_screen_width, top_screen_height, orientation);
         break;
     }
     case Settings::StereoRenderOption::CardboardVR: {
-        DrawSingleScreen(0, top_screen_left, top_screen_top, top_screen_width, top_screen_height,
-                         orientation);
+        DrawSingleScreen(leftside, top_screen_left, top_screen_top, top_screen_width,
+                         top_screen_height, orientation);
         draw_info.layer = 1;
         DrawSingleScreen(
-            1, static_cast<float>(layout.cardboard.top_screen_right_eye + (layout.width / 2)),
+            rightside,
+            static_cast<float>(layout.cardboard.top_screen_right_eye + (layout.width / 2)),
             top_screen_top, top_screen_width, top_screen_height, orientation);
         break;
     }
     case Settings::StereoRenderOption::Anaglyph:
     case Settings::StereoRenderOption::Interlaced:
     case Settings::StereoRenderOption::ReverseInterlaced: {
-        DrawSingleScreenStereo(0, 1, top_screen_left, top_screen_top, top_screen_width,
-                               top_screen_height, orientation);
+        DrawSingleScreenStereo(leftside, rightside, top_screen_left, top_screen_top,
+                               top_screen_width, top_screen_height, orientation);
         break;
     }
     }
@@ -745,14 +748,21 @@ void RendererVulkan::DrawBottomScreen(const Layout::FramebufferLayout& layout,
                          bottom_screen_height, orientation);
         break;
     }
-    case Settings::StereoRenderOption::SideBySide: // Bottom screen is identical on both sides
-    case Settings::StereoRenderOption::ReverseSideBySide: {
+    case Settings::StereoRenderOption::SideBySide: {
         DrawSingleScreen(2, bottom_screen_left / 2, bottom_screen_top, bottom_screen_width / 2,
                          bottom_screen_height, orientation);
         draw_info.layer = 1;
         DrawSingleScreen(2, static_cast<float>((bottom_screen_left / 2) + (layout.width / 2)),
                          bottom_screen_top, bottom_screen_width / 2, bottom_screen_height,
                          orientation);
+        break;
+    }
+    case Settings::StereoRenderOption::SideBySideFull: {
+        DrawSingleScreen(2, bottom_screen_left, bottom_screen_top, bottom_screen_width,
+                         bottom_screen_height, orientation);
+        draw_info.layer = 1;
+        DrawSingleScreen(2, bottom_screen_left + layout.width / 2, bottom_screen_top,
+                         bottom_screen_width, bottom_screen_height, orientation);
         break;
     }
     case Settings::StereoRenderOption::CardboardVR: {

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -676,8 +676,8 @@ void RendererVulkan::DrawTopScreen(const Layout::FramebufferLayout& layout,
         return;
     }
     int leftside, rightside;
-    leftside = Settings::values.swap_eyes_3d.GetValue() ? 0 : 1;
-    rightside = Settings::values.swap_eyes_3d.GetValue() ? 1 : 0;
+    leftside = Settings::values.swap_eyes_3d.GetValue() ? 1 : 0;
+    rightside = Settings::values.swap_eyes_3d.GetValue() ? 0 : 1;
     const float top_screen_left = static_cast<float>(top_screen.left);
     const float top_screen_top = static_cast<float>(top_screen.top);
     const float top_screen_width = static_cast<float>(top_screen.GetWidth());


### PR DESCRIPTION
Rebased from #401 by @DavidRGriswold

> This PR removes the Reverse Side By Side stereo layout that was added recently and replaces it with a Side By Side Full setting that generates a full-width side by side layout rather than a half-width one. In order to keep the functionality of the reverse side by side option available, it also adds a boolean setting for swapping eyes, which will apply to any rendering option, matching how Dolphin does it since these settings are often compared by users.
>
> Here is a screenshot of the most common use case for this - full width side by side stereo layout with the eyes swapped. If you cross your eyes at it like a Magic Eye, you should be able to see the image in full 3d in the center (might be best opening the screenshot in a separate tab)
>
> ![SEGA 3D Classics Collection_27 08 24_12 10 58 75](https://github.com/user-attachments/assets/b687784f-eec2-4ac7-ae3a-926618051678)

---

The original author mentioned that the following things have yet to be tested:
- [ ] Test screenshot functionality (openGL)
- [ ] Test all layouts with side by side full on both swapped and not swapped eyes on desktop (openGL)
- [ ] Test swap eye setting with traditional side by side in all layouts on desktop (openGL)
- [ ] Test anaglyph and interlaced with and without swap to make sure nothing broke, on both vulkan and opengl
- [ ] Test CardboardVR on android to make sure it still works as expected

Additionally, an off-by-one error was caught in review in the original thread and was never fixed before the PR was closed. This should be addressed before being marked as ready for review.