### PR TITLE
android: Implement support for automatic resolution scale

### DIFF
--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -309,6 +309,7 @@
     </integer-array>
 
     <string-array name="resolutionFactorNames">
+        <item>@string/internal_resolution_setting_auto</item>
         <item>@string/internal_resolution_setting_1x</item>
         <item>@string/internal_resolution_setting_2x</item>
         <item>@string/internal_resolution_setting_3x</item>
@@ -321,6 +322,7 @@
         <item>@string/internal_resolution_setting_10x</item>
     </string-array>
     <integer-array name="resolutionFactorValues">
+        <item>0</item>
         <item>1</item>
         <item>2</item>
         <item>3</item>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -249,6 +249,7 @@
     <string name="frame_limit_slider_description">Specifies the percentage to limit emulation speed. With the default of 100% emulation will be limited to normal speed. Values higher or lower will increase or decrease the speed limit.</string>
     <string name="internal_resolution">Internal Resolution</string>
     <string name="internal_resolution_description">Specifies the resolution used to render at. A high resolution will improve visual quality a lot but is also quite heavy on performance and might cause glitches in certain applications.</string>
+    <string name="internal_resolution_setting_auto">Auto (Screen Size)</string>
     <string name="internal_resolution_setting_1x">Native (400x240)</string>
     <string name="internal_resolution_setting_2x">2x Native (800x480)</string>
     <string name="internal_resolution_setting_3x">3x Native (1200x720)</string>


### PR DESCRIPTION
Rebased from #418 by @kleidis

> Available on Qt but was missing on android.
> 
> This puts the internal res scale at the closest value of your screen resolution