### PR TITLE
android: Original Portrait Layout

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/display/ScreenLayout.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/display/ScreenLayout.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/display/ScreenLayout.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/display/ScreenLayout.kt
@@ -41,7 +41,8 @@ enum class SmallScreenPosition(val int: Int) {
 enum class PortraitScreenLayout(val int: Int) {
     // These must match what is defined in src/common/settings.h
     TOP_FULL_WIDTH(0),
-    CUSTOM_PORTRAIT_LAYOUT(1);
+    CUSTOM_PORTRAIT_LAYOUT(1),
+    ORIGINAL(2);
 
     companion object {
         fun from(int: Int): PortraitScreenLayout {

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
@@ -902,10 +902,10 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
         val layoutOptionMenuItem = when (IntSetting.PORTRAIT_SCREEN_LAYOUT.int) {
             PortraitScreenLayout.TOP_FULL_WIDTH.int ->
                 R.id.menu_portrait_layout_top_full
-
             PortraitScreenLayout.CUSTOM_PORTRAIT_LAYOUT.int ->
                 R.id.menu_portrait_layout_custom
-
+            PortraitScreenLayout.ORIGINAL.int ->
+                R.id.menu_portrait_layout_original
             else ->
                 R.id.menu_portrait_layout_top_full
 
@@ -927,6 +927,11 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
                         Toast.LENGTH_LONG
                     ).show()
                     screenAdjustmentUtil.changePortraitOrientation(PortraitScreenLayout.CUSTOM_PORTRAIT_LAYOUT.int)
+                    true
+                }
+
+                R.id.menu_portrait_layout_original -> {
+                    screenAdjustmentUtil.changePortraitOrientation(PortraitScreenLayout.ORIGINAL.int)
                     true
                 }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
@@ -902,10 +902,10 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
         val layoutOptionMenuItem = when (IntSetting.PORTRAIT_SCREEN_LAYOUT.int) {
             PortraitScreenLayout.TOP_FULL_WIDTH.int ->
                 R.id.menu_portrait_layout_top_full
-            PortraitScreenLayout.CUSTOM_PORTRAIT_LAYOUT.int ->
-                R.id.menu_portrait_layout_custom
             PortraitScreenLayout.ORIGINAL.int ->
                 R.id.menu_portrait_layout_original
+            PortraitScreenLayout.CUSTOM_PORTRAIT_LAYOUT.int ->
+                R.id.menu_portrait_layout_custom
             else ->
                 R.id.menu_portrait_layout_top_full
 
@@ -920,6 +920,11 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
                     true
                 }
 
+                R.id.menu_portrait_layout_original -> {
+                    screenAdjustmentUtil.changePortraitOrientation(PortraitScreenLayout.ORIGINAL.int)
+                    true
+                }
+
                 R.id.menu_portrait_layout_custom -> {
                     Toast.makeText(
                         requireContext(),
@@ -927,11 +932,6 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
                         Toast.LENGTH_LONG
                     ).show()
                     screenAdjustmentUtil.changePortraitOrientation(PortraitScreenLayout.CUSTOM_PORTRAIT_LAYOUT.int)
-                    true
-                }
-
-                R.id.menu_portrait_layout_original -> {
-                    screenAdjustmentUtil.changePortraitOrientation(PortraitScreenLayout.ORIGINAL.int)
                     true
                 }
 

--- a/src/android/app/src/main/res/menu/menu_portrait_screen_layout.xml
+++ b/src/android/app/src/main/res/menu/menu_portrait_screen_layout.xml
@@ -11,6 +11,10 @@
             android:id="@+id/menu_portrait_layout_custom"
             android:title="@string/emulation_screen_layout_custom" />
 
+        <item
+            android:id="@+id/menu_portrait_layout_original"
+            android:title="@string/emulation_screen_layout_original" />
+
     </group>
 
 </menu>

--- a/src/android/app/src/main/res/menu/menu_portrait_screen_layout.xml
+++ b/src/android/app/src/main/res/menu/menu_portrait_screen_layout.xml
@@ -8,12 +8,12 @@
             android:title="@string/emulation_portrait_layout_top_full" />
 
         <item
-            android:id="@+id/menu_portrait_layout_custom"
-            android:title="@string/emulation_screen_layout_custom" />
-
-        <item
             android:id="@+id/menu_portrait_layout_original"
             android:title="@string/emulation_screen_layout_original" />
+
+        <item
+            android:id="@+id/menu_portrait_layout_custom"
+            android:title="@string/emulation_screen_layout_custom" />
 
     </group>
 

--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -32,11 +32,13 @@
     <string-array name="portraitLayouts">
         <item>@string/emulation_portrait_layout_top_full</item>
         <item>@string/emulation_screen_layout_custom</item>
+        <item>@string/emulation_screen_layout_original</item>
     </string-array>
 
     <integer-array name="portraitLayoutValues">
         <item>0</item>
         <item>1</item>
+        <item>2</item>
     </integer-array>
 
     <string-array name="smallScreenPositions">

--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -31,14 +31,14 @@
 
     <string-array name="portraitLayouts">
         <item>@string/emulation_portrait_layout_top_full</item>
-        <item>@string/emulation_screen_layout_custom</item>
         <item>@string/emulation_screen_layout_original</item>
+        <item>@string/emulation_screen_layout_custom</item>
     </string-array>
 
     <integer-array name="portraitLayoutValues">
         <item>0</item>
-        <item>1</item>
         <item>2</item>
+        <item>1</item>
     </integer-array>
 
     <string-array name="smallScreenPositions">

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -51,6 +51,7 @@ enum class PortraitLayoutOption : u32 {
     // formerly mobile portrait
     PortraitTopFullWidth,
     PortraitCustomLayout,
+    PortraitOriginal
 };
 
 /** Defines where the small screen will appear relative to the large screen

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -222,7 +222,8 @@ void EmuWindow::UpdateCurrentFramebufferLayout(u32 width, u32 height, bool is_po
                 width, height, Settings::values.swap_screen.GetValue(), is_portrait_mode);
             break;
         case Settings::PortraitLayoutOption::PortraitOriginal:
-            layout = Layout::PortraitOriginalLayout(width, height, Settings::values.swap_screen.GetValue());
+            layout = Layout::PortraitOriginalLayout(width, height,
+                                                    Settings::values.swap_screen.GetValue());
             break;
         }
     } else {

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -221,6 +221,9 @@ void EmuWindow::UpdateCurrentFramebufferLayout(u32 width, u32 height, bool is_po
             layout = Layout::CustomFrameLayout(
                 width, height, Settings::values.swap_screen.GetValue(), is_portrait_mode);
             break;
+        case Settings::PortraitLayoutOption::PortraitOriginal:
+            layout = Layout::PortraitOriginalLayout(width, height, Settings::values.swap_screen.GetValue());
+            break;
         }
     } else {
         switch (layout_option) {

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -359,7 +359,7 @@ FramebufferLayout CustomFrameLayout(u32 width, u32 height, bool is_swapped, bool
 
 FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondary,
                                                  bool is_portrait) {
-    int width, height;
+    u32 width, height;
     if (is_portrait) {
         auto layout_option = Settings::values.portrait_layout_option.GetValue();
         switch (layout_option) {
@@ -376,7 +376,7 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
                 Settings::values.swap_screen.GetValue(), is_portrait);
         case Settings::PortraitLayoutOption::PortraitTopFullWidth:
             width = Core::kScreenTopWidth * res_scale;
-            height = (Core::kScreenTopHeight + Core::kScreenBottomHeight * 1.25) * res_scale;
+            height = static_cast<int>(Core::kScreenTopHeight + Core::kScreenBottomHeight * 1.25) * res_scale;
             return PortraitTopFullFrameLayout(width, height,
                                               Settings::values.swap_screen.GetValue());
         case Settings::PortraitLayoutOption::PortraitOriginal:

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -61,7 +61,6 @@ FramebufferLayout PortraitOriginalLayout(u32 width, u32 height, bool swapped) {
     res.top_screen = res.top_screen.TranslateY(shiftY);
     res.bottom_screen = res.bottom_screen.TranslateY(shiftY);
     return res;
-
 }
 
 FramebufferLayout SingleFrameLayout(u32 width, u32 height, bool swapped, bool upright) {
@@ -376,7 +375,8 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
                 Settings::values.swap_screen.GetValue(), is_portrait);
         case Settings::PortraitLayoutOption::PortraitTopFullWidth:
             width = Core::kScreenTopWidth * res_scale;
-            height = static_cast<int>(Core::kScreenTopHeight + Core::kScreenBottomHeight * 1.25) * res_scale;
+            height = static_cast<int>(Core::kScreenTopHeight + Core::kScreenBottomHeight * 1.25) *
+                     res_scale;
             return PortraitTopFullFrameLayout(width, height,
                                               Settings::values.swap_screen.GetValue());
         case Settings::PortraitLayoutOption::PortraitOriginal:

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -51,6 +51,19 @@ FramebufferLayout PortraitTopFullFrameLayout(u32 width, u32 height, bool swapped
     return res;
 }
 
+FramebufferLayout PortraitOriginalLayout(u32 width, u32 height, bool swapped) {
+    ASSERT(width > 0);
+    ASSERT(height > 0);
+    const float scale_factor = 1;
+    FramebufferLayout res = LargeFrameLayout(width, height, swapped, false, scale_factor,
+                                             Settings::SmallScreenPosition::BelowLarge);
+    const int shiftY = -(int)(swapped ? res.bottom_screen.top : res.top_screen.top);
+    res.top_screen = res.top_screen.TranslateY(shiftY);
+    res.bottom_screen = res.bottom_screen.TranslateY(shiftY);
+    return res;
+
+}
+
 FramebufferLayout SingleFrameLayout(u32 width, u32 height, bool swapped, bool upright) {
     ASSERT(width > 0);
     ASSERT(height > 0);
@@ -363,9 +376,13 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
                 Settings::values.swap_screen.GetValue(), is_portrait);
         case Settings::PortraitLayoutOption::PortraitTopFullWidth:
             width = Core::kScreenTopWidth * res_scale;
-            height = (Core::kScreenTopHeight + Core::kScreenBottomHeight) * res_scale;
+            height = (Core::kScreenTopHeight + Core::kScreenBottomHeight * 1.25) * res_scale;
             return PortraitTopFullFrameLayout(width, height,
                                               Settings::values.swap_screen.GetValue());
+        case Settings::PortraitLayoutOption::PortraitOriginal:
+            width = Core::kScreenTopWidth * res_scale;
+            height = (Core::kScreenTopHeight + Core::kScreenBottomHeight) * res_scale;
+            return PortraitOriginalLayout(width, height, Settings::values.swap_screen.GetValue());
         }
     } else {
         auto layout_option = Settings::values.layout_option.GetValue();
@@ -497,6 +514,7 @@ FramebufferLayout GetCardboardSettings(const FramebufferLayout& layout) {
     if (is_portrait) {
         switch (Settings::values.portrait_layout_option.GetValue()) {
         case Settings::PortraitLayoutOption::PortraitTopFullWidth:
+        case Settings::PortraitLayoutOption::PortraitOriginal:
             cardboard_screen_width = top_screen_width;
             cardboard_screen_height = top_screen_height + bottom_screen_height;
             bottom_screen_left += (top_screen_width - bottom_screen_width) / 2;

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -1,4 +1,4 @@
-// Copyright 2016 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -62,14 +62,24 @@ FramebufferLayout reverseLayout(FramebufferLayout layout);
 FramebufferLayout DefaultFrameLayout(u32 width, u32 height, bool is_swapped, bool upright);
 
 /**
- * Factory method for constructing the mobile Full Width Top layout
- * Two screens at top, full width, no gap between them
+ * Factory method for constructing the mobile Full Width (Default) layout
+ * Two screens at top, full width (so different heights)
  * @param width Window framebuffer width in pixels
  * @param height Window framebuffer height in pixels
  * @param is_swapped if true, the bottom screen will be displayed above the top screen
  * @return Newly created FramebufferLayout object with mobile portrait screen regions initialized
  */
 FramebufferLayout PortraitTopFullFrameLayout(u32 width, u32 height, bool is_swapped);
+
+/**
+ * Factory method for constructing the mobile Original layout
+ * Two screens at top, equal heights
+ * @param width Window framebuffer width in pixels
+ * @param height Window framebuffer height in pixels
+ * @param is_swapped if true, the bottom screen will be displayed above the top screen
+ * @return Newly created FramebufferLayout object with mobile portrait screen regions initialized
+ */
+FramebufferLayout PortraitOriginalLayout(u32 width, u32 height, bool is_swapped);
 
 /**
  * Factory method for constructing a FramebufferLayout with only the top or bottom screen


### PR DESCRIPTION
This adds a new layout called Original on Portrait android that keeps the two screens at the same height rather than scaling them to the same width. This matches the Default layout on desktop and allows screens to line up more correctly (especially when combined with the Screen Gap option in a different PR)

![34314](https://github.com/user-attachments/assets/20e23106-c0dc-4520-ab81-61b10d3c5691)
