### PR TITLE
cmake: Add option `ENABLE_NATIVE_OPTIMIZATION`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ option(USE_DISCORD_PRESENCE "Enables Discord Rich Presence" OFF)
 # Compile options
 CMAKE_DEPENDENT_OPTION(COMPILE_WITH_DWARF "Add DWARF debugging information" ${IS_DEBUG_BUILD} "MINGW" OFF)
 option(ENABLE_LTO "Enable link time optimization" ${DEFAULT_ENABLE_LTO})
+option(ENABLE_NATIVE_OPTIMIZATION "Enables processor-specific optimizations via -march=native" OFF)
 option(CITRA_USE_PRECOMPILED_HEADERS "Use precompiled headers" ON)
 option(CITRA_WARNINGS_AS_ERRORS "Enable warnings as errors" ON)
 
@@ -144,6 +145,22 @@ if (ENABLE_LTO)
     endif()
 else()
     message(STATUS "LTO disabled")
+endif()
+
+# Check for march=native support
+# =======================================================================
+if (ENABLE_NATIVE_OPTIMIZATION)
+    include(CheckCCompilerFlag)
+    include(CheckCXXCompilerFlag)
+    CHECK_C_COMPILER_FLAG("-march=native" C_COMPILER_SUPPORTS_MARCH_NATIVE)
+    CHECK_CXX_COMPILER_FLAG("-march=native" CXX_COMPILER_SUPPORTS_MARCH_NATIVE)
+
+    if (C_COMPILER_SUPPORTS_MARCH_NATIVE)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=native")
+    endif()
+    if (CXX_COMPILER_SUPPORTS_MARCH_NATIVE)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+    endif()
 endif()
 
 # Sanity check : Check that all submodules are present


### PR DESCRIPTION
This new option enables aggressive processor-specific optimizations by setting -march=native in the C and C++ compile flags.

This option is disabled by default because the binaries compiled for one processor with this flag enabled may not run on another processor due to the aforementioned processor-specific optimizations, but if someone is only compiling for personal use, enabling this flag may result in very minor performance improvements at no cost.