### PR TITLE
Remove .3ds from valid file extension list on MacOS

### DIFF
--- a/dist/apple/Info.plist.in
+++ b/dist/apple/Info.plist.in
@@ -31,7 +31,6 @@
         <dict>
             <key>CFBundleTypeExtensions</key>
             <array>
-                <string>3ds</string>
                 <string>3dsx</string>
                 <string>cci</string>
                 <string>cxi</string>


### PR DESCRIPTION
I think this is the last mention of .3ds in the codebase (not counting outdated translations)