### PR TITLE
qt: Add update checker

### DIFF
--- a/.ci/linux.sh
+++ b/.ci/linux.sh
@@ -11,6 +11,10 @@ else
     export EXTRA_CMAKE_FLAGS=(-DCITRA_USE_PRECOMPILED_HEADERS=OFF)
 fi
 
+if [ "$GITHUB_REF_TYPE" == "tag" ]; then
+	export EXTRA_CMAKE_FLAGS=($EXTRA_CMAKE_FLAGS -DENABLE_QT_UPDATE_CHECKER=ON)
+fi
+
 mkdir build && cd build
 cmake .. -G Ninja \
     -DCMAKE_BUILD_TYPE=Release \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ option(USE_SYSTEM_SDL2 "Use the system SDL2 lib (instead of the bundled one)" OF
 # Set bundled qt as dependent options.
 option(ENABLE_QT "Enable the Qt frontend" ON)
 option(ENABLE_QT_TRANSLATION "Enable translations for the Qt frontend" OFF)
+option(ENABLE_QT_UPDATE_CHECKER "Enable built-in update checker for the Qt frontend" OFF)
 
 CMAKE_DEPENDENT_OPTION(ENABLE_TESTS "Enable generating tests executable" ON "NOT IOS" OFF)
 CMAKE_DEPENDENT_OPTION(ENABLE_ROOM "Enable generating dedicated room executable" ON "NOT ANDROID AND NOT IOS" OFF)

--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -198,6 +198,12 @@ file(GLOB COMPAT_LIST
 file(GLOB_RECURSE ICONS ${PROJECT_SOURCE_DIR}/dist/icons/*)
 file(GLOB_RECURSE THEMES ${PROJECT_SOURCE_DIR}/dist/qt_themes/*)
 
+if (ENABLE_QT_UPDATE_CHECKER)
+    target_link_libraries(citra_qt PRIVATE httplib json-headers)
+    target_sources(citra_qt PRIVATE update_checker.cpp)
+    target_compile_definitions(citra_qt PUBLIC ENABLE_QT_UPDATE_CHECKER)
+endif()
+
 if (ENABLE_QT_TRANSLATION)
     set(CITRA_QT_LANGUAGES "${PROJECT_SOURCE_DIR}/dist/languages" CACHE PATH "Path to the translation bundle for the Qt frontend")
     option(GENERATE_QT_TRANSLATION "Generate en.ts as the translation source file" OFF)

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -309,16 +309,19 @@ GMainWindow::GMainWindow(Core::System& system_)
     }
 
 #ifdef ENABLE_QT_UPDATE_CHECKER
-    const std::optional<std::string> latest_release = UpdateChecker::CheckForUpdate();
-    if (latest_release && latest_release.value() != Common::g_build_fullname) {
-        if (QMessageBox::information(
-                this, tr("Update Available"),
-                tr("Update %1 for Azahar is available.\nWould you like to download it?")
-                    .arg(QString::fromStdString(latest_release.value())),
-                QMessageBox::Yes | QMessageBox::Ignore) == QMessageBox::Yes) {
-            QDesktopServices::openUrl(QUrl(QString::fromStdString(
-                "https://github.com/azahar-emu/azahar/releases/tag/" + latest_release.value())));
-            exit(0);
+    if (UISettings::values.check_for_update_on_start) {
+        const std::optional<std::string> latest_release = UpdateChecker::CheckForUpdate();
+        if (latest_release && latest_release.value() != Common::g_build_fullname) {
+            if (QMessageBox::information(
+                    this, tr("Update Available"),
+                    tr("Update %1 for Azahar is available.\nWould you like to download it?")
+                        .arg(QString::fromStdString(latest_release.value())),
+                    QMessageBox::Yes | QMessageBox::Ignore) == QMessageBox::Yes) {
+                QDesktopServices::openUrl(QUrl(
+                    QString::fromStdString("https://github.com/azahar-emu/azahar/releases/tag/" +
+                                           latest_release.value())));
+                exit(0);
+            }
         }
     }
 #endif

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -69,6 +69,9 @@
 #include "citra_qt/play_time_manager.h"
 #include "citra_qt/qt_image_interface.h"
 #include "citra_qt/uisettings.h"
+#ifdef ENABLE_QT_UPDATE_CHECKER
+#include "citra_qt/update_checker.h"
+#endif
 #include "citra_qt/util/clickable_label.h"
 #include "citra_qt/util/graphics_device_info.h"
 #include "citra_qt/util/util.h"
@@ -304,6 +307,21 @@ GMainWindow::GMainWindow(Core::System& system_)
             continue;
         }
     }
+
+#ifdef ENABLE_QT_UPDATE_CHECKER
+    const std::optional<std::string> latest_release = UpdateChecker::CheckForUpdate();
+    if (latest_release && latest_release.value() != Common::g_build_fullname) {
+        if (QMessageBox::information(
+                this, tr("Update Available"),
+                tr("Update %1 for Azahar is available.\nWould you like to download it?")
+                    .arg(QString::fromStdString(latest_release.value())),
+                QMessageBox::Yes | QMessageBox::Ignore) == QMessageBox::Yes) {
+            QDesktopServices::openUrl(QUrl(QString::fromStdString(
+                "https://github.com/azahar-emu/azahar/releases/tag/" + latest_release.value())));
+            exit(0);
+        }
+    }
+#endif
 
 #ifdef __unix__
     SetGamemodeEnabled(Settings::values.enable_gamemode.GetValue());

--- a/src/citra_qt/citra_qt.h
+++ b/src/citra_qt/citra_qt.h
@@ -7,6 +7,13 @@
 #include <array>
 #include <memory>
 #include <vector>
+#ifdef __unix__
+#include <QDBusObjectPath>
+#endif
+#ifdef ENABLE_QT_UPDATE_CHECKER
+#include <QFuture>
+#include <QFutureWatcher>
+#endif
 #include <QMainWindow>
 #include <QPushButton>
 #include <QString>
@@ -17,10 +24,6 @@
 #include "citra_qt/user_data_migration.h"
 #include "core/core.h"
 #include "core/savestate.h"
-
-#ifdef __unix__
-#include <QDBusObjectPath>
-#endif
 
 // Needs to be included at the end due to https://bugreports.qt.io/browse/QTBUG-73263
 #include <filesystem>
@@ -290,6 +293,9 @@ private slots:
     void OnDecreaseVolume();
     void OnIncreaseVolume();
     void OnMute();
+#ifdef ENABLE_QT_UPDATE_CHECKER
+    void OnEmulatorUpdateAvailable();
+#endif
 
 private:
     Q_INVOKABLE void OnMoviePlaybackCompleted();
@@ -414,6 +420,12 @@ private:
     HotkeyRegistry hotkey_registry;
 
     std::shared_ptr<Camera::QtMultimediaCameraHandlerFactory> qt_cameras;
+
+    // Prompt shown when update check succeeds
+#ifdef ENABLE_QT_UPDATE_CHECKER
+    QFuture<QString> update_future;
+    QFutureWatcher<QString> update_watcher;
+#endif
 
 #ifdef __unix__
     QDBusObjectPath wake_lock{};

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -559,6 +559,7 @@ void QtConfig::ReadMiscellaneousValues() {
     ReadBasicSetting(Settings::values.log_filter);
     ReadBasicSetting(Settings::values.log_regex_filter);
     ReadBasicSetting(Settings::values.enable_gamemode);
+    ReadBasicSetting(UISettings::values.check_for_update_on_start);
 
     qt_config->endGroup();
 }
@@ -795,7 +796,6 @@ void QtConfig::ReadUIValues() {
         ReadBasicSetting(UISettings::values.enable_discord_presence);
         ReadBasicSetting(UISettings::values.screenshot_resolution_factor);
 
-        ReadUpdaterValues();
         ReadUILayoutValues();
         ReadUIGameListValues();
         ReadShortcutValues();
@@ -857,15 +857,6 @@ void QtConfig::ReadUILayoutValues() {
     UISettings::values.microprofile_geometry =
         ReadSetting(QStringLiteral("microProfileDialogGeometry")).toByteArray();
     ReadBasicSetting(UISettings::values.microprofile_visible);
-
-    qt_config->endGroup();
-}
-
-void QtConfig::ReadUpdaterValues() {
-    qt_config->beginGroup(QStringLiteral("Updater"));
-
-    ReadBasicSetting(UISettings::values.check_for_update_on_start);
-    ReadBasicSetting(UISettings::values.update_on_close);
 
     qt_config->endGroup();
 }
@@ -1123,6 +1114,7 @@ void QtConfig::SaveMiscellaneousValues() {
     WriteBasicSetting(Settings::values.log_filter);
     WriteBasicSetting(Settings::values.log_regex_filter);
     WriteBasicSetting(Settings::values.enable_gamemode);
+    WriteBasicSetting(UISettings::values.check_for_update_on_start);
 
     qt_config->endGroup();
 }
@@ -1310,7 +1302,6 @@ void QtConfig::SaveUIValues() {
         WriteBasicSetting(UISettings::values.enable_discord_presence);
         WriteBasicSetting(UISettings::values.screenshot_resolution_factor);
 
-        SaveUpdaterValues();
         SaveUILayoutValues();
         SaveUIGameListValues();
         SaveShortcutValues();
@@ -1370,15 +1361,6 @@ void QtConfig::SaveUILayoutValues() {
     WriteSetting(QStringLiteral("microProfileDialogGeometry"),
                  UISettings::values.microprofile_geometry);
     WriteBasicSetting(UISettings::values.microprofile_visible);
-
-    qt_config->endGroup();
-}
-
-void QtConfig::SaveUpdaterValues() {
-    qt_config->beginGroup(QStringLiteral("Updater"));
-
-    WriteBasicSetting(UISettings::values.check_for_update_on_start);
-    WriteBasicSetting(UISettings::values.update_on_close);
 
     qt_config->endGroup();
 }

--- a/src/citra_qt/configuration/config.h
+++ b/src/citra_qt/configuration/config.h
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Citra Emulator Project
+﻿// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -48,7 +48,6 @@ private:
     void ReadUIValues();
     void ReadUIGameListValues();
     void ReadUILayoutValues();
-    void ReadUpdaterValues();
     void ReadUtilityValues();
     void ReadWebServiceValues();
     void ReadVideoDumpingValues();
@@ -70,7 +69,6 @@ private:
     void SaveUIValues();
     void SaveUIGameListValues();
     void SaveUILayoutValues();
-    void SaveUpdaterValues();
     void SaveUtilityValues();
     void SaveWebServiceValues();
     void SaveVideoDumpingValues();

--- a/src/citra_qt/configuration/configure_general.cpp
+++ b/src/citra_qt/configuration/configure_general.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -35,9 +35,11 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
     ui->emulation_speed_display_label->setMinimumWidth(width);
     ui->emulation_speed_combo->setVisible(!Settings::IsConfiguringGlobal());
     ui->screenshot_combo->setVisible(!Settings::IsConfiguringGlobal());
-    ui->updateBox->setVisible(UISettings::values.updater_found);
 #ifndef __unix__
     ui->toggle_gamemode->setVisible(false);
+#endif
+#ifndef ENABLE_QT_UPDATE_CHECKER
+    ui->toggle_update_checker->setVisible(false);
 #endif
 
     SetupPerGameUI();
@@ -77,10 +79,8 @@ void ConfigureGeneral::SetConfiguration() {
         ui->toggle_background_mute->setChecked(
             UISettings::values.mute_when_in_background.GetValue());
         ui->toggle_hide_mouse->setChecked(UISettings::values.hide_mouse.GetValue());
-
-        ui->toggle_update_check->setChecked(
+        ui->toggle_update_checker->setChecked(
             UISettings::values.check_for_update_on_start.GetValue());
-        ui->toggle_auto_update->setChecked(UISettings::values.update_on_close.GetValue());
 #ifdef __unix__
         ui->toggle_gamemode->setChecked(Settings::values.enable_gamemode.GetValue());
 #endif
@@ -178,9 +178,7 @@ void ConfigureGeneral::ApplyConfiguration() {
         UISettings::values.pause_when_in_background = ui->toggle_background_pause->isChecked();
         UISettings::values.mute_when_in_background = ui->toggle_background_mute->isChecked();
         UISettings::values.hide_mouse = ui->toggle_hide_mouse->isChecked();
-
-        UISettings::values.check_for_update_on_start = ui->toggle_update_check->isChecked();
-        UISettings::values.update_on_close = ui->toggle_auto_update->isChecked();
+        UISettings::values.check_for_update_on_start = ui->toggle_update_checker->isChecked();
 #ifdef __unix__
         Settings::values.enable_gamemode = ui->toggle_gamemode->isChecked();
 #endif
@@ -211,9 +209,9 @@ void ConfigureGeneral::SetupPerGameUI() {
     });
 
     ui->general_group->setVisible(false);
-    ui->updateBox->setVisible(false);
     ui->button_reset_defaults->setVisible(false);
     ui->toggle_gamemode->setVisible(false);
+    ui->toggle_update_checker->setVisible(false);
 
     ConfigurationShared::SetColoredComboBox(
         ui->region_combobox, ui->widget_region,

--- a/src/citra_qt/configuration/configure_general.ui
+++ b/src/citra_qt/configuration/configure_general.ui
@@ -57,26 +57,10 @@
           </property>
          </widget>
         </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="updateBox">
-       <property name="title">
-        <string>Updates</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_4">
         <item>
-         <widget class="QCheckBox" name="toggle_update_check">
+         <widget class="QCheckBox" name="toggle_update_checker">
           <property name="text">
-           <string>Check for updates on start</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="toggle_auto_update">
-          <property name="text">
-           <string>Silently auto update after closing</string>
+           <string>Check for updates</string>
           </property>
          </widget>
         </item>
@@ -324,8 +308,7 @@
   <tabstop>toggle_check_exit</tabstop>
   <tabstop>toggle_background_pause</tabstop>
   <tabstop>toggle_hide_mouse</tabstop>
-  <tabstop>toggle_update_check</tabstop>
-  <tabstop>toggle_auto_update</tabstop>
+  <tabstop>toggle_update_checker</tabstop>
   <tabstop>button_reset_defaults</tabstop>
  </tabstops>
  <resources/>

--- a/src/citra_qt/uisettings.h
+++ b/src/citra_qt/uisettings.h
@@ -1,4 +1,4 @@
-// Copyright 2016 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -82,9 +82,6 @@ struct Values {
     Settings::Setting<bool> pause_when_in_background{false, "pauseWhenInBackground"};
     Settings::Setting<bool> mute_when_in_background{false, "muteWhenInBackground"};
     Settings::Setting<bool> hide_mouse{false, "hideInactiveMouse"};
-
-    bool updater_found;
-    Settings::Setting<bool> update_on_close{false, "update_on_close"};
     Settings::Setting<bool> check_for_update_on_start{true, "check_for_update_on_start"};
 
     // Discord RPC

--- a/src/citra_qt/update_checker.cpp
+++ b/src/citra_qt/update_checker.cpp
@@ -12,8 +12,13 @@
 std::optional<std::string> UpdateChecker::CheckForUpdate() {
     constexpr auto UPDATE_CHECK_URL = "http://api.github.com";
     constexpr auto UPDATE_CHECK_PATH = "/repos/azahar-emu/azahar/releases/latest";
+    constexpr std::size_t UPDATE_CHECK_TIMEOUT_SECONDS = 15;
 
     std::unique_ptr<httplib::Client> client = std::make_unique<httplib::Client>(UPDATE_CHECK_URL);
+    client->set_connection_timeout(UPDATE_CHECK_TIMEOUT_SECONDS);
+    client->set_read_timeout(UPDATE_CHECK_TIMEOUT_SECONDS);
+    client->set_write_timeout(UPDATE_CHECK_TIMEOUT_SECONDS);
+
     if (client == nullptr) {
         LOG_ERROR(Frontend, "Invalid URL {}{}", UPDATE_CHECK_URL, UPDATE_CHECK_PATH);
         return {};

--- a/src/citra_qt/update_checker.cpp
+++ b/src/citra_qt/update_checker.cpp
@@ -1,0 +1,50 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <optional>
+#include <string>
+#include <httplib.h>
+#include <json.hpp>
+#include "common/logging/log.h"
+#include "update_checker.h"
+
+std::optional<std::string> UpdateChecker::CheckForUpdate() {
+    constexpr auto UPDATE_CHECK_URL = "http://api.github.com";
+    constexpr auto UPDATE_CHECK_PATH = "/repos/azahar-emu/azahar/releases/latest";
+
+    std::unique_ptr<httplib::Client> client = std::make_unique<httplib::Client>(UPDATE_CHECK_URL);
+    if (client == nullptr) {
+        LOG_ERROR(Frontend, "Invalid URL {}{}", UPDATE_CHECK_URL, UPDATE_CHECK_PATH);
+        return {};
+    }
+
+    httplib::Request request{
+        .method = "GET",
+        .path = UPDATE_CHECK_PATH,
+    };
+
+    client->set_follow_location(true);
+    const auto result = client->send(request);
+    if (!result) {
+        LOG_ERROR(Frontend, "GET to {}{} returned null", UPDATE_CHECK_URL, UPDATE_CHECK_PATH);
+        return {};
+    }
+
+    const auto& response = result.value();
+    if (response.status >= 400) {
+        LOG_ERROR(Frontend, "GET to {}{} returned error status code: {}", UPDATE_CHECK_URL,
+                  UPDATE_CHECK_PATH, response.status);
+        return {};
+    }
+    if (!response.headers.contains("content-type")) {
+        LOG_ERROR(Frontend, "GET to {}{} returned no content", UPDATE_CHECK_URL, UPDATE_CHECK_PATH);
+        return {};
+    }
+
+    try {
+        return nlohmann::json::parse(response.body).at("tag_name");
+    } catch (nlohmann::detail::out_of_range&) {
+        return {};
+    }
+}

--- a/src/citra_qt/update_checker.h
+++ b/src/citra_qt/update_checker.h
@@ -1,0 +1,12 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace UpdateChecker {
+std::optional<std::string> CheckForUpdate();
+}


### PR DESCRIPTION
Closes #635 

This PR adds an update checker which runs whenever the Qt frontend is opened.

If an update is available, the following interface is displayed:

![Azahar update prompt](https://github.com/user-attachments/assets/4c06fe63-e3bc-4c48-9db9-2f70e70a31a3)

If the user accepts the prompt, the emulator is not opened, and instead the URL to download the latest update is opened in the user's default web browser.

If the user ignores the update, the emulator is opened as usual.

---

I have tested this PR using releases generated from my fork. It works as expected when using an outdated version, as well as when using the most up-to-date version.

Additionally, I have tested this code under a situation with no internet connection, and under a circumstance where the non-error GitHub API response doesn't contain `tag_name` (which should never happen, but good to check anyway). It handles all of these circumstances without any user-facing error, and logs information as required.

---

To do before review:
- [x] Allow users to disable update checks from the settings
- [x] Enable `ENABLE_QT_UPDATE_CHECKER` for releases