### PR TITLE
Add cmake option to enable microprofile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,8 @@ option(ENABLE_VULKAN "Enables the Vulkan renderer" ON)
 
 option(USE_DISCORD_PRESENCE "Enables Discord Rich Presence" OFF)
 
+option(ENABLE_MICROPROFILE "Enables microprofile capabilities" OFF)
+
 # Compile options
 CMAKE_DEPENDENT_OPTION(COMPILE_WITH_DWARF "Add DWARF debugging information" ${IS_DEBUG_BUILD} "MINGW" OFF)
 option(ENABLE_LTO "Enable link time optimization" ${DEFAULT_ENABLE_LTO})

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -138,6 +138,11 @@ endif()
 # MicroProfile
 add_library(microprofile INTERFACE)
 target_include_directories(microprofile SYSTEM INTERFACE ./microprofile)
+if (ENABLE_MICROPROFILE)
+    target_compile_definitions(microprofile INTERFACE MICROPROFILE_ENABLED=1)
+else()
+    target_compile_definitions(microprofile INTERFACE MICROPROFILE_ENABLED=0)
+endif()
 
 # Nihstro
 add_library(nihstro-headers INTERFACE)

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -590,6 +590,11 @@ void GMainWindow::InitializeDebugWidgets() {
     microProfileDialog = new MicroProfileDialog(this);
     microProfileDialog->hide();
     debug_menu->addAction(microProfileDialog->toggleViewAction());
+#else
+    auto micro_profile_stub = new QAction(tr("MicroProfile (unavailable)"), this);
+    micro_profile_stub->setEnabled(false);
+    micro_profile_stub->setChecked(false);
+    debug_menu->addAction(micro_profile_stub);
 #endif
 
     registersWidget = new RegistersWidget(system, this);
@@ -3851,8 +3856,11 @@ static Qt::HighDpiScaleFactorRoundingPolicy GetHighDpiRoundingPolicy() {
 
 void LaunchQtFrontend(int argc, char* argv[]) {
     Common::DetachedTasks detached_tasks;
+
+#if MICROPROFILE_ENABLED
     MicroProfileOnThreadCreate("Frontend");
     SCOPE_EXIT({ MicroProfileShutdown(); });
+#endif
 
     // Init settings params
     QCoreApplication::setOrganizationName(QStringLiteral("Azahar Developers"));

--- a/src/citra_qt/citra_qt.h
+++ b/src/citra_qt/citra_qt.h
@@ -42,7 +42,9 @@ class GRenderWindow;
 class IPCRecorderWidget;
 class LLEServiceModulesWidget;
 class LoadingScreen;
+#if MICROPROFILE_ENABLED
 class MicroProfileDialog;
+#endif
 class MultiplayerState;
 class ProfilerWidget;
 class QFileOpenEvent;
@@ -383,7 +385,9 @@ private:
 
     // Debugger panes
     ProfilerWidget* profilerWidget;
+#if MICROPROFILE_ENABLED
     MicroProfileDialog* microProfileDialog;
+#endif
     RegistersWidget* registersWidget;
     GPUCommandStreamWidget* graphicsWidget;
     GPUCommandListWidget* graphicsCommandsWidget;

--- a/src/citra_qt/debugger/profiler.cpp
+++ b/src/citra_qt/debugger/profiler.cpp
@@ -1,6 +1,8 @@
-// Copyright 2015 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
+
+#if MICROPROFILE_ENABLED
 
 #include <QAction>
 #include <QLayout>
@@ -15,7 +17,7 @@
 
 // Include the implementation of the UI in this file. This isn't in microprofile.cpp because the
 // non-Qt frontends don't need it (and don't implement the UI drawing hooks either).
-#if MICROPROFILE_ENABLED
+
 #define MICROPROFILEUI_IMPL 1
 #include "common/microprofileui.h"
 
@@ -44,16 +46,12 @@ private:
     qreal x_scale = 1.0, y_scale = 1.0;
 };
 
-#endif
-
 MicroProfileDialog::MicroProfileDialog(QWidget* parent) : QWidget(parent, Qt::Dialog) {
     setObjectName(QStringLiteral("MicroProfile"));
     setWindowTitle(tr("MicroProfile"));
     resize(1000, 600);
     // Enable the maximize button
     setWindowFlags(windowFlags() | Qt::WindowMaximizeButtonHint);
-
-#if MICROPROFILE_ENABLED
 
     MicroProfileWidget* widget = new MicroProfileWidget(this);
 
@@ -67,7 +65,6 @@ MicroProfileDialog::MicroProfileDialog(QWidget* parent) : QWidget(parent, Qt::Di
     setFocusProxy(widget);
     widget->setFocusPolicy(Qt::StrongFocus);
     widget->setFocus();
-#endif
 }
 
 QAction* MicroProfileDialog::toggleViewAction() {
@@ -94,8 +91,6 @@ void MicroProfileDialog::hideEvent(QHideEvent* event) {
     }
     QWidget::hideEvent(event);
 }
-
-#if MICROPROFILE_ENABLED
 
 /// There's no way to pass a user pointer to MicroProfile, so this variable is used to make the
 /// QPainter available inside the drawing callbacks.

--- a/src/citra_qt/debugger/profiler.h
+++ b/src/citra_qt/debugger/profiler.h
@@ -1,8 +1,10 @@
-// Copyright 2015 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
 #pragma once
+
+#if MICROPROFILE_ENABLED
 
 #include <QWidget>
 #include "common/common_types.h"
@@ -24,3 +26,5 @@ protected:
 private:
     QAction* toggle_view_action = nullptr;
 };
+
+#endif

--- a/src/video_core/renderer_opengl/gl_resource_manager.h
+++ b/src/video_core/renderer_opengl/gl_resource_manager.h
@@ -1,10 +1,11 @@
-// Copyright 2022 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
 #pragma once
 
 #include <span>
+#include <string_view>
 #include <utility>
 #include <vector>
 #include <glad/glad.h>


### PR DESCRIPTION
Disables microprofile by default, saving a bit of RAM. Add a cmake compile time define instead.