### PR TITLE
Enable decryption on DLP sysmodule

### DIFF
--- a/src/common/hacks/hack_list.cpp
+++ b/src/common/hacks/hack_list.cpp
@@ -67,6 +67,9 @@ HackManager hack_manager = {
                      0x0004013000002C02, // Normal
                      0x0004013000002C03, // Safe mode
                      0x0004013020002C03, // New 3DS safe mode
+
+                     // DLP
+                     0x0004013000002802,
                  },
          }},
 


### PR DESCRIPTION
DLP sends encrypted CIAs over the network which the target console installs in order to work. This used to work on Citra, but with the new decrcyption limitation it has broken. Add the DLP sysmodule to the hacks list of allowed programs for decryption to fix the issue.

Untested, but I'm pretty sure it should work

Fixes #663