### PR TITLE
NSIS installer: Clean up Windows Start Menu entry

### DIFF
--- a/src/installer/citra.nsi
+++ b/src/installer/citra.nsi
@@ -160,20 +160,13 @@ Section "Base"
   !insertmacro UPDATE_DISPLAYNAME
 
   ; Create start menu and desktop shortcuts
-  ; This needs to be done after azahar.exe is copied
-  CreateDirectory "$SMPROGRAMS\${PRODUCT_NAME}"
-  CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\$DisplayName.lnk" "$INSTDIR\azahar.exe"
+  CreateShortCut "$SMPROGRAMS\$DisplayName.lnk" "$INSTDIR\azahar.exe"
   ${If} $DesktopShortcut == 1
     CreateShortCut "$DESKTOP\$DisplayName.lnk" "$INSTDIR\azahar.exe"
   ${EndIf}
 
   ; ??
   SetOutPath "$TEMP"
-SectionEnd
-
-Section -AdditionalIcons
-  ; Create start menu shortcut for the uninstaller
-  CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\Uninstall $DisplayName.lnk" "$INSTDIR\uninst.exe" "/$MultiUser.InstallMode"
 SectionEnd
 
 !include "FileFunc.nsh"
@@ -200,11 +193,8 @@ SectionEnd
 Section Uninstall
   !insertmacro UPDATE_DISPLAYNAME
 
-  Delete "$SMPROGRAMS\${PRODUCT_NAME}\Uninstall $DisplayName.lnk"
-
   Delete "$DESKTOP\$DisplayName.lnk"
-  Delete "$SMPROGRAMS\${PRODUCT_NAME}\$DisplayName.lnk"
-  RMDir "$SMPROGRAMS\${PRODUCT_NAME}"
+  Delete "$SMPROGRAMS\$DisplayName.lnk"
 
   ; Be a bit careful to not delete files a user may have put into the install directory.
   Delete "$INSTDIR\*.dll"

--- a/src/installer/citra.nsi
+++ b/src/installer/citra.nsi
@@ -160,6 +160,9 @@ Section "Base"
   !insertmacro UPDATE_DISPLAYNAME
 
   ; Create start menu and desktop shortcuts
+  Delete "$SMPROGRAMS\${PRODUCT_NAME}\$DisplayName.lnk"
+  Delete "$SMPROGRAMS\${PRODUCT_NAME}\Uninstall $DisplayName.lnk"
+  RMDir "$SMPROGRAMS\${PRODUCT_NAME}"
   CreateShortCut "$SMPROGRAMS\$DisplayName.lnk" "$INSTDIR\azahar.exe"
   ${If} $DesktopShortcut == 1
     CreateShortCut "$DESKTOP\$DisplayName.lnk" "$INSTDIR\azahar.exe"
@@ -195,6 +198,10 @@ Section Uninstall
 
   Delete "$DESKTOP\$DisplayName.lnk"
   Delete "$SMPROGRAMS\$DisplayName.lnk"
+
+  Delete "$SMPROGRAMS\${PRODUCT_NAME}\$DisplayName.lnk"
+  Delete "$SMPROGRAMS\${PRODUCT_NAME}\Uninstall $DisplayName.lnk"
+  RMDir "$SMPROGRAMS\${PRODUCT_NAME}"
 
   ; Be a bit careful to not delete files a user may have put into the install directory.
   Delete "$INSTDIR\*.dll"


### PR DESCRIPTION
Cleans up the Windows Start Menu entry by removing the uninstall shortcut (which is ignored and no longer created since at least W10) and by removing the program folder, creating the shortcut directly in the Start Menu. This follows more modern conventions and makes the appearance cleaner (removes the step of needing to expand a folder each time in W10).

UX/UI change in the installer .nsi. File could potentially need some further updates and cleanups, can look at it more in depth later.