### PR TITLE
Add support for uninitialized movable

### DIFF
--- a/src/core/hw/unique_data.h
+++ b/src/core/hw/unique_data.h
@@ -66,7 +66,10 @@ struct MovableSed {
     static constexpr std::array<u8, 0x4> seed_magic{0x53, 0x45, 0x45, 0x44};
 
     std::array<u8, 0x4> magic;
-    u32 seed_info;
+    u8 unk0;
+    u8 is_full;
+    u8 unk1;
+    u8 unk2;
     LocalFriendCodeSeedB lfcs;
     std::array<u8, 0x8> key_y;
 
@@ -79,6 +82,10 @@ struct MovableSed {
     }
 
     bool VerifySignature() const;
+
+    bool IsFull() {
+        return is_full != 0;
+    }
 };
 static_assert(sizeof(MovableSed) == 0x120);
 
@@ -100,6 +107,14 @@ struct MovableSedFull {
     bool VerifySignature() const {
         // TODO(PabloMK7): Implement AES MAC verification
         return body.sed.VerifySignature();
+    }
+
+    bool IsFull() {
+        return body.sed.IsFull();
+    }
+
+    size_t GetRealSize() {
+        return IsFull() ? sizeof(MovableSedFull) : sizeof(MovableSed);
     }
 };
 static_assert(sizeof(MovableSedFull) == 0x140);


### PR DESCRIPTION
Adds support for 0x120 bytes movables.

Fixes #681 