### PR TITLE
Fix VS uniform fields type declaration

### DIFF
--- a/src/video_core/rasterizer_accelerated.cpp
+++ b/src/video_core/rasterizer_accelerated.cpp
@@ -850,7 +850,7 @@ void RasterizerAccelerated::SyncClipPlane() {
     const auto raw_clip_coef = regs.rasterizer.GetClipCoef();
     const Common::Vec4f new_clip_coef = {raw_clip_coef.x.ToFloat32(), raw_clip_coef.y.ToFloat32(),
                                          raw_clip_coef.z.ToFloat32(), raw_clip_coef.w.ToFloat32()};
-    if (enable_clip1 != vs_uniform_block_data.data.enable_clip1 ||
+    if (enable_clip1 != (vs_uniform_block_data.data.enable_clip1 != 0) ||
         new_clip_coef != vs_uniform_block_data.data.clip_coef) {
         vs_uniform_block_data.data.enable_clip1 = enable_clip1;
         vs_uniform_block_data.data.clip_coef = new_clip_coef;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -411,7 +411,7 @@ bool RasterizerOpenGL::Draw(bool accelerate, bool is_indexed) {
 
     // If the framebuffer is flipped, request vertex shader to flip vertex y
     const bool is_flipped = regs.framebuffer.framebuffer.IsFlipped();
-    vs_uniform_block_data.dirty |= vs_uniform_block_data.data.flip_viewport != is_flipped;
+    vs_uniform_block_data.dirty |= (vs_uniform_block_data.data.flip_viewport != 0) != is_flipped;
     vs_uniform_block_data.data.flip_viewport = is_flipped;
     state.cull.mode = is_flipped && state.cull.enabled ? GL_FRONT : GL_BACK;
 

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -511,7 +511,7 @@ bool RasterizerVulkan::Draw(bool accelerate, bool is_indexed) {
 
     // If the framebuffer is flipped, request to also flip vulkan viewport
     const bool is_flipped = regs.framebuffer.framebuffer.IsFlipped();
-    vs_uniform_block_data.dirty |= vs_uniform_block_data.data.flip_viewport != is_flipped;
+    vs_uniform_block_data.dirty |= (vs_uniform_block_data.data.flip_viewport != 0) != is_flipped;
     vs_uniform_block_data.data.flip_viewport = is_flipped;
     pipeline_info.rasterization.flip_viewport.Assign(is_flipped);
 

--- a/src/video_core/shader/generator/shader_uniforms.h
+++ b/src/video_core/shader/generator/shader_uniforms.h
@@ -86,8 +86,8 @@ struct PicaUniformsData {
 };
 
 struct VSUniformData {
-    alignas(4) bool enable_clip1;
-    alignas(4) bool flip_viewport;
+    u32 enable_clip1;
+    u32 flip_viewport;
     alignas(16) Common::Vec4f clip_coef;
 };
 static_assert(sizeof(VSUniformData) == 32,


### PR DESCRIPTION
The VS uniform field definition is a bool in C, which is 1 byte, but on shaders this is 4 bytes. When setting the bool in C the lower byte is the only changed, leaving the other 3 as garbage.