### PR TITLE
Bump CMake MacOS compilation target to MacOS 13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,8 @@ if (APPLE)
         set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)
         set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)
     else()
-        # Minimum macOS 11
-        set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0")
+        # Minimum macOS 13
+        set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0")
     endif()
 endif()
 


### PR DESCRIPTION
The minimum required MacOS version was already documented as MacOS 13, but until now the compilation target was set to MacOS 11.

This may allow the compiler to introduce additional micro-optimizations or something? Not really sure what this done on a low level. Regardless, this probably can't hurt.

Was originally going to include this in 2120, but was unable to due to build failures caused by an outdated dependency of dynarmic, however now that dynarmic's dependencies have been updated in 2120-rc2, this change can now be evaluated for 2121.

Will self-review this as I have access to the necessary hardware.