### PR TITLE
Fix bug where log file was not generated on first run

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -210,7 +210,7 @@ public:
         }
         initialization_in_progress_suppress_logging = true;
         const auto& log_dir = FileUtil::GetUserPath(FileUtil::UserPath::LogDir);
-        void(FileUtil::CreateDir(log_dir));
+        void(FileUtil::CreateFullPath(log_dir));
         Filter filter;
         filter.ParseFilterString(Settings::values.log_filter.GetValue());
         instance = std::unique_ptr<Impl, decltype(&Deleter)>(


### PR DESCRIPTION
This fix resolves issue #727.
    
On first start, `Log::Initialize` attempts to create the `azahar-emu/log/` directory. However, it fails because `azahar-emu/` does not exist. Using `FileUtil::CreateFullPath` instead will create both `azahar-emu/` and `log/`.
