### PR TITLE
gradle: Change applicationId to "io.github.azahar.android"

### DIFF
--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -62,7 +62,7 @@ android {
     defaultConfig {
         // The application ID refers to Lime3DS to allow for
         // the Play Store listing, which was originally set up for Lime3DS, to still be used.
-        applicationId = "io.github.lime3ds.android"
+        applicationId = "io.github.azahar.android"
         minSdk = 28
         targetSdk = 35
         versionCode = autoVersion


### PR DESCRIPTION
This will allow to co-install the package next to the old Lime3DS package. However, it is untested what the impact is when migrating games, saves or app settings.