### PR TITLE
video_core: Fixed emulation window artefacts on OpenGL + Wayland

### DIFF
--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -307,7 +307,7 @@ void RendererOpenGL::FillScreen(Common::Vec3<u8> color, TextureInfo& texture) {
  */
 void RendererOpenGL::InitOpenGLObjects() {
     glClearColor(Settings::values.bg_red.GetValue(), Settings::values.bg_green.GetValue(),
-                 Settings::values.bg_blue.GetValue(), 0.0f);
+                 Settings::values.bg_blue.GetValue(), 1.0f);
 
     for (std::size_t i = 0; i < samplers.size(); i++) {
         samplers[i].Create();
@@ -637,7 +637,7 @@ void RendererOpenGL::DrawScreens(const Layout::FramebufferLayout& layout, bool f
     if (settings.bg_color_update_requested.exchange(false)) {
         // Update background color before drawing
         glClearColor(Settings::values.bg_red.GetValue(), Settings::values.bg_green.GetValue(),
-                     Settings::values.bg_blue.GetValue(), 0.0f);
+                     Settings::values.bg_blue.GetValue(), 1.0f);
     }
 
     if (settings.shader_update_requested.exchange(false)) {


### PR DESCRIPTION
This pull request fixes an issue where anything that passed over the portion of the emulation window not occupied by the 3DS screens would leave visual artefacts behind:

<img src=https://github.com/user-attachments/assets/13625d48-6ad8-4f6b-b45a-4dc7def5fd78 width=500px />

This PR fixes this by changing the opacity of two `glClearColor` calls from `0.0` to `1.0`. 

On most platforms this value is seemingly ignored and it is displayed as if it was set to `1.0`, but on Wayland it respects the value and causes this issue. I'm not sure why they were originally set to that value, there seems to be no benefit to doing so, especially considering that the background colours are set up in the same call, which would be invisible if this was working correctly.