### PR TITLE
Show warning that 3ds files are no longer supported

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/GamesFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/GamesFragment.kt
@@ -1,4 +1,4 @@
-// Copyright Citra Emulator Project / Lime3DS Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -6,10 +6,12 @@ package org.citra.citra_emu.fragments
 
 import android.annotation.SuppressLint
 import android.os.Bundle
+import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.MarginLayoutParams
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -22,6 +24,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.GridLayoutManager
 import com.google.android.material.color.MaterialColors
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.transition.MaterialFadeThrough
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -33,6 +36,8 @@ import org.citra.citra_emu.features.settings.model.Settings
 import org.citra.citra_emu.model.Game
 import org.citra.citra_emu.viewmodel.GamesViewModel
 import org.citra.citra_emu.viewmodel.HomeViewModel
+import androidx.core.content.edit
+import androidx.core.text.HtmlCompat
 
 class GamesFragment : Fragment() {
     private var _binding: FragmentGamesBinding? = null
@@ -40,6 +45,7 @@ class GamesFragment : Fragment() {
 
     private val gamesViewModel: GamesViewModel by activityViewModels()
     private val homeViewModel: HomeViewModel by activityViewModels()
+    private var show3DSFileWarning: Boolean = true
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -141,6 +147,34 @@ class GamesFragment : Fragment() {
         }
 
         setInsets()
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        if (show3DSFileWarning &&
+            !PreferenceManager.getDefaultSharedPreferences(CitraApplication.appContext)
+                .getBoolean("show_3ds_files_warning", false)) {
+            val message = HtmlCompat.fromHtml(getString(R.string.warning_3ds_files),
+                HtmlCompat.FROM_HTML_MODE_LEGACY)
+
+            context?.let {
+                val alert = MaterialAlertDialogBuilder(it)
+                    .setTitle(getString(R.string.important))
+                    .setMessage(message)
+                    .setPositiveButton(R.string.dont_show_again) { _, _ ->
+                        PreferenceManager.getDefaultSharedPreferences(CitraApplication.appContext)
+                            .edit() {
+                            putBoolean("show_3ds_files_warning", true)
+                        }
+                    }
+                    .show()
+
+                val alertMessage = alert.findViewById<View>(android.R.id.message) as TextView
+                alertMessage.movementMethod = LinkMovementMethod.getInstance()
+            }
+        }
+        show3DSFileWarning = false
     }
 
     override fun onDestroyView() {

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
     <string name="app_game_install_description">Next, you will need to select an Applications Folder. Azahar will display all of the 3DS ROMs inside of the selected folder in the app.\n\nCIA ROMs, updates and DLC will need to be installed separately by clicking on the folder icon and selecting Install CIA.</string>
     <string name="start">Start</string>
     <string name="cancelling">Cancelling…</string>
+    <string name="important">Important</string>
+    <string name="dont_show_again">Don\'t show again</string>
 
     <!-- Home Strings -->
     <string name="grid_menu_core_settings">Settings</string>
@@ -38,6 +40,7 @@
     <string name="select_citra_user_folder_home_description">Changes the files that Azahar uses to load applications</string>
     <string name="theme_and_color_description">Modify the look of the app</string>
     <string name="install_cia_title">Install CIA</string>
+    <string name="warning_3ds_files">Encrypted files and .3ds files are no longer supported. Decrypting and/or renaming to .cci may be necessary. &lt;a href=\"https://azahar-emu.org/blog/game-loading-changes/\">Learn more.&lt;/a></string>
 
     <!-- GPU driver installation -->
     <string name="select_gpu_driver">Select GPU driver</string>

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -828,6 +828,7 @@ void QtConfig::ReadUIGameListValues() {
     ReadBasicSetting(UISettings::values.game_list_row_2);
     ReadBasicSetting(UISettings::values.game_list_hide_no_icon);
     ReadBasicSetting(UISettings::values.game_list_single_line_mode);
+    ReadBasicSetting(UISettings::values.show_3ds_files_warning);
 
     ReadBasicSetting(UISettings::values.show_compat_column);
     ReadBasicSetting(UISettings::values.show_region_column);
@@ -1335,6 +1336,7 @@ void QtConfig::SaveUIGameListValues() {
     WriteBasicSetting(UISettings::values.game_list_row_2);
     WriteBasicSetting(UISettings::values.game_list_hide_no_icon);
     WriteBasicSetting(UISettings::values.game_list_single_line_mode);
+    WriteBasicSetting(UISettings::values.show_3ds_files_warning);
 
     WriteBasicSetting(UISettings::values.show_compat_column);
     WriteBasicSetting(UISettings::values.show_region_column);

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -350,6 +350,41 @@ GameList::GameList(PlayTime::PlayTimeManager& play_time_manager_, GMainWindow* p
 
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);
+
+    if (UISettings::values.show_3ds_files_warning.GetValue()) {
+
+        warning_layout = new QHBoxLayout;
+        deprecated_3ds_warning = new QLabel;
+        deprecated_3ds_warning->setText(
+            tr("IMPORTANT: Encrypted files and .3ds files are no longer supported. Decrypting "
+               "and/or renaming to .cci may be necessary. <a "
+               "href=\"https://azahar-emu.org/blog/game-loading-changes/\">Learn more.</a>"));
+        deprecated_3ds_warning->setOpenExternalLinks(true);
+        deprecated_3ds_warning->setStyleSheet(
+            QString::fromStdString("color: black; font-weight: bold;"));
+
+        warning_hide = new QPushButton(tr("Don't show again"));
+        warning_hide->setStyleSheet(
+            QString::fromStdString("color: blue; text-decoration: underline;"));
+        warning_hide->setFlat(true);
+        warning_hide->setCursor(Qt::PointingHandCursor);
+
+        connect(warning_hide, &QPushButton::clicked, [this]() {
+            warning_widget->setVisible(false);
+            UISettings::values.show_3ds_files_warning.SetValue(false);
+        });
+
+        warning_layout->addWidget(deprecated_3ds_warning);
+        warning_layout->addStretch();
+        warning_layout->addWidget(warning_hide);
+        warning_layout->setContentsMargins(3, 3, 3, 3);
+        warning_widget = new QWidget;
+        warning_widget->setStyleSheet(QString::fromStdString("background-color: khaki;"));
+        warning_widget->setLayout(warning_layout);
+
+        layout->addWidget(warning_widget);
+    }
+
     layout->addWidget(tree_view);
     layout->addWidget(search_field);
     setLayout(layout);

--- a/src/citra_qt/game_list.h
+++ b/src/citra_qt/game_list.h
@@ -1,10 +1,11 @@
-// Copyright 2015 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
 #pragma once
 
 #include <QMenu>
+#include <QPushButton>
 #include <QString>
 #include <QVector>
 #include <QWidget>
@@ -133,6 +134,10 @@ private:
     void changeEvent(QEvent*) override;
     void RetranslateUI();
 
+    QHBoxLayout* warning_layout = nullptr;
+    QWidget* warning_widget = nullptr;
+    QLabel* deprecated_3ds_warning = nullptr;
+    QPushButton* warning_hide = nullptr;
     GameListSearchField* search_field;
     GMainWindow* main_window = nullptr;
     QVBoxLayout* layout = nullptr;

--- a/src/citra_qt/uisettings.h
+++ b/src/citra_qt/uisettings.h
@@ -94,6 +94,7 @@ struct Values {
     Settings::Setting<GameListText> game_list_row_2{GameListText::FileName, "row2"};
     Settings::Setting<bool> game_list_hide_no_icon{false, "hideNoIcon"};
     Settings::Setting<bool> game_list_single_line_mode{false, "singleLineMode"};
+    Settings::Setting<bool> show_3ds_files_warning{true, "show_3ds_files_warning"};
 
     // Compatibility List
     Settings::Setting<bool> show_compat_column{true, "show_compat_column"};


### PR DESCRIPTION
A warning in QT and Android is shown on launch specifying that support for encrypted files are .3ds files has been dropped. The user can click "don't show again" to dismiss the warning and it will not show again.