### PR TITLE
Make AM:GetPersonalizedTicketInfoList only return personal tickets

### DIFF
--- a/src/core/file_sys/ticket.cpp
+++ b/src/core/file_sys/ticket.cpp
@@ -167,4 +167,19 @@ std::optional<std::array<u8, 16>> Ticket::GetTitleKey() const {
     return title_key;
 }
 
+bool Ticket::IsPersonal() {
+    if (ticket_body.console_id == 0u) {
+        // Common ticket
+        return false;
+    }
+
+    auto& otp = HW::UniqueData::GetOTP();
+    if (!otp.Valid()) {
+        LOG_ERROR(HW_AES, "Invalid OTP");
+        return false;
+    }
+
+    return ticket_body.console_id == otp.GetDeviceID();
+}
+
 } // namespace FileSys

--- a/src/core/file_sys/ticket.h
+++ b/src/core/file_sys/ticket.h
@@ -1,4 +1,4 @@
-// Copyright 2018 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -66,6 +66,8 @@ public:
     size_t GetSerializedSize() {
         return serialized_size;
     }
+
+    bool IsPersonal();
 
 private:
     Body ticket_body;


### PR DESCRIPTION
The function `AM:GetPersonalizedTicketInfoList` should only return the tickets for the current device ID, but it was not doing so. This causes eShop/nim to delete the tickets that are not for the current device ID, making them disappear from the home menu.