### PR TITLE
Make Android show unsupported encrypted app

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/model/GameInfo.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/model/GameInfo.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -21,6 +21,8 @@ class GameInfo(path: String) {
     protected external fun finalize()
 
     external fun getTitle(): String
+
+    external fun isEncrypted(): Boolean
 
     external fun getRegions(): String
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/GameHelper.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/GameHelper.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -11,6 +11,7 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.citra.citra_emu.CitraApplication
 import org.citra.citra_emu.NativeLibrary
+import org.citra.citra_emu.R
 import org.citra.citra_emu.model.CheapDocument
 import org.citra.citra_emu.model.Game
 import org.citra.citra_emu.model.GameInfo
@@ -69,10 +70,16 @@ object GameHelper {
 
     fun getGame(uri: Uri, isInstalled: Boolean, addedToLibrary: Boolean): Game {
         val filePath = uri.toString()
-        val gameInfo: GameInfo? = try {
+        var gameInfo: GameInfo? = try {
             GameInfo(filePath)
         } catch (e: IOException) {
             null
+        }
+
+        var isEncrypted = false
+        if (gameInfo?.isEncrypted() == true) {
+            gameInfo = null
+            isEncrypted = true
         }
 
         val newGame = Game(
@@ -81,7 +88,7 @@ object GameHelper {
             filePath,
             NativeLibrary.getTitleId(filePath),
             gameInfo?.getCompany() ?: "",
-            gameInfo?.getRegions() ?: "Invalid region",
+            gameInfo?.getRegions() ?: (if (isEncrypted) { CitraApplication.appContext.getString(R.string.unsupported_encrypted) } else { CitraApplication.appContext.getString(R.string.invalid_region) }),
             isInstalled,
             NativeLibrary.getIsSystemTitle(filePath),
             gameInfo?.getIsVisibleSystemTitle() ?: false,

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -465,6 +465,8 @@
     <string name="save_load_error">Save/Load Error</string>
     <string name="fatal_error">Fatal Error</string>
     <string name="fatal_error_message">A fatal error occurred. Check the log for details.\nContinuing emulation may result in crashes and bugs.</string>
+    <string name="invalid_region">Invalid region</string>
+    <string name="unsupported_encrypted">Unsupported encrypted application</string>
 
     <!-- Disk Shader Cache -->
     <string name="preparing_shaders">Preparing Shaders</string>


### PR DESCRIPTION
Makes android show an unsupported application message instead of just "Invalid region". Also moves both strings to the translation files.