### PR TITLE
Controller Touchpad Support for direct touchscreen input

### DIFF
--- a/CMakeModules/GenerateSettingKeys.cmake
+++ b/CMakeModules/GenerateSettingKeys.cmake
@@ -199,6 +199,8 @@ if (ENABLE_QT)
         "name"
         "bind"
         "profile"
+        "use_touchpad"
+        "controller_touch_device"
         "use_touch_from_button"
         "touch_from_button_map"
         "touch_from_button_maps" # Why are these two so similar? Basically typo bait

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -405,6 +405,11 @@ void QtConfig::ReadControlValues() {
             ReadSetting(Settings::QKeys::touch_device, QStringLiteral("engine:emu_window"))
                 .toString()
                 .toStdString();
+        profile.use_touchpad = ReadSetting(Settings::QKeys::use_touchpad, false).toBool();
+        profile.controller_touch_device =
+            ReadSetting(Settings::QKeys::controller_touch_device, QStringLiteral(""))
+                .toString()
+                .toStdString();
         profile.use_touch_from_button =
             ReadSetting(Settings::QKeys::use_touch_from_button, false).toBool();
         profile.touch_from_button_map_index =
@@ -1005,6 +1010,9 @@ void QtConfig::SaveControlValues() {
             QStringLiteral("engine:motion_emu,update_period:100,sensitivity:0.01,tilt_clamp:90.0"));
         WriteSetting(Settings::QKeys::touch_device, QString::fromStdString(profile.touch_device),
                      QStringLiteral("engine:emu_window"));
+        WriteSetting(Settings::QKeys::use_touchpad, profile.use_touchpad, false);
+        WriteSetting(Settings::QKeys::controller_touch_device,
+                     QString::fromStdString(profile.controller_touch_device), QStringLiteral(""));
         WriteSetting(Settings::QKeys::use_touch_from_button, profile.use_touch_from_button, false);
         WriteSetting(Settings::QKeys::touch_from_button_map, profile.touch_from_button_map_index,
                      0);

--- a/src/citra_qt/configuration/configure_motion_touch.h
+++ b/src/citra_qt/configuration/configure_motion_touch.h
@@ -1,4 +1,4 @@
-// Copyright 2018 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -76,6 +76,9 @@ private:
     // Used for SDL input polling
     std::string guid;
     int port;
+    std::string tpguid; // guid for touchpad
+    int tpport;         // port for touchpad
+    int tp;             // which touchpad
     std::unique_ptr<QTimer> timeout_timer;
     std::unique_ptr<QTimer> poll_timer;
     std::vector<std::unique_ptr<InputCommon::Polling::DevicePoller>> device_pollers;

--- a/src/citra_qt/configuration/configure_motion_touch.ui
+++ b/src/citra_qt/configuration/configure_motion_touch.ui
@@ -2,16 +2,16 @@
 <ui version="4.0">
  <class>ConfigureMotionTouch</class>
  <widget class="QDialog" name="ConfigureMotionTouch">
-  <property name="windowTitle">
-   <string>Configure Motion / Touch</string>
-  </property>
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>500</width>
-    <height>450</height>
+    <width>517</width>
+    <height>659</height>
    </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Configure Motion / Touch</string>
   </property>
   <layout class="QVBoxLayout">
    <item>
@@ -175,6 +175,27 @@
         </item>
        </layout>
       </item>
+      <item>
+       <layout class="QHBoxLayout" name="touchpad_hlayout">
+        <item>
+         <widget class="QCheckBox" name="touchpad_checkbox">
+          <property name="toolTip">
+           <string>Map touchpads on controllers like the DualSense directly to touch</string>
+          </property>
+          <property name="text">
+           <string>Use controller touchpad</string>
+          </property>
+         </widget>
+        </item>
+        <item alignment="Qt::AlignRight">
+         <widget class="QPushButton" name="touchpad_config_btn">
+          <property name="text">
+           <string>Configure</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
      </layout>
     </widget>
    </item>
@@ -324,4 +345,5 @@
   </layout>
  </widget>
  <resources/>
+ <connections/>
 </ui>

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -442,6 +442,8 @@ struct InputProfile {
     std::array<std::string, NativeAnalog::NumAnalogs> analogs;
     std::string motion_device;
     std::string touch_device;
+    std::string controller_touch_device;
+    bool use_touchpad;
     bool use_touch_from_button;
     int touch_from_button_map_index;
     std::string udp_input_address;

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -115,6 +115,7 @@ DirectionState GetStickDirectionState(s16 circle_pad_x, s16 circle_pad_y) {
 }
 
 void Module::LoadInputDevices() {
+    LOG_DEBUG(Frontend, "Loading input devices");
     std::transform(Settings::values.current_input_profile.buttons.begin() +
                        Settings::NativeButton::BUTTON_HID_BEGIN,
                    Settings::values.current_input_profile.buttons.begin() +
@@ -126,6 +127,13 @@ void Module::LoadInputDevices() {
         Settings::values.current_input_profile.motion_device);
     touch_device = Input::CreateDevice<Input::TouchDevice>(
         Settings::values.current_input_profile.touch_device);
+    if (Settings::values.current_input_profile.use_touchpad &&
+        Settings::values.current_input_profile.controller_touch_device != "") {
+        controller_touch_device = Input::CreateDevice<Input::TouchDevice>(
+            Settings::values.current_input_profile.controller_touch_device);
+    } else {
+        controller_touch_device.reset();
+    }
     if (Settings::values.current_input_profile.use_touch_from_button) {
         touch_btn_device = Input::CreateDevice<Input::TouchDevice>("engine:touch_from_button");
     } else {
@@ -277,6 +285,9 @@ void Module::UpdatePadCallback(std::uintptr_t user_data, s64 cycles_late) {
         std::tie(x, y, pressed) = touch_device->GetStatus();
         if (!pressed && touch_btn_device) {
             std::tie(x, y, pressed) = touch_btn_device->GetStatus();
+        }
+        if (!pressed && controller_touch_device) {
+            std::tie(x, y, pressed) = controller_touch_device->GetStatus();
         }
         touch_entry.x = static_cast<u16>(x * Core::kScreenBottomWidth);
         touch_entry.y = static_cast<u16>(y * Core::kScreenBottomHeight);

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -1,4 +1,4 @@
-// Copyright 2015 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -390,6 +390,7 @@ private:
         buttons;
     std::unique_ptr<Input::AnalogDevice> circle_pad;
     std::unique_ptr<Input::MotionDevice> motion_device;
+    std::unique_ptr<Input::TouchDevice> controller_touch_device;
     std::unique_ptr<Input::TouchDevice> touch_device;
     std::unique_ptr<Input::TouchDevice> touch_btn_device;
 

--- a/src/input_common/main.h
+++ b/src/input_common/main.h
@@ -1,4 +1,4 @@
-// Copyright 2017 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -45,7 +45,7 @@ void ReloadInputDevices();
 
 namespace Polling {
 
-enum class DeviceType { Button, Analog };
+enum class DeviceType { Button, Analog, Touchpad };
 
 /**
  * A class that can be used to get inputs from an input device like controllers without having to

--- a/src/input_common/sdl/sdl.cpp
+++ b/src/input_common/sdl/sdl.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/input_common/sdl/sdl_impl.h
+++ b/src/input_common/sdl/sdl_impl.h
@@ -1,4 +1,4 @@
-// Copyright 2018 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -24,6 +24,7 @@ class SDLGameController;
 class SDLButtonFactory;
 class SDLAnalogFactory;
 class SDLMotionFactory;
+class SDLTouchFactory;
 
 class SDLState : public State {
 public:
@@ -62,6 +63,7 @@ private:
     std::unordered_map<std::string, std::vector<std::shared_ptr<SDLJoystick>>> joystick_map;
     std::mutex joystick_map_mutex;
 
+    std::shared_ptr<SDLTouchFactory> touch_factory;
     std::shared_ptr<SDLButtonFactory> button_factory;
     std::shared_ptr<SDLAnalogFactory> analog_factory;
     std::shared_ptr<SDLMotionFactory> motion_factory;


### PR DESCRIPTION
This Pull Request adds a setting on desktop that allows a controller touchpad, such as those on the DualShock or DualSense controllers, to control the touchscreen directly. It can be used in addition to mouse or UDP input.

Closes #1329 