### PR TITLE
Fix fatal error caused by auto-detect region

### DIFF
--- a/src/common/hacks/hack_list.cpp
+++ b/src/common/hacks/hack_list.cpp
@@ -108,5 +108,53 @@ HackManager hack_manager = {
                  },
          }},
 
+        {HackType::REGION_FROM_SECURE,
+         HackEntry{
+             .mode = HackAllowMode::FORCE,
+             .affected_title_ids =
+                 {
+                     // eShop
+                     0x0004001000020900, // JPN
+                     0x0004001000021900, // USA
+                     0x0004001000022900, // EUR
+                     0x0004001000027900, // KOR
+                     0x0004001000028900, // TWN
+
+                     // System Settings
+                     0x0004001000020000, // JPN
+                     0x0004001000021000, // USA
+                     0x0004001000022000, // EUR
+                     0x0004001000026000, // CHN
+                     0x0004001000027000, // KOR
+                     0x0004001000028000, // TWN
+
+                     // Nintendo Network ID Settings
+                     0x000400100002BF00, // JPN
+                     0x000400100002C000, // USA
+                     0x000400100002C100, // EUR
+
+                     // System Settings
+                     0x0004003000008202, // JPN
+                     0x0004003000008F02, // USA
+                     0x0004003000009802, // EUR
+                     0x000400300000A102, // CHN
+                     0x000400300000A902, // KOR
+                     0x000400300000B102, // TWN
+
+                     // NIM
+                     0x0004013000002C02, // Normal
+                     0x0004013000002C03, // Safe mode
+                     0x0004013020002C03, // New 3DS safe mode
+
+                     // ACT
+                     0x0004013000003802, // Normal
+
+                     // FRD
+                     0x0004013000003202, // Normal
+                     0x0004013000003203, // Safe mode
+                     0x0004013020003203, // New 3DS safe mode
+                 },
+         }},
+
     }};
 }

--- a/src/common/hacks/hack_list.h
+++ b/src/common/hacks/hack_list.h
@@ -13,6 +13,7 @@ enum class HackType : int {
     ACCURATE_MULTIPLICATION,
     DECRYPTION_AUTHORIZED,
     ONLINE_LLE_REQUIRED,
+    REGION_FROM_SECURE,
 };
 
 class UserHackData {};

--- a/src/core/hle/service/apt/applet_manager.cpp
+++ b/src/core/hle/service/apt/applet_manager.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -573,9 +573,11 @@ Result AppletManager::PrepareToStartLibraryApplet(AppletId applet_id) {
     capture_buffer_info.reset();
 
     if (Settings::values.lle_applets) {
+        bool is_setup = system.GetAppLoader().DoingInitialSetup();
         auto cfg = Service::CFG::GetModule(system);
-        auto process = NS::LaunchTitle(system, FS::MediaType::NAND,
-                                       GetTitleIdForApplet(applet_id, cfg->GetRegionValue()));
+        auto process =
+            NS::LaunchTitle(system, FS::MediaType::NAND,
+                            GetTitleIdForApplet(applet_id, cfg->GetRegionValue(is_setup)));
         if (process) {
             return ResultSuccess;
         }
@@ -602,9 +604,11 @@ Result AppletManager::PreloadLibraryApplet(AppletId applet_id) {
     last_prepared_library_applet = applet_id;
 
     if (Settings::values.lle_applets) {
+        bool is_setup = system.GetAppLoader().DoingInitialSetup();
         auto cfg = Service::CFG::GetModule(system);
-        auto process = NS::LaunchTitle(system, FS::MediaType::NAND,
-                                       GetTitleIdForApplet(applet_id, cfg->GetRegionValue()));
+        auto process =
+            NS::LaunchTitle(system, FS::MediaType::NAND,
+                            GetTitleIdForApplet(applet_id, cfg->GetRegionValue(is_setup)));
         if (process) {
             return ResultSuccess;
         }
@@ -814,9 +818,11 @@ Result AppletManager::StartSystemApplet(AppletId applet_id, std::shared_ptr<Kern
     const auto slot_id =
         applet_id == AppletId::HomeMenu ? AppletSlot::HomeMenu : AppletSlot::SystemApplet;
     if (!GetAppletSlot(slot_id)->registered) {
+        bool is_setup = system.GetAppLoader().DoingInitialSetup();
         auto cfg = Service::CFG::GetModule(system);
-        auto process = NS::LaunchTitle(system, FS::MediaType::NAND,
-                                       GetTitleIdForApplet(applet_id, cfg->GetRegionValue()));
+        auto process =
+            NS::LaunchTitle(system, FS::MediaType::NAND,
+                            GetTitleIdForApplet(applet_id, cfg->GetRegionValue(is_setup)));
         if (!process) {
             // TODO: Find the right error code.
             return {ErrorDescription::NotFound, ErrorModule::Applet, ErrorSummary::NotSupported,
@@ -1422,7 +1428,7 @@ void AppletManager::EnsureHomeMenuLoaded() {
     }
 
     auto cfg = Service::CFG::GetModule(system);
-    auto menu_title_id = GetTitleIdForApplet(AppletId::HomeMenu, cfg->GetRegionValue());
+    auto menu_title_id = GetTitleIdForApplet(AppletId::HomeMenu, cfg->GetRegionValue(false));
     auto process = NS::LaunchTitle(system, FS::MediaType::NAND, menu_title_id);
     if (!process) {
         LOG_WARNING(Service_APT,

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -196,7 +196,7 @@ static u32 DecompressLZ11(const u8* in, u8* out) {
 bool Module::LoadSharedFont() {
     auto cfg = Service::CFG::GetModule(system);
     u8 font_region_code;
-    switch (cfg->GetRegionValue()) {
+    switch (cfg->GetRegionValue(false)) {
     case 4: // CHN
         font_region_code = 2;
         break;

--- a/src/core/hle/service/cfg/cfg.h
+++ b/src/core/hle/service/cfg/cfg.h
@@ -484,7 +484,7 @@ private:
     void LoadMCUConfig();
 
 public:
-    u32 GetRegionValue();
+    u32 GetRegionValue(bool from_secure_info);
 
     // Utilities for frontend to set config data.
     // Note: UpdateConfigNANDSavegame should be called after making changes to config data.


### PR DESCRIPTION
Some users have been reporting fatal errors after running the setup tool. This is happens because they are playing out-of-region games that do not match the region of the donor console, and the region auto-detect feature was reporting the wrong region to the act sysmodule.

The act sysmodule has been added as an exception so that the region matches the one on SecureInfo_A. Same as some other apps.