### PR TITLE
framebuffer: Add hybrid layout mode to FrameLayoutFromResolutionScale

### DIFF
--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -452,7 +452,7 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
                 width = Core::kScreenTopWidth;
             }
             // 2.25f comes from HybridScreenLayout's scale_factor value.
-            width = (width + (Core::kScreenTopWidth / 2.25f)) * res_scale;
+            width = static_cast<int>((width + (Core::kScreenTopWidth / 2.25f)) * res_scale);
 
             if (Settings::values.upright_screen.GetValue()) {
                 std::swap(width, height);

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -444,7 +444,6 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
                                     Settings::SmallScreenPosition::MiddleRight);
 
         case Settings::LayoutOption::HybridScreen:
-        default:
             width = (Core::kScreenTopWidth + Core::kScreenBottomWidth) * res_scale;
             height = (Core::kScreenTopHeight + Core::kScreenBottomHeight) * res_scale;
 
@@ -456,6 +455,7 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
                                       Settings::values.upright_screen.GetValue());
 
         case Settings::LayoutOption::Default:
+        default:
             width = Core::kScreenTopWidth * res_scale;
             height = (Core::kScreenTopHeight + Core::kScreenBottomHeight) * res_scale;
 

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -443,8 +443,19 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
                                     Settings::values.upright_screen.GetValue(), 1,
                                     Settings::SmallScreenPosition::MiddleRight);
 
-        case Settings::LayoutOption::Default:
+        case Settings::LayoutOption::HybridScreen:
         default:
+            width = (Core::kScreenTopWidth + Core::kScreenBottomWidth) * res_scale;
+            height = (Core::kScreenTopHeight + Core::kScreenBottomHeight) * res_scale;
+
+            if (Settings::values.upright_screen.GetValue()) {
+                std::swap(width, height);
+            }
+
+            return HybridScreenLayout(width, height, Settings::values.swap_screen.GetValue(),
+                                      Settings::values.upright_screen.GetValue());
+
+        case Settings::LayoutOption::Default:
             width = Core::kScreenTopWidth * res_scale;
             height = (Core::kScreenTopHeight + Core::kScreenBottomHeight) * res_scale;
 

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -444,8 +444,15 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
                                     Settings::SmallScreenPosition::MiddleRight);
 
         case Settings::LayoutOption::HybridScreen:
-            width = (Core::kScreenTopWidth + Core::kScreenBottomWidth) * res_scale;
-            height = (Core::kScreenTopHeight + Core::kScreenBottomHeight) * res_scale;
+            height = Core::kScreenTopHeight * res_scale;
+
+            if (Settings::values.swap_screen.GetValue()) {
+                width = Core::kScreenBottomWidth;
+            } else {
+                width = Core::kScreenTopWidth;
+            }
+            // 2.25f comes from HybridScreenLayout's scale_factor value.
+            width = (width + (Core::kScreenTopWidth / 2.25f)) * res_scale;
 
             if (Settings::values.upright_screen.GetValue()) {
                 std::swap(width, height);


### PR DESCRIPTION
Re-opened from #751 
Closes #507

> Description from that issue describes it all:
>> If you take a screenshot using Lime's built-in tool while in hybrid mode, a Default layout screenshot is made instead. This appears to be because the Hybrid layout was never added to the FrameLayoutFromResolutionScale method so it is falling back to the default behavior.

