### PR TITLE
android: Add game thumbnail to `EmulationFragment` nav drawer

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
@@ -22,6 +22,7 @@ import android.view.Surface
 import android.view.SurfaceHolder
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import android.widget.PopupMenu
 import android.widget.TextView
 import android.widget.Toast
@@ -232,8 +233,14 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
             )
         }
 
-        binding.inGameMenu.getHeaderView(0).findViewById<TextView>(R.id.text_game_title).text =
-            game.title
+        binding.inGameMenu.getHeaderView(0).apply {
+            val titleView = findViewById<TextView>(R.id.text_game_title)
+            val iconView = findViewById<ImageView>(R.id.game_icon)
+
+            titleView.text = game.title
+
+            GameIconUtils.loadGameIcon(requireActivity(), game, iconView)
+}
         binding.inGameMenu.setNavigationItemSelectedListener {
             when (it.itemId) {
                 R.id.menu_emulation_pause -> {

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
@@ -240,7 +240,8 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
             titleView.text = game.title
 
             GameIconUtils.loadGameIcon(requireActivity(), game, iconView)
-}
+        }
+
         binding.inGameMenu.setNavigationItemSelectedListener {
             when (it.itemId) {
                 R.id.menu_emulation_pause -> {

--- a/src/android/app/src/main/res/layout/header_in_game.xml
+++ b/src/android/app/src/main/res/layout/header_in_game.xml
@@ -1,14 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.material.textview.MaterialTextView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/text_game_title"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:orientation="horizontal"
     android:layout_marginTop="24dp"
     android:layout_marginStart="24dp"
-    android:layout_marginEnd="24dp"
-    android:textAppearance="?attr/textAppearanceHeadlineMedium"
-    android:textColor="?attr/colorOnSurface"
-    android:textAlignment="viewStart"
-    tools:text="Super Mario 3D Land" />
+    android:layout_marginEnd="24dp">
+
+    <ImageView
+        android:id="@+id/game_icon"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_marginEnd="16dp"/>
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/text_game_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceHeadlineMedium"
+        android:textColor="?attr/colorOnSurface"
+        android:textAlignment="viewStart"
+        tools:text="Super Mario 3D Land" />
+
+</LinearLayout>

--- a/src/android/app/src/main/res/layout/header_in_game.xml
+++ b/src/android/app/src/main/res/layout/header_in_game.xml
@@ -21,6 +21,6 @@
         android:textAppearance="?attr/textAppearanceHeadlineMedium"
         android:textColor="?attr/colorOnSurface"
         android:textAlignment="viewStart"
-        tools:text="Super Mario 3D Land" />
+        tools:text="text_game_title" />
 
 </LinearLayout>


### PR DESCRIPTION
Re-opened from #611 

> This PR adds an icon to the title header of the navigation drawer on emulation fragment
> 
> We can discuss if this is the proper way to do it though because I am not sure 
> 
> <img src="https://github.com/user-attachments/assets/d22ffb2b-6644-4f8f-a988-1a409339ec04" width="35%">