### PR TITLE
android: Update emulation_pause icon on resume

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
@@ -455,6 +455,14 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
         Choreographer.getInstance().postFrameCallback(this)
         if (NativeLibrary.isRunning()) {
             NativeLibrary.unPauseEmulation()
+            binding.inGameMenu.menu.findItem(R.id.menu_emulation_pause)?.let { menuItem ->
+                menuItem.title = resources.getString(R.string.pause_emulation)
+                menuItem.icon = ResourcesCompat.getDrawable(
+                    resources,
+                    R.drawable.ic_pause,
+                    requireContext().theme
+                )
+            }
             return
         }
 


### PR DESCRIPTION
Re-opened from #612

> If the fragment got paused while emulationState also was paused manually via the menu bar, once the fragment got unpasued, the binding would still remain paused

---

> > Can you provide a step-by-step set of instructions that can be used to replicate the original issue? Your description is unclear.
> 
> Basically turn off the device / put it to sleep after pausing the emulator manually
> 
> The emulator should unpause on device wake and the emulation drawer should still say "Resume Emulation"