### PR TITLE
android: Add rotate screen upright toggle to UI

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/display/ScreenAdjustmentUtil.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/display/ScreenAdjustmentUtil.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/display/ScreenAdjustmentUtil.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/display/ScreenAdjustmentUtil.kt
@@ -68,4 +68,13 @@ class ScreenAdjustmentUtil(
         settings.saveSetting(IntSetting.ORIENTATION_OPTION, SettingsFile.FILE_NAME_CONFIG)
         activity.requestedOrientation = orientationOption
     }
+
+    fun toggleScreenUpright() {
+        val uprightBoolean = BooleanSetting.UPRIGHT_SCREEN.boolean
+        BooleanSetting.UPRIGHT_SCREEN.boolean = !uprightBoolean
+        settings.saveSetting(BooleanSetting.UPRIGHT_SCREEN, SettingsFile.FILE_NAME_CONFIG)
+        NativeLibrary.reloadSettings()
+        NativeLibrary.updateFramebuffer(NativeLibrary.isPortraitMode)
+
+    }
 }

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
@@ -45,7 +45,8 @@ enum class BooleanSetting(
     USE_FRAME_LIMIT("use_frame_limit", Settings.SECTION_RENDERER, true),
     DEBUG_RENDERER("renderer_debug", Settings.SECTION_DEBUG, false),
     DISABLE_RIGHT_EYE_RENDER("disable_right_eye_render", Settings.SECTION_RENDERER, false),
-    USE_ARTIC_BASE_CONTROLLER("use_artic_base_controller", Settings.SECTION_CONTROLS, false);
+    USE_ARTIC_BASE_CONTROLLER("use_artic_base_controller", Settings.SECTION_CONTROLS, false),
+    UPRIGHT_SCREEN("upright_screen", Settings.SECTION_LAYOUT, false);
 
     override var boolean: Boolean = defaultValue
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -1073,6 +1073,15 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                 )
             )
             add(
+                SwitchSetting(
+                    BooleanSetting.UPRIGHT_SCREEN,
+                    R.string.emulation_rotate_upright,
+                    0,
+                    BooleanSetting.UPRIGHT_SCREEN.key,
+                    BooleanSetting.UPRIGHT_SCREEN.defaultValue
+                )
+            )
+            add(
                 SingleChoiceSetting(
                     IntSetting.PORTRAIT_SCREEN_LAYOUT,
                     R.string.emulation_switch_portrait_layout,

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
@@ -306,6 +306,11 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
                     true
                 }
 
+                R.id.menu_rotate_upright -> {
+                    screenAdjustmentUtil.toggleScreenUpright()
+                    true
+                }
+
                 R.id.menu_lock_drawer -> {
                     when (EmulationMenuSettings.drawerLockMode) {
                         DrawerLayout.LOCK_MODE_UNLOCKED -> {

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -202,6 +202,7 @@ void Config::ReadValues() {
     ReadSetting("Layout", Settings::values.cardboard_screen_size);
     ReadSetting("Layout", Settings::values.cardboard_x_shift);
     ReadSetting("Layout", Settings::values.cardboard_y_shift);
+    ReadSetting("Layout", Settings::values.upright_screen);
 
     Settings::values.portrait_layout_option =
         static_cast<Settings::PortraitLayoutOption>(sdl2_config->GetInteger(

--- a/src/android/app/src/main/res/drawable/ic_rotate_up_right.xml
+++ b/src/android/app/src/main/res/drawable/ic_rotate_up_right.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M16,18l2.29,-2.29 -4.88,-4.88 -4,4L2,7.41 3.41,6l6,6 4,-4 6.3,6.29L22,12v6z"/>
+
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,2L8,6h4v3h2V6h4L12,2z"/>
+</vector>

--- a/src/android/app/src/main/res/menu/menu_in_game.xml
+++ b/src/android/app/src/main/res/menu/menu_in_game.xml
@@ -35,8 +35,12 @@
     <item
         android:id="@+id/menu_swap_screens"
         android:icon="@drawable/ic_splitscreen"
-
         android:title="@string/emulation_swap_screens" />
+
+    <item
+        android:id="@+id/menu_rotate_upright"
+        android:icon="@drawable/ic_rotate_up_right"
+        android:title="@string/emulation_rotate_upright" />
 
     <item
         android:id="@+id/menu_lock_drawer"

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -459,6 +459,7 @@
     <string name="emulation_custom_layout_height">Height</string>
     <string name="emulation_cycle_landscape_layouts">Cycle Layouts</string>
     <string name="emulation_swap_screens">Swap Screens</string>
+    <string name="emulation_rotate_upright">Rotate Screen Upright</string>
     <string name="emulation_touch_overlay_reset">Reset Overlay</string>
     <string name="emulation_show_controller_overlay">Show Controller Overlay</string>
     <string name="emulation_close_game">Close Game</string>

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -215,7 +215,8 @@ void EmuWindow::UpdateCurrentFramebufferLayout(u32 width, u32 height, bool is_po
         switch (portrait_layout_option) {
         case Settings::PortraitLayoutOption::PortraitTopFullWidth:
             layout = Layout::PortraitTopFullFrameLayout(width, height,
-                                                        Settings::values.swap_screen.GetValue());
+                                                        Settings::values.swap_screen.GetValue(),
+                                                        Settings::values.upright_screen.GetValue());
             break;
         case Settings::PortraitLayoutOption::PortraitCustomLayout:
             layout = Layout::CustomFrameLayout(
@@ -223,7 +224,8 @@ void EmuWindow::UpdateCurrentFramebufferLayout(u32 width, u32 height, bool is_po
             break;
         case Settings::PortraitLayoutOption::PortraitOriginal:
             layout = Layout::PortraitOriginalLayout(width, height,
-                                                    Settings::values.swap_screen.GetValue());
+                                                    Settings::values.swap_screen.GetValue(),
+                                                    Settings::values.upright_screen.GetValue());
             break;
         }
     } else {

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -39,11 +39,11 @@ FramebufferLayout DefaultFrameLayout(u32 width, u32 height, bool swapped, bool u
                             Settings::SmallScreenPosition::BelowLarge);
 }
 
-FramebufferLayout PortraitTopFullFrameLayout(u32 width, u32 height, bool swapped) {
+FramebufferLayout PortraitTopFullFrameLayout(u32 width, u32 height, bool swapped, bool upright) {
     ASSERT(width > 0);
     ASSERT(height > 0);
     const float scale_factor = swapped ? 1.25f : 0.8f;
-    FramebufferLayout res = LargeFrameLayout(width, height, swapped, false, scale_factor,
+    FramebufferLayout res = LargeFrameLayout(width, height, swapped, upright, scale_factor,
                                              Settings::SmallScreenPosition::BelowLarge);
     const int shiftY = -(int)(swapped ? res.bottom_screen.top : res.top_screen.top);
     res.top_screen = res.top_screen.TranslateY(shiftY);
@@ -51,11 +51,11 @@ FramebufferLayout PortraitTopFullFrameLayout(u32 width, u32 height, bool swapped
     return res;
 }
 
-FramebufferLayout PortraitOriginalLayout(u32 width, u32 height, bool swapped) {
+FramebufferLayout PortraitOriginalLayout(u32 width, u32 height, bool swapped, bool upright) {
     ASSERT(width > 0);
     ASSERT(height > 0);
     const float scale_factor = 1;
-    FramebufferLayout res = LargeFrameLayout(width, height, swapped, false, scale_factor,
+    FramebufferLayout res = LargeFrameLayout(width, height, swapped, upright, scale_factor,
                                              Settings::SmallScreenPosition::BelowLarge);
     const int shiftY = -(int)(swapped ? res.bottom_screen.top : res.top_screen.top);
     res.top_screen = res.top_screen.TranslateY(shiftY);
@@ -408,7 +408,8 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
                      res_scale) + gap;
             // clang-format on
             return PortraitTopFullFrameLayout(width, height,
-                                              Settings::values.swap_screen.GetValue());
+                                              Settings::values.swap_screen.GetValue(),
+                                              Settings::values.upright_screen.GetValue());
         case Settings::PortraitLayoutOption::PortraitOriginal:
             width = Core::kScreenTopWidth * res_scale;
             height = (Core::kScreenTopHeight + Core::kScreenBottomHeight) * res_scale;

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -71,7 +71,8 @@ FramebufferLayout DefaultFrameLayout(u32 width, u32 height, bool is_swapped, boo
  * @param is_swapped if true, the bottom screen will be displayed above the top screen
  * @return Newly created FramebufferLayout object with mobile portrait screen regions initialized
  */
-FramebufferLayout PortraitTopFullFrameLayout(u32 width, u32 height, bool is_swapped);
+FramebufferLayout PortraitTopFullFrameLayout(u32 width, u32 height, bool is_swapped,
+                                             bool upright = false);
 
 /**
  * Factory method for constructing the mobile Original layout
@@ -81,7 +82,8 @@ FramebufferLayout PortraitTopFullFrameLayout(u32 width, u32 height, bool is_swap
  * @param is_swapped if true, the bottom screen will be displayed above the top screen
  * @return Newly created FramebufferLayout object with mobile portrait screen regions initialized
  */
-FramebufferLayout PortraitOriginalLayout(u32 width, u32 height, bool is_swapped);
+FramebufferLayout PortraitOriginalLayout(u32 width, u32 height, bool is_swapped,
+                                         bool upright = false);
 
 /**
  * Factory method for constructing a FramebufferLayout with only the top or bottom screen


### PR DESCRIPTION
Re-opened from #654

Closes #640

> Ports the "Rotate Screen Upright" toggle which is present in QT to Android and which is used in games which require you to rotate your 3DS to portrait mode for certain parts, like Mario And Luigi Bowser's Inside Story / Dream Team
> 
> Showcase:
> 
> https://github.com/user-attachments/assets/189d8b4e-13d6-45c3-ac39-d482b4d8c08a