### PR TITLE
Room moderation functionality adjustments

### DIFF
--- a/src/citra_qt/multiplayer/chat_room.cpp
+++ b/src/citra_qt/multiplayer/chat_room.cpp
@@ -459,11 +459,14 @@ void ChatRoom::PopupContextMenu(const QPoint& menu_location) {
         });
     }
 
-    if (has_mod_perms && nickname != cur_nickname) { // You can't kick or ban yourself
+    if (nickname != cur_nickname) { // You can't kick or ban yourself
         context_menu.addSeparator();
 
         QAction* kick_action = context_menu.addAction(tr("Kick"));
         QAction* ban_action = context_menu.addAction(tr("Ban"));
+
+        kick_action->setEnabled(has_mod_perms);
+        ban_action->setEnabled(has_mod_perms);
 
         connect(kick_action, &QAction::triggered, [this, nickname] {
             QMessageBox::StandardButton result =

--- a/src/citra_qt/multiplayer/chat_room.cpp
+++ b/src/citra_qt/multiplayer/chat_room.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/citra_qt/multiplayer/client_room.cpp
+++ b/src/citra_qt/multiplayer/client_room.cpp
@@ -47,8 +47,6 @@ ClientRoomWindow::ClientRoomWindow(QWidget* parent)
         ModerationDialog dialog(this);
         dialog.exec();
     });
-    ui->moderation->setDefault(false);
-    ui->moderation->setAutoDefault(false);
     connect(ui->chat, &ChatRoom::UserPinged, this, &ClientRoomWindow::ShowNotification);
     UpdateView();
 }
@@ -57,9 +55,7 @@ ClientRoomWindow::~ClientRoomWindow() = default;
 
 void ClientRoomWindow::SetModPerms(bool is_mod) {
     ui->chat->SetModPerms(is_mod);
-    ui->moderation->setVisible(is_mod);
-    ui->moderation->setDefault(false);
-    ui->moderation->setAutoDefault(false);
+    ui->moderation->setEnabled(is_mod);
 }
 
 void ClientRoomWindow::RetranslateUi() {

--- a/src/citra_qt/multiplayer/client_room.cpp
+++ b/src/citra_qt/multiplayer/client_room.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/citra_qt/multiplayer/client_room.ui
+++ b/src/citra_qt/multiplayer/client_room.ui
@@ -47,7 +47,7 @@
           <string>Moderation...</string>
          </property>
          <property name="visible">
-          <bool>false</bool>
+          <bool>true</bool>
          </property>
         </widget>
        </item>

--- a/src/citra_qt/multiplayer/host_room.cpp
+++ b/src/citra_qt/multiplayer/host_room.cpp
@@ -144,8 +144,8 @@ void HostRoomWindow::Host() {
             bool created = room->Create(ui->room_name->text().toStdString(),
                                         ui->room_description->toPlainText().toStdString(), "",
                                         static_cast<u16>(port), password, ui->max_player->value(),
-                                        ui->username->text().toStdString(),, game_name.toStdString(),
-                                        game_id, CreateVerifyBackend(is_public), ban_list, true);
+                                        ui->username->text().toStdString(), game_name.toStdString(),
+                                        game_id, CreateVerifyBackend(is_public), ban_list);
             if (!created) {
                 NetworkMessage::ErrorManager::ShowError(
                     NetworkMessage::ErrorManager::COULD_NOT_CREATE_ROOM);

--- a/src/citra_qt/multiplayer/host_room.cpp
+++ b/src/citra_qt/multiplayer/host_room.cpp
@@ -144,8 +144,8 @@ void HostRoomWindow::Host() {
             bool created = room->Create(ui->room_name->text().toStdString(),
                                         ui->room_description->toPlainText().toStdString(), "",
                                         static_cast<u16>(port), password, ui->max_player->value(),
-                                        NetSettings::values.citra_username, game_name.toStdString(),
-                                        game_id, CreateVerifyBackend(is_public), ban_list);
+                                        ui->username->text().toStdString(),, game_name.toStdString(),
+                                        game_id, CreateVerifyBackend(is_public), ban_list, true);
             if (!created) {
                 NetworkMessage::ErrorManager::ShowError(
                     NetworkMessage::ErrorManager::COULD_NOT_CREATE_ROOM);

--- a/src/citra_room/citra_room.cpp
+++ b/src/citra_room/citra_room.cpp
@@ -183,7 +183,6 @@ void LaunchRoom(int argc, char** argv, bool called_by_option) {
     u64 preferred_game_id = 0;
     u16 port = Network::DefaultRoomPort;
     u32 max_members = 16;
-    bool enable_citra_mods = false;
 
     static struct option long_options[] = {
         {"room-name", required_argument, 0, 'n'},
@@ -249,9 +248,6 @@ void LaunchRoom(int argc, char** argv, bool called_by_option) {
                 break;
             case 'l':
                 log_file.assign(optarg);
-                break;
-            case 'e':
-                enable_citra_mods = true;
                 break;
             case 'h':
                 PrintHelp(argv[0]);
@@ -324,10 +320,6 @@ void LaunchRoom(int argc, char** argv, bool called_by_option) {
             NetSettings::values.citra_token = token;
         }
     }
-    if (!announce && enable_citra_mods) {
-        enable_citra_mods = false;
-        std::cout << "Can not enable Citra Moderators for private rooms\n\n";
-    }
 
     InitializeLogging(log_file);
 
@@ -354,8 +346,7 @@ void LaunchRoom(int argc, char** argv, bool called_by_option) {
     Network::Init();
     if (std::shared_ptr<Network::Room> room = Network::GetRoom().lock()) {
         if (!room->Create(room_name, room_description, "", port, password, max_members, username,
-                          preferred_game, preferred_game_id, std::move(verify_backend), ban_list,
-                          enable_citra_mods)) {
+                          preferred_game, preferred_game_id, std::move(verify_backend), ban_list)) {
             std::cout << "Failed to create room: \n\n";
             exit(-1);
         }

--- a/src/citra_room/citra_room.cpp
+++ b/src/citra_room/citra_room.cpp
@@ -56,7 +56,6 @@ static void PrintHelp(const char* argv0) {
                  "--web-api-url       Citra Web API url\n"
                  "--ban-list-file     The file for storing the room ban list\n"
                  "--log-file          The file for storing the room log\n"
-                 "--enable-citra-mods Allow Citra Community Moderators to moderate on your room\n"
                  "-h, --help          Display this help and exit\n"
                  "-v, --version       Output version information and exit\n";
 }
@@ -197,10 +196,10 @@ void LaunchRoom(int argc, char** argv, bool called_by_option) {
         {"web-api-url", required_argument, 0, 'a'},
         {"ban-list-file", required_argument, 0, 'b'},
         {"log-file", required_argument, 0, 'l'},
-        {"enable-citra-mods", no_argument, 0, 'e'},
         {"help", no_argument, 0, 'h'},
         {"version", no_argument, 0, 'v'},
         // Removed options
+        {"enable-citra-mods", no_argument, 0, 'e'},
         {"preferred-game", optional_argument, 0, 'g'},
         {"preferred-game-id", optional_argument, 0, 0},
         // Entry option
@@ -210,7 +209,8 @@ void LaunchRoom(int argc, char** argv, bool called_by_option) {
     };
 
     while (optind < argc) {
-        int arg = getopt_long(argc, argv, "n:d:p:m:w:s:u:t:a:i:l:hvg", long_options, &option_index);
+        int arg =
+            getopt_long(argc, argv, "n:d:p:m:w:s:u:t:a:i:l:hveg", long_options, &option_index);
         if (arg != -1) {
             switch (static_cast<char>(arg)) {
             case 'n':
@@ -255,6 +255,9 @@ void LaunchRoom(int argc, char** argv, bool called_by_option) {
             case 'v':
                 PrintVersion();
                 exit(0);
+            case 'e':
+                PrintRemovedOptionWarning(argv[0], "--enable-citra-mods/-e");
+                exit(255);
             case 'g':
                 PrintRemovedOptionWarning(argv[0], "--preferred-game/-g");
                 exit(255);

--- a/src/network/room.cpp
+++ b/src/network/room.cpp
@@ -373,12 +373,10 @@ void Room::RoomImpl::HandleJoinRequest(const ENetEvent* event) {
     }
     member.user_data = verify_backend->LoadUserData(uid, token);
 
-
     if (nickname == room_information.host_username) {
         member.user_data.moderator = true;
         LOG_INFO(Network, "User {} is a moderator", std::string(room_information.host_username));
     }
-
 
     std::string ip;
     {
@@ -605,8 +603,7 @@ bool Room::RoomImpl::HasModPermission(const ENetPeer* client) const {
     if (sending_member == members.end()) {
         return false;
     }
-    if (room_information.enable_citra_mods &&
-        sending_member->user_data.moderator) { // Community moderator
+    if (sending_member->user_data.moderator) { // Community moderator
 
         return true;
     }
@@ -1020,7 +1017,7 @@ bool Room::Create(const std::string& name, const std::string& description,
                   const u32 max_connections, const std::string& host_username,
                   const std::string& preferred_game, u64 preferred_game_id,
                   std::unique_ptr<VerifyUser::Backend> verify_backend,
-                  const Room::BanList& ban_list, bool enable_citra_mods) {
+                  const Room::BanList& ban_list) {
     ENetAddress address;
     address.host = ENET_HOST_ANY;
     if (!server_address.empty()) {
@@ -1043,7 +1040,6 @@ bool Room::Create(const std::string& name, const std::string& description,
     room_impl->room_information.preferred_game = preferred_game;
     room_impl->room_information.preferred_game_id = preferred_game_id;
     room_impl->room_information.host_username = host_username;
-    room_impl->room_information.enable_citra_mods = enable_citra_mods;
     room_impl->password = password;
     room_impl->verify_backend = std::move(verify_backend);
     room_impl->username_ban_list = ban_list.first;

--- a/src/network/room.cpp
+++ b/src/network/room.cpp
@@ -373,6 +373,13 @@ void Room::RoomImpl::HandleJoinRequest(const ENetEvent* event) {
     }
     member.user_data = verify_backend->LoadUserData(uid, token);
 
+
+    if (nickname == room_information.host_username) {
+        member.user_data.moderator = true;
+        LOG_INFO(Network, "User {} is a moderator", std::string(room_information.host_username));
+    }
+
+
     std::string ip;
     {
         std::lock_guard lock(ban_list_mutex);

--- a/src/network/room.cpp
+++ b/src/network/room.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/network/room.h
+++ b/src/network/room.h
@@ -32,7 +32,6 @@ struct RoomInformation {
     std::string preferred_game; ///< Game to advertise that you want to play
     u64 preferred_game_id;      ///< Title ID for the advertised game
     std::string host_username;  ///< Forum username of the host
-    bool enable_citra_mods;     ///< Allow Citra Moderators to moderate on this room
 };
 
 struct GameInfo {
@@ -148,7 +147,7 @@ public:
                 const std::string& host_username = "", const std::string& preferred_game = "",
                 u64 preferred_game_id = 0,
                 std::unique_ptr<VerifyUser::Backend> verify_backend = nullptr,
-                const BanList& ban_list = {}, bool enable_citra_mods = false);
+                const BanList& ban_list = {});
 
     /**
      * Sets the verification GUID of the room.

--- a/src/network/room.h
+++ b/src/network/room.h
@@ -1,4 +1,4 @@
-// Copyright 2017 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 


### PR DESCRIPTION
Re-opened from #646

> This was done in preparation for porting private room multiplayer from Citra MMJ into Azahar Android
> 
> Previously, moderation was locked to public rooms using Citra Web service stuff. I am not sure why that was the case, but on Citra MMJ any private room owner is given moderation access and is allowed to kick/ban people from the room
> 
> This PR makes that the case for Azahar as well 
> QT frontend is updated to reflect this change and the moderation buttons now are always visible, just grayed out for non-moderators 