### PR TITLE
citra_qt: Allow to set server address on room_create

### DIFF
--- a/src/citra_qt/multiplayer/host_room.cpp
+++ b/src/citra_qt/multiplayer/host_room.cpp
@@ -3,12 +3,16 @@
 // Refer to the license.txt file included.
 
 #include <future>
+#include <QApplication>
+#include <QClipboard>
 #include <QColor>
+#include <QHostInfo>
 #include <QImage>
 #include <QList>
 #include <QLocale>
 #include <QMessageBox>
 #include <QMetaType>
+#include <QNetworkInterface>
 #include <QTime>
 #include <QtConcurrent/QtConcurrentRun>
 #include "citra_qt/game_list_p.h"
@@ -49,6 +53,7 @@ HostRoomWindow::HostRoomWindow(Core::System& system_, QWidget* parent, QStandard
 
     // Connect all the widgets to the appropriate events
     connect(ui->host, &QPushButton::clicked, this, &HostRoomWindow::Host);
+    connect(ui->copy_ip_button, &QPushButton::clicked, this, &HostRoomWindow::CopyIPToClipboard);
 
     // Restore the settings:
     ui->username->setText(UISettings::values.room_nickname);
@@ -68,6 +73,8 @@ HostRoomWindow::HostRoomWindow(Core::System& system_, QWidget* parent, QStandard
         ui->game_list->setCurrentIndex(index);
     }
     ui->room_description->setText(UISettings::values.room_description);
+
+    SetLocalIPAddress();
 }
 
 HostRoomWindow::~HostRoomWindow() = default;
@@ -130,6 +137,7 @@ void HostRoomWindow::Host() {
             }
         }
         ui->host->setDisabled(true);
+        std::string ip_address = ui->server_address_box->text().toStdString();
 
         auto game_name = ui->game_list->currentData(Qt::DisplayRole).toString();
         auto game_id = ui->game_list->currentData(GameListItemPath::ProgramIdRole).toLongLong();
@@ -144,7 +152,7 @@ void HostRoomWindow::Host() {
             bool created = room->Create(ui->room_name->text().toStdString(),
                                         ui->room_description->toPlainText().toStdString(), "",
                                         static_cast<u16>(port), password, ui->max_player->value(),
-                                        ui->username->text().toStdString(), game_name.toStdString(),
+                                        NetSettings::values.citra_username, game_name.toStdString(),
                                         game_id, CreateVerifyBackend(is_public), ban_list);
             if (!created) {
                 NetworkMessage::ErrorManager::ShowError(
@@ -193,8 +201,8 @@ void HostRoomWindow::Host() {
         }
 #endif
         member->Join(ui->username->text().toStdString(), Service::CFG::GetConsoleIdHash(system),
-                     "127.0.0.1", static_cast<u16>(port), 0, Network::NoPreferredMac, password,
-                     token);
+                     ip_address.c_str(), static_cast<u16>(port), 0, Network::NoPreferredMac,
+                     password, token);
 
         // Store settings
         UISettings::values.room_nickname = ui->username->text();
@@ -233,4 +241,27 @@ bool ComboBoxProxyModel::lessThan(const QModelIndex& left, const QModelIndex& ri
     auto leftData = left.data(GameListItemPath::TitleRole).toString();
     auto rightData = right.data(GameListItemPath::TitleRole).toString();
     return leftData.compare(rightData) < 0;
+}
+
+void HostRoomWindow::SetLocalIPAddress() {
+    QString local_ip;
+
+    foreach (const QHostAddress& address, QNetworkInterface::allAddresses()) {
+        if (address.protocol() == QAbstractSocket::IPv4Protocol &&
+            address != QHostAddress(QHostAddress::LocalHost)) {
+            local_ip = address.toString();
+            break;
+        }
+    }
+
+    if (!local_ip.isEmpty()) {
+        ui->server_address_box->setText(local_ip);
+    } else {
+        ui->server_address_box->setPlaceholderText(tr("Enter Server Address"));
+    }
+}
+
+void HostRoomWindow::CopyIPToClipboard() {
+    QClipboard* clipboard = QApplication::clipboard();
+    clipboard->setText(ui->server_address_box->text());
 }

--- a/src/citra_qt/multiplayer/host_room.h
+++ b/src/citra_qt/multiplayer/host_room.h
@@ -1,4 +1,4 @@
-// Copyright 2017 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/citra_qt/multiplayer/host_room.h
+++ b/src/citra_qt/multiplayer/host_room.h
@@ -49,6 +49,8 @@ public:
 
 private:
     void Host();
+    void SetLocalIPAddress();
+    void CopyIPToClipboard();
     std::unique_ptr<Network::VerifyUser::Backend> CreateVerifyBackend(bool use_validation) const;
 
     std::unique_ptr<Ui::HostRoom> ui;

--- a/src/citra_qt/multiplayer/host_room.ui
+++ b/src/citra_qt/multiplayer/host_room.ui
@@ -7,13 +7,34 @@
     <x>0</x>
     <y>0</y>
     <width>607</width>
-    <height>211</height>
+    <height>236</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Create Room</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="server_address_label">
+       <property name="text">
+        <string>Server Address:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="server_address_box"/>
+     </item>
+     <item>
+      <widget class="QPushButton" name="copy_ip_button">
+       <property name="text">
+        <string>Copy</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
    <item>
     <widget class="QWidget" name="settings" native="true">
      <layout class="QHBoxLayout">
@@ -31,38 +52,38 @@
         <property name="labelAlignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
-        <item row="0" column="0">
+        <item row="1" column="0">
          <widget class="QLabel" name="label">
           <property name="text">
            <string>Room Name</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="1">
+        <item row="1" column="1">
          <widget class="QLineEdit" name="room_name">
           <property name="maxLength">
            <number>50</number>
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
+        <item row="2" column="0">
          <widget class="QLabel" name="label_3">
           <property name="text">
            <string>Preferred Application</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
+        <item row="2" column="1">
          <widget class="QComboBox" name="game_list"/>
         </item>
-        <item row="2" column="0">
+        <item row="3" column="0">
          <widget class="QLabel" name="label_2">
           <property name="text">
            <string>Max Players</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
+        <item row="3" column="1">
          <widget class="QSpinBox" name="max_player">
           <property name="minimum">
            <number>2</number>
@@ -82,13 +103,20 @@
         <property name="labelAlignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
-        <item row="0" column="1">
-         <widget class="QLineEdit" name="username"/>
-        </item>
         <item row="0" column="0">
          <widget class="QLabel" name="label_6">
           <property name="text">
            <string>Username</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLineEdit" name="username"/>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Password</string>
           </property>
          </widget>
         </item>
@@ -102,6 +130,13 @@
           </property>
          </widget>
         </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Port</string>
+          </property>
+         </widget>
+        </item>
         <item row="2" column="1">
          <widget class="QLineEdit" name="port">
           <property name="inputMethodHints">
@@ -109,20 +144,6 @@
           </property>
           <property name="maxLength">
            <number>5</number>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_5">
-          <property name="text">
-           <string>Password</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_4">
-          <property name="text">
-           <string>Port</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
Re-opened from #613

> Allows you to set a custom IP address to the server address on room creation and automatically shows you the default local IP of your local network
> 
> Setting a custom server address can be useful for people who wish to use zero tier , playit.gg and other network forwarding services because by default azahar will prioritize the local network IP over these services who have their own IP
> 
> Demo:
> 
> ![image](https://github.com/user-attachments/assets/ee64d67f-6143-415f-88dd-deee41490f98)
> 