### PR TITLE
citra_meta: Remove explicitly set `SUBSYSTEM` value on Windows

### DIFF
--- a/src/citra_meta/CMakeLists.txt
+++ b/src/citra_meta/CMakeLists.txt
@@ -60,15 +60,6 @@ if (ENABLE_QT AND USE_DISCORD_PRESENCE)
     target_link_libraries(citra_meta PRIVATE discord-rpc)
 endif()
 
-if(WIN32)
-    # compile as a win32 gui application instead of a console application
-    if(MSVC)
-        set_target_properties(citra_meta PROPERTIES LINK_FLAGS_RELEASE "/SUBSYSTEM:WINDOWS")
-    elseif(MINGW)
-        set_target_properties(citra_meta PROPERTIES LINK_FLAGS_RELEASE "-mwindows")
-    endif()
-endif()
-
 if (CITRA_USE_PRECOMPILED_HEADERS)
     target_precompile_headers(citra_meta PRIVATE precompiled_headers.h)
 endif()


### PR DESCRIPTION
This allows console output to be produced when running the `azahar.exe` executable through the command line.