### PR TITLE
qt: Various updates to the settings menu to improve consistency

### DIFF
--- a/src/citra_qt/configuration/configure_general.cpp
+++ b/src/citra_qt/configuration/configure_general.cpp
@@ -60,12 +60,14 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
     });
 
     connect(ui->change_screenshot_dir, &QToolButton::clicked, this, [this] {
+        ui->change_screenshot_dir->setEnabled(false);
         const QString dir_path = QFileDialog::getExistingDirectory(
             this, tr("Select Screenshot Directory"), ui->screenshot_dir_path->text(),
             QFileDialog::ShowDirsOnly);
         if (!dir_path.isEmpty()) {
             ui->screenshot_dir_path->setText(dir_path);
         }
+        ui->change_screenshot_dir->setEnabled(true);
     });
 }
 
@@ -135,12 +137,14 @@ void ConfigureGeneral::SetConfiguration() {
 }
 
 void ConfigureGeneral::ResetDefaults() {
+    ui->button_reset_defaults->setEnabled(false);
     QMessageBox::StandardButton answer = QMessageBox::question(
         this, tr("Azahar"),
         tr("Are you sure you want to <b>reset your settings</b> and close Azahar?"),
         QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
 
     if (answer == QMessageBox::No) {
+        ui->button_reset_defaults->setEnabled(true);
         return;
     }
 

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -1,4 +1,4 @@
-// Copyright Citra Emulator Project / Lime3DS Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -377,8 +377,10 @@ ConfigureInput::ConfigureInput(Core::System& _system, QWidget* parent)
             });
 
     connect(ui->buttonMotionTouch, &QPushButton::clicked, this, [this] {
+        ui->buttonMotionTouch->setEnabled(false);
         QDialog* motion_touch_dialog = new ConfigureMotionTouch(this);
-        return motion_touch_dialog->exec();
+        motion_touch_dialog->exec();
+        ui->buttonMotionTouch->setEnabled(true);
     });
 
     ui->buttonDelete->setEnabled(ui->profile->count() > 1);
@@ -580,9 +582,11 @@ void ConfigureInput::MapFromButton(const Common::ParamPackage& params) {
 }
 
 void ConfigureInput::AutoMap() {
+    ui->buttonAutoMap->setEnabled(false);
     if (QMessageBox::information(this, tr("Information"),
                                  tr("After pressing OK, press any button on your joystick"),
                                  QMessageBox::Ok | QMessageBox::Cancel) == QMessageBox::Cancel) {
+        ui->buttonAutoMap->setEnabled(true);
         return;
     }
     input_setter = [this](const Common::ParamPackage& params) {
@@ -597,6 +601,7 @@ void ConfigureInput::AutoMap() {
     }
     timeout_timer->start(5000); // Cancel after 5 seconds
     poll_timer->start(200);     // Check for new inputs every 200ms
+    ui->buttonAutoMap->setEnabled(true);
 }
 
 void ConfigureInput::HandleClick(QPushButton* button,
@@ -671,13 +676,16 @@ void ConfigureInput::RetranslateUI() {
 }
 
 void ConfigureInput::NewProfile() {
+    ui->buttonNew->setEnabled(false);
     const QString name =
         QInputDialog::getText(this, tr("New Profile"), tr("Enter the name for the new profile."));
     if (name.isEmpty()) {
+        ui->buttonNew->setEnabled(true);
         return;
     }
     if (IsProfileNameDuplicate(name)) {
         WarnProposedProfileNameIsDuplicate();
+        ui->buttonNew->setEnabled(true);
         return;
     }
 
@@ -688,12 +696,15 @@ void ConfigureInput::NewProfile() {
     ui->profile->setCurrentIndex(Settings::values.current_input_profile_index);
     LoadConfiguration();
     ui->buttonDelete->setEnabled(ui->profile->count() > 1);
+    ui->buttonNew->setEnabled(true);
 }
 
 void ConfigureInput::DeleteProfile() {
+    ui->buttonDelete->setEnabled(false);
     const auto answer = QMessageBox::question(
         this, tr("Delete Profile"), tr("Delete profile %1?").arg(ui->profile->currentText()));
     if (answer != QMessageBox::Yes) {
+        ui->buttonDelete->setEnabled(true);
         return;
     }
     const int index = ui->profile->currentIndex();
@@ -705,18 +716,22 @@ void ConfigureInput::DeleteProfile() {
 }
 
 void ConfigureInput::RenameProfile() {
+    ui->buttonRename->setEnabled(false);
     const QString new_name = QInputDialog::getText(this, tr("Rename Profile"), tr("New name:"));
     if (new_name.isEmpty()) {
+        ui->buttonRename->setEnabled(true);
         return;
     }
     if (IsProfileNameDuplicate(new_name)) {
         WarnProposedProfileNameIsDuplicate();
+        ui->buttonRename->setEnabled(true);
         return;
     }
 
     ui->profile->setItemText(ui->profile->currentIndex(), new_name);
     Settings::RenameCurrentProfile(new_name.toStdString());
     Settings::SaveProfile(ui->profile->currentIndex());
+    ui->buttonRename->setEnabled(true);
 }
 
 bool ConfigureInput::IsProfileNameDuplicate(const QString& name) const {

--- a/src/citra_qt/configuration/configure_layout.cpp
+++ b/src/citra_qt/configuration/configure_layout.cpp
@@ -1,4 +1,4 @@
-// Copyright Citra Emulator Project / Lime3DS Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -98,8 +98,10 @@ ConfigureLayout::ConfigureLayout(QWidget* parent)
 #endif
 
     connect(ui->bg_button, &QPushButton::clicked, this, [this] {
+        ui->bg_button->setEnabled(false);
         const QColor new_bg_color = QColorDialog::getColor(bg_color);
         if (!new_bg_color.isValid()) {
+            ui->bg_button->setEnabled(true);
             return;
         }
         bg_color = new_bg_color;
@@ -107,6 +109,7 @@ ConfigureLayout::ConfigureLayout(QWidget* parent)
         pixmap.fill(bg_color);
         const QIcon color_icon(pixmap);
         ui->bg_button->setIcon(color_icon);
+        ui->bg_button->setEnabled(true);
     });
 }
 

--- a/src/citra_qt/configuration/configure_storage.cpp
+++ b/src/citra_qt/configuration/configure_storage.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -21,6 +21,7 @@ ConfigureStorage::ConfigureStorage(bool is_powered_on_, QWidget* parent)
     });
 
     connect(ui->change_nand_dir, &QPushButton::clicked, this, [this]() {
+        ui->change_nand_dir->setEnabled(false);
         const QString dir_path = QFileDialog::getExistingDirectory(
             this, tr("Select NAND Directory"),
             QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir)),
@@ -29,6 +30,7 @@ ConfigureStorage::ConfigureStorage(bool is_powered_on_, QWidget* parent)
             FileUtil::UpdateUserPath(FileUtil::UserPath::NANDDir, dir_path.toStdString());
             SetConfiguration();
         }
+        ui->change_nand_dir->setEnabled(true);
     });
 
     connect(ui->open_sdmc_dir, &QPushButton::clicked, []() {
@@ -37,6 +39,7 @@ ConfigureStorage::ConfigureStorage(bool is_powered_on_, QWidget* parent)
     });
 
     connect(ui->change_sdmc_dir, &QPushButton::clicked, this, [this]() {
+        ui->change_sdmc_dir->setEnabled(false);
         const QString dir_path = QFileDialog::getExistingDirectory(
             this, tr("Select SDMC Directory"),
             QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)),
@@ -45,6 +48,7 @@ ConfigureStorage::ConfigureStorage(bool is_powered_on_, QWidget* parent)
             FileUtil::UpdateUserPath(FileUtil::UserPath::SDMCDir, dir_path.toStdString());
             SetConfiguration();
         }
+        ui->change_sdmc_dir->setEnabled(true);
     });
 
     connect(ui->toggle_virtual_sd, &QCheckBox::clicked, this, [this]() {

--- a/src/citra_qt/configuration/configure_system.cpp
+++ b/src/citra_qt/configuration/configure_system.cpp
@@ -238,7 +238,7 @@ ConfigureSystem::ConfigureSystem(Core::System& system_, QWidget* parent)
     connect(ui->button_regenerate_console_id, &QPushButton::clicked, this,
             &ConfigureSystem::RefreshConsoleID);
     connect(ui->button_regenerate_mac, &QPushButton::clicked, this, &ConfigureSystem::RefreshMAC);
-    connect(ui->button_linked_console, &QPushButton::clicked, this,
+    connect(ui->button_unlink_console, &QPushButton::clicked, this,
             &ConfigureSystem::UnlinkConsole);
     connect(ui->combo_country, qOverload<int>(&QComboBox::currentIndexChanged), this,
             [this](int index) {
@@ -557,15 +557,17 @@ void ConfigureSystem::UpdateInitTicks(int init_ticks_type) {
 }
 
 void ConfigureSystem::RefreshConsoleID() {
+    ui->button_regenerate_console_id->setEnabled(false);
     QMessageBox::StandardButton reply;
     QString warning_text =
         tr("This will replace your current virtual 3DS console ID with a new one. "
            "Your current virtual 3DS console ID will not be recoverable. "
            "This might have unexpected effects in applications. This might fail "
            "if you use an outdated config save. Continue?");
-    reply = QMessageBox::critical(this, tr("Warning"), warning_text,
-                                  QMessageBox::No | QMessageBox::Yes);
+    reply =
+        QMessageBox::warning(this, tr("Warning"), warning_text, QMessageBox::No | QMessageBox::Yes);
     if (reply == QMessageBox::No) {
+        ui->button_regenerate_console_id->setEnabled(true);
         return;
     }
 
@@ -574,9 +576,11 @@ void ConfigureSystem::RefreshConsoleID() {
     cfg->UpdateConfigNANDSavegame();
     ui->label_console_id->setText(
         tr("Console ID: 0x%1").arg(QString::number(console_id, 16).toUpper()));
+    ui->button_regenerate_console_id->setEnabled(true);
 }
 
 void ConfigureSystem::RefreshMAC() {
+    ui->button_regenerate_mac->setEnabled(false);
     QMessageBox::StandardButton reply;
     QString warning_text = tr("This will replace your current MAC address with a new one. "
                               "It is not recommended to do this if you got the MAC address from "
@@ -584,14 +588,17 @@ void ConfigureSystem::RefreshMAC() {
     reply =
         QMessageBox::warning(this, tr("Warning"), warning_text, QMessageBox::No | QMessageBox::Yes);
     if (reply == QMessageBox::No) {
+        ui->button_regenerate_mac->setEnabled(true);
         return;
     }
 
     mac_address = Service::CFG::GenerateRandomMAC();
     ui->label_mac->setText(tr("MAC: %1").arg(QString::fromStdString(mac_address)));
+    ui->button_regenerate_mac->setEnabled(true);
 }
 
 void ConfigureSystem::UnlinkConsole() {
+    ui->button_unlink_console->setEnabled(false);
     QMessageBox::StandardButton reply;
     QString warning_text =
         tr("This action will unlink your real console from Azahar, with the following "
@@ -603,11 +610,13 @@ void ConfigureSystem::UnlinkConsole() {
     reply =
         QMessageBox::warning(this, tr("Warning"), warning_text, QMessageBox::No | QMessageBox::Yes);
     if (reply == QMessageBox::No) {
+        ui->button_unlink_console->setEnabled(true);
         return;
     }
 
     HW::UniqueData::UnlinkConsole();
     RefreshSecureDataStatus();
+    ui->button_unlink_console->setEnabled(true);
 }
 
 void ConfigureSystem::CheckCountryValid(u8 country) {

--- a/src/citra_qt/configuration/configure_system.ui
+++ b/src/citra_qt/configuration/configure_system.ui
@@ -590,7 +590,7 @@ online features (if installed)</string>
                     </widget>
                    </item>
                    <item>
-                    <widget class="QPushButton" name="button_linked_console">
+                    <widget class="QPushButton" name="button_unlink_console">
                      <property name="sizePolicy">
                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                        <horstretch>0</horstretch>


### PR DESCRIPTION
- All buttons which open a modal interface now disable themselves until their interface is closed
- Renamed button_linked_console to button_unlink_console to better reflect what it actually does
- Changed the warning icon of the Regenerate Console ID button to be the same as the Regenerate MAC Address button

Closes #469

Will self-review due to the trivial nature of these changes