### PR TITLE
android: Added button sliding to button overlay

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
@@ -849,9 +849,9 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
         val editor = preferences.edit()
 
         val buttonslidingmodes = mutableListOf<String>()
-        buttonslidingmodes.add(getString(R.string.emulation_button_sliding_mode_none))
-        buttonslidingmodes.add(getString(R.string.emulation_button_sliding_mode_simple))
-        buttonslidingmodes.add(getString(R.string.emulation_button_sliding_mode_keep_first))
+        buttonslidingmodes.add(getString(R.string.emulation_button_sliding_mode_disabled))
+        buttonslidingmodes.add(getString(R.string.emulation_button_sliding_mode_enabled))
+        buttonslidingmodes.add(getString(R.string.emulation_button_sliding_mode_alternative))
 
         MaterialAlertDialogBuilder(requireContext())
             .setTitle(R.string.emulation_button_sliding_mode)

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
@@ -796,7 +796,7 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
                     true
                 }
 
-                R.id.menu_emulation_button_sliding_mode -> {
+                R.id.menu_emulation_button_sliding -> {
                     showButtonSlidingModeMenu()
                     true
                 }
@@ -849,12 +849,12 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
         val editor = preferences.edit()
 
         val buttonSlidingModes = mutableListOf<String>()
-        buttonSlidingModes.add(getString(R.string.emulation_button_sliding_mode_disabled))
-        buttonSlidingModes.add(getString(R.string.emulation_button_sliding_mode_enabled))
-        buttonSlidingModes.add(getString(R.string.emulation_button_sliding_mode_alternative))
+        buttonSlidingModes.add(getString(R.string.emulation_button_sliding_disabled))
+        buttonSlidingModes.add(getString(R.string.emulation_button_sliding_enabled))
+        buttonSlidingModes.add(getString(R.string.emulation_button_sliding_alternative))
 
         MaterialAlertDialogBuilder(requireContext())
-            .setTitle(R.string.emulation_button_sliding_mode)
+            .setTitle(R.string.emulation_button_sliding)
             .setSingleChoiceItems(
                 buttonSlidingModes.toTypedArray(),
                 EmulationMenuSettings.buttonSlide

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
@@ -848,15 +848,15 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
     private fun showButtonSlidingModeMenu() {
         val editor = preferences.edit()
 
-        val buttonslidingmodes = mutableListOf<String>()
-        buttonslidingmodes.add(getString(R.string.emulation_button_sliding_mode_disabled))
-        buttonslidingmodes.add(getString(R.string.emulation_button_sliding_mode_enabled))
-        buttonslidingmodes.add(getString(R.string.emulation_button_sliding_mode_alternative))
+        val buttonSlidingModes = mutableListOf<String>()
+        buttonSlidingModes.add(getString(R.string.emulation_button_sliding_mode_disabled))
+        buttonSlidingModes.add(getString(R.string.emulation_button_sliding_mode_enabled))
+        buttonSlidingModes.add(getString(R.string.emulation_button_sliding_mode_alternative))
 
         MaterialAlertDialogBuilder(requireContext())
             .setTitle(R.string.emulation_button_sliding_mode)
             .setSingleChoiceItems(
-                buttonslidingmodes.toTypedArray(),
+                buttonSlidingModes.toTypedArray(),
                 EmulationMenuSettings.buttonSlide
             ) { _: DialogInterface?, which: Int ->
                 EmulationMenuSettings.buttonSlide = which

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
@@ -797,7 +797,7 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
                 }
 
                 R.id.menu_emulation_button_sliding -> {
-                    showButtonSlidingModeMenu()
+                    showButtonSlidingMenu()
                     true
                 }
 
@@ -845,7 +845,7 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
         popupMenu.show()
     }
 
-    private fun showButtonSlidingModeMenu() {
+    private fun showButtonSlidingMenu() {
         val editor = preferences.edit()
 
         val buttonSlidingModes = mutableListOf<String>()

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
@@ -796,6 +796,11 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
                     true
                 }
 
+                R.id.menu_emulation_button_sliding_mode -> {
+                    showButtonSlidingModeMenu()
+                    true
+                }
+
                 R.id.menu_emulation_dpad_slide_enable -> {
                     EmulationMenuSettings.dpadSlide = !EmulationMenuSettings.dpadSlide
                     true
@@ -838,6 +843,28 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
         }
 
         popupMenu.show()
+    }
+
+    private fun showButtonSlidingModeMenu() {
+        val editor = preferences.edit()
+
+        val buttonslidingmodes = mutableListOf<String>()
+        buttonslidingmodes.add(getString(R.string.emulation_button_sliding_mode_none))
+        buttonslidingmodes.add(getString(R.string.emulation_button_sliding_mode_simple))
+        buttonslidingmodes.add(getString(R.string.emulation_button_sliding_mode_keep_first))
+
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.emulation_button_sliding_mode)
+            .setSingleChoiceItems(
+                buttonslidingmodes.toTypedArray(),
+                EmulationMenuSettings.buttonSlide
+            ) { _: DialogInterface?, which: Int ->
+                EmulationMenuSettings.buttonSlide = which
+            }
+            .setPositiveButton(android.R.string.ok) { _: DialogInterface?, _: Int ->
+                editor.apply()
+            }
+            .show()
     }
 
     private fun showLandscapeScreenLayoutMenu() {

--- a/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlay.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlay.kt
@@ -129,7 +129,8 @@ class InputOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(contex
         var shouldUpdateView = false
         if(!hasActiveDpad && !hasActiveJoy) {
             for (button in overlayButtons) {
-                if (!button.updateStatus(event, hasActiveButtons, this)) {
+                val stateChanged = button.updateStatus(event, hasActiveButtons, this)
+                if (!stateChanged) {
                     continue
                 }
 
@@ -145,21 +146,23 @@ class InputOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(contex
                     button.id,
                     button.status
                 )
+
                 shouldUpdateView = true
             }
         }
 
         if(!hasActiveButtons && !hasActiveJoy) {
             for (dpad in overlayDpads) {
-                if (!dpad.updateStatus(
-                        event,
-                        hasActiveDpad,
-                        EmulationMenuSettings.dpadSlide,
-                        this
-                    )
-                ) {
+                val stateChanged = dpad.updateStatus(
+                    event,
+                    hasActiveDpad,
+                    EmulationMenuSettings.dpadSlide,
+                    this
+                )
+                if (!stateChanged) {
                     continue
                 }
+
                 NativeLibrary.onGamePadEvent(
                     NativeLibrary.TouchScreenDevice,
                     dpad.upId,
@@ -180,15 +183,18 @@ class InputOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(contex
                     dpad.rightId,
                     dpad.rightStatus
                 )
+
                 shouldUpdateView = true
             }
         }
 
         if(!hasActiveDpad && !hasActiveButtons) {
             for (joystick in overlayJoysticks) {
-                if (!joystick.updateStatus(event, hasActiveJoy, this)) {
+                val stateChanged = joystick.updateStatus(event, hasActiveJoy, this)
+                if (!stateChanged) {
                     continue
                 }
+
                 val axisID = joystick.joystickId
                 NativeLibrary.onGamePadMoveEvent(
                     NativeLibrary.TouchScreenDevice,
@@ -196,6 +202,7 @@ class InputOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(contex
                     joystick.xAxis,
                     joystick.yAxis
                 )
+
                 shouldUpdateView = true
             }
         }

--- a/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlay.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlay.kt
@@ -96,57 +96,108 @@ class InputOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(contex
         if (isInEditMode) {
             return onTouchWhileEditing(event)
         }
-        var shouldUpdateView = false
+
+        var hasActiveButtons = false
+        val pointerIndex = event.actionIndex
+        val pointerId = event.getPointerId(pointerIndex)
         for (button in overlayButtons) {
-            if (!button.updateStatus(event, this)) {
-                continue
+            if (button.trackId == pointerId) {
+                hasActiveButtons = true
+                break
             }
-
-            if (button.id == NativeLibrary.ButtonType.BUTTON_SWAP && button.status == NativeLibrary.ButtonState.PRESSED) {
-                swapScreen()
-            }
-
-            if (button.id == NativeLibrary.ButtonType.BUTTON_TURBO && button.status == NativeLibrary.ButtonState.PRESSED) {
-                TurboHelper.toggleTurbo(true)
-            }
-
-            NativeLibrary.onGamePadEvent(NativeLibrary.TouchScreenDevice, button.id, button.status)
-            shouldUpdateView = true
         }
-        for (dpad in overlayDpads) {
-            if (!dpad.updateStatus(event, EmulationMenuSettings.dpadSlide, this)) {
-                continue
+        var hasActiveDpad = false
+        if (!hasActiveButtons) {
+            for (dpad in overlayDpads) {
+                if (dpad.trackId == pointerId) {
+                    hasActiveDpad = true
+                    break
+                }
             }
-            NativeLibrary.onGamePadEvent(NativeLibrary.TouchScreenDevice, dpad.upId, dpad.upStatus)
-            NativeLibrary.onGamePadEvent(
-                NativeLibrary.TouchScreenDevice,
-                dpad.downId,
-                dpad.downStatus
-            )
-            NativeLibrary.onGamePadEvent(
-                NativeLibrary.TouchScreenDevice,
-                dpad.leftId,
-                dpad.leftStatus
-            )
-            NativeLibrary.onGamePadEvent(
-                NativeLibrary.TouchScreenDevice,
-                dpad.rightId,
-                dpad.rightStatus
-            )
-            shouldUpdateView = true
         }
-        for (joystick in overlayJoysticks) {
-            if (!joystick.updateStatus(event, this)) {
-                continue
+
+        var hasActiveJoy = false
+        if(!hasActiveButtons && !hasActiveDpad){
+            for (joystick in overlayJoysticks) {
+                if (joystick.trackId == pointerId) {
+                    hasActiveJoy = true
+                    break
+                }
             }
-            val axisID = joystick.joystickId
-            NativeLibrary.onGamePadMoveEvent(
-                NativeLibrary.TouchScreenDevice,
-                axisID,
-                joystick.xAxis,
-                joystick.yAxis
-            )
-            shouldUpdateView = true
+        }
+
+        var shouldUpdateView = false
+        if(!hasActiveDpad && !hasActiveJoy) {
+            for (button in overlayButtons) {
+                if (!button.updateStatus(event, hasActiveButtons, this)) {
+                    continue
+                }
+
+                if (button.id == NativeLibrary.ButtonType.BUTTON_SWAP && button.status == NativeLibrary.ButtonState.PRESSED) {
+                    swapScreen()
+                }
+                else if (button.id == NativeLibrary.ButtonType.BUTTON_TURBO && button.status == NativeLibrary.ButtonState.PRESSED) {
+                    TurboHelper.toggleTurbo(true)
+                }
+
+                NativeLibrary.onGamePadEvent(
+                    NativeLibrary.TouchScreenDevice,
+                    button.id,
+                    button.status
+                )
+                shouldUpdateView = true
+            }
+        }
+
+        if(!hasActiveButtons && !hasActiveJoy) {
+            for (dpad in overlayDpads) {
+                if (!dpad.updateStatus(
+                        event,
+                        hasActiveDpad,
+                        EmulationMenuSettings.dpadSlide,
+                        this
+                    )
+                ) {
+                    continue
+                }
+                NativeLibrary.onGamePadEvent(
+                    NativeLibrary.TouchScreenDevice,
+                    dpad.upId,
+                    dpad.upStatus
+                )
+                NativeLibrary.onGamePadEvent(
+                    NativeLibrary.TouchScreenDevice,
+                    dpad.downId,
+                    dpad.downStatus
+                )
+                NativeLibrary.onGamePadEvent(
+                    NativeLibrary.TouchScreenDevice,
+                    dpad.leftId,
+                    dpad.leftStatus
+                )
+                NativeLibrary.onGamePadEvent(
+                    NativeLibrary.TouchScreenDevice,
+                    dpad.rightId,
+                    dpad.rightStatus
+                )
+                shouldUpdateView = true
+            }
+        }
+
+        if(!hasActiveDpad && !hasActiveButtons) {
+            for (joystick in overlayJoysticks) {
+                if (!joystick.updateStatus(event, hasActiveJoy, this)) {
+                    continue
+                }
+                val axisID = joystick.joystickId
+                NativeLibrary.onGamePadMoveEvent(
+                    NativeLibrary.TouchScreenDevice,
+                    axisID,
+                    joystick.xAxis,
+                    joystick.yAxis
+                )
+                shouldUpdateView = true
+            }
         }
 
         if (shouldUpdateView) {
@@ -157,10 +208,8 @@ class InputOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(contex
             return true
         }
 
-        val pointerIndex = event.actionIndex
         val xPosition = event.getX(pointerIndex).toInt()
         val yPosition = event.getY(pointerIndex).toInt()
-        val pointerId = event.getPointerId(pointerIndex)
         val motionEvent = event.action and MotionEvent.ACTION_MASK
         val isActionDown =
             motionEvent == MotionEvent.ACTION_DOWN || motionEvent == MotionEvent.ACTION_POINTER_DOWN

--- a/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlay.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlay.kt
@@ -116,18 +116,18 @@ class InputOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(contex
             }
         }
 
-        var hasActiveJoy = false
+        var hasActiveJoystick = false
         if(!hasActiveButtons && !hasActiveDpad){
             for (joystick in overlayJoysticks) {
                 if (joystick.trackId == pointerId) {
-                    hasActiveJoy = true
+                    hasActiveJoystick = true
                     break
                 }
             }
         }
 
         var shouldUpdateView = false
-        if(!hasActiveDpad && !hasActiveJoy) {
+        if(!hasActiveDpad && !hasActiveJoystick) {
             for (button in overlayButtons) {
                 val stateChanged = button.updateStatus(event, hasActiveButtons, this)
                 if (!stateChanged) {
@@ -151,7 +151,7 @@ class InputOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(contex
             }
         }
 
-        if(!hasActiveButtons && !hasActiveJoy) {
+        if(!hasActiveButtons && !hasActiveJoystick) {
             for (dpad in overlayDpads) {
                 val stateChanged = dpad.updateStatus(
                     event,
@@ -190,7 +190,7 @@ class InputOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(contex
 
         if(!hasActiveDpad && !hasActiveButtons) {
             for (joystick in overlayJoysticks) {
-                val stateChanged = joystick.updateStatus(event, hasActiveJoy, this)
+                val stateChanged = joystick.updateStatus(event, hasActiveJoystick, this)
                 if (!stateChanged) {
                     continue
                 }

--- a/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableButton.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableButton.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableButton.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableButton.kt
@@ -16,15 +16,15 @@ import org.citra.citra_emu.utils.EmulationMenuSettings
 
 enum class ButtonSlidingMode(val int: Int) {
     // Disabled, buttons can only be triggered by pressing them directly.
-    None(0),
+    Disabled(0),
 
     // Additionally to pressing buttons directly, they can be activated and released by sliding into
     // and out of their area.
-    Simple(1),
+    Enabled(1),
 
     // The first button is kept activated until released, further buttons use the simple button
     // sliding method.
-    KeepFirst(2)
+    Alternative(2)
 }
 
 /**
@@ -97,7 +97,7 @@ class InputOverlayDrawableButton(
         }
 
         val isActionMoving = motionEvent == MotionEvent.ACTION_MOVE
-        if (buttonSliding != ButtonSlidingMode.None.int && isActionMoving) {
+        if (buttonSliding != ButtonSlidingMode.Disabled.int && isActionMoving) {
             val inside = bounds.contains(xPosition, yPosition)
             if (pressedState) {
                 // button is already pressed
@@ -106,7 +106,7 @@ class InputOverlayDrawableButton(
                     return false
                 }
                 // prevent the first (directly pressed) button to deactivate when sliding off
-                if (buttonSliding == ButtonSlidingMode.KeepFirst.int && isMotionFirstButton) {
+                if (buttonSliding == ButtonSlidingMode.Alternative.int && isMotionFirstButton) {
                     return false
                 }
                 buttonUp(overlay)

--- a/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableButton.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableButton.kt
@@ -45,7 +45,7 @@ class InputOverlayDrawableButton(
 ) {
     var trackId: Int
 
-    private var isMotionFirstButton = false // mark buttons that did not get activated by sliding
+    private var isMotionFirstButton = false // mark the first activated button with the current motion
 
     private var previousTouchX = 0
     private var previousTouchY = 0

--- a/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableButton.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableButton.kt
@@ -12,18 +12,19 @@ import android.graphics.drawable.BitmapDrawable
 import android.view.HapticFeedbackConstants
 import android.view.MotionEvent
 import org.citra.citra_emu.NativeLibrary
+import org.citra.citra_emu.utils.EmulationMenuSettings
 
-enum class ButtonSlidingMode {
+enum class ButtonSlidingMode(val int: Int) {
     // Disabled, buttons can only be triggered by pressing them directly.
-    None,
+    None(0),
 
     // Additionally to pressing buttons directly, they can be activated and released by sliding into
     // and out of their area.
-    Simple,
+    Simple(1),
 
     // A pressed button is kept activated until released. Further buttons can be triggered with the
     // sliding method.
-    KeepFirst
+    KeepFirst(2)
 }
 
 /**
@@ -44,7 +45,6 @@ class InputOverlayDrawableButton(
 ) {
     var trackId: Int
 
-    var buttonSliding = ButtonSlidingMode.Simple
     private var pressedDirectTouch = false // mark buttons that did not get activated by sliding
 
     private var previousTouchX = 0
@@ -71,6 +71,7 @@ class InputOverlayDrawableButton(
      * @return true if value was changed
      */
     fun updateStatus(event: MotionEvent, overlay:InputOverlay): Boolean {
+        val buttonSliding = EmulationMenuSettings.buttonSlide
         val pointerIndex = event.actionIndex
         val xPosition = event.getX(pointerIndex).toInt()
         val yPosition = event.getY(pointerIndex).toInt()
@@ -102,7 +103,7 @@ class InputOverlayDrawableButton(
         }
 
         val isActionMoving = motionEvent == MotionEvent.ACTION_MOVE
-        if (buttonSliding != ButtonSlidingMode.None && isActionMoving) {
+        if (buttonSliding != ButtonSlidingMode.None.int && isActionMoving) {
             val inside = bounds.contains(xPosition, yPosition)
             if (pressedState) {
                 // button is already pressed
@@ -111,7 +112,7 @@ class InputOverlayDrawableButton(
                     return false
                 }
                 // prevent the first (directly pressed) button to deactivate when sliding off
-                if (buttonSliding == ButtonSlidingMode.KeepFirst && pressedDirectTouch) {
+                if (buttonSliding == ButtonSlidingMode.KeepFirst.int && pressedDirectTouch) {
                     return false
                 }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableDpad.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableDpad.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -12,6 +12,7 @@ import android.graphics.drawable.BitmapDrawable
 import android.view.HapticFeedbackConstants
 import android.view.MotionEvent
 import org.citra.citra_emu.NativeLibrary
+import org.citra.citra_emu.utils.EmulationMenuSettings
 
 /**
  * Custom [BitmapDrawable] that is capable
@@ -62,15 +63,19 @@ class InputOverlayDrawableDpad(
         trackId = -1
     }
 
-    fun updateStatus(event: MotionEvent, dpadSlide: Boolean, overlay:InputOverlay): Boolean {
+    fun updateStatus(event: MotionEvent, hasActiveButtons: Boolean, dpadSlide: Boolean, overlay: InputOverlay): Boolean {
         var isDown = false
         val pointerIndex = event.actionIndex
         val xPosition = event.getX(pointerIndex).toInt()
         val yPosition = event.getY(pointerIndex).toInt()
         val pointerId = event.getPointerId(pointerIndex)
         val motionEvent = event.action and MotionEvent.ACTION_MASK
-        val isActionDown =
+        var isActionDown =
             motionEvent == MotionEvent.ACTION_DOWN || motionEvent == MotionEvent.ACTION_POINTER_DOWN
+        if (!isActionDown && EmulationMenuSettings.buttonSlide != ButtonSlidingMode.None.int) {
+            isActionDown = motionEvent == MotionEvent.ACTION_MOVE && !hasActiveButtons
+        }
+
         val isActionUp =
             motionEvent == MotionEvent.ACTION_UP || motionEvent == MotionEvent.ACTION_POINTER_UP
         if (isActionDown) {

--- a/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableDpad.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableDpad.kt
@@ -72,7 +72,7 @@ class InputOverlayDrawableDpad(
         val motionEvent = event.action and MotionEvent.ACTION_MASK
         var isActionDown =
             motionEvent == MotionEvent.ACTION_DOWN || motionEvent == MotionEvent.ACTION_POINTER_DOWN
-        if (!isActionDown && EmulationMenuSettings.buttonSlide != ButtonSlidingMode.None.int) {
+        if (!isActionDown && EmulationMenuSettings.buttonSlide != ButtonSlidingMode.Disabled.int) {
             isActionDown = motionEvent == MotionEvent.ACTION_MOVE && !hasActiveButtons
         }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableJoystick.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableJoystick.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -93,14 +93,18 @@ class InputOverlayDrawableJoystick(
         currentStateBitmapDrawable.draw(canvas)
     }
 
-    fun updateStatus(event: MotionEvent, overlay:InputOverlay): Boolean {
+    fun updateStatus(event: MotionEvent, hasActiveButtons: Boolean, overlay: InputOverlay): Boolean {
         val pointerIndex = event.actionIndex
         val xPosition = event.getX(pointerIndex).toInt()
         val yPosition = event.getY(pointerIndex).toInt()
         val pointerId = event.getPointerId(pointerIndex)
         val motionEvent = event.action and MotionEvent.ACTION_MASK
-        val isActionDown =
+        var isActionDown =
             motionEvent == MotionEvent.ACTION_DOWN || motionEvent == MotionEvent.ACTION_POINTER_DOWN
+        if (!isActionDown && EmulationMenuSettings.buttonSlide != ButtonSlidingMode.None.int) {
+            isActionDown = motionEvent == MotionEvent.ACTION_MOVE && !hasActiveButtons
+        }
+
         val isActionUp =
             motionEvent == MotionEvent.ACTION_UP || motionEvent == MotionEvent.ACTION_POINTER_UP
         if (isActionDown) {

--- a/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableJoystick.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableJoystick.kt
@@ -101,7 +101,7 @@ class InputOverlayDrawableJoystick(
         val motionEvent = event.action and MotionEvent.ACTION_MASK
         var isActionDown =
             motionEvent == MotionEvent.ACTION_DOWN || motionEvent == MotionEvent.ACTION_POINTER_DOWN
-        if (!isActionDown && EmulationMenuSettings.buttonSlide != ButtonSlidingMode.None.int) {
+        if (!isActionDown && EmulationMenuSettings.buttonSlide != ButtonSlidingMode.Disabled.int) {
             isActionDown = motionEvent == MotionEvent.ACTION_MOVE && !hasActiveButtons
         }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationMenuSettings.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationMenuSettings.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationMenuSettings.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationMenuSettings.kt
@@ -7,6 +7,7 @@ package org.citra.citra_emu.utils
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.preference.PreferenceManager
 import org.citra.citra_emu.CitraApplication
+import org.citra.citra_emu.overlay.ButtonSlidingMode
 
 object EmulationMenuSettings {
     private val preferences =
@@ -24,6 +25,13 @@ object EmulationMenuSettings {
         set(value) {
             preferences.edit()
                 .putBoolean("EmulationMenuSettings_DpadSlideEnable", value)
+                .apply()
+        }
+    var buttonSlide: Int
+        get() = preferences.getInt("EmulationMenuSettings_ButtonSlideMode", ButtonSlidingMode.None.int)
+        set(value) {
+            preferences.edit()
+                .putInt("EmulationMenuSettings_ButtonSlideMode", value)
                 .apply()
         }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationMenuSettings.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationMenuSettings.kt
@@ -28,7 +28,7 @@ object EmulationMenuSettings {
                 .apply()
         }
     var buttonSlide: Int
-        get() = preferences.getInt("EmulationMenuSettings_ButtonSlideMode", ButtonSlidingMode.None.int)
+        get() = preferences.getInt("EmulationMenuSettings_ButtonSlideMode", ButtonSlidingMode.Disabled.int)
         set(value) {
             preferences.edit()
                 .putInt("EmulationMenuSettings_ButtonSlideMode", value)

--- a/src/android/app/src/main/res/menu/menu_overlay_options.xml
+++ b/src/android/app/src/main/res/menu/menu_overlay_options.xml
@@ -86,6 +86,10 @@
         android:id="@+id/menu_emulation_adjust_opacity"
         android:title="@string/emulation_control_opacity" />
 
+    <item
+        android:id="@+id/menu_emulation_button_sliding_mode"
+        android:title="@string/emulation_button_sliding_mode">
+    </item>
     <group android:checkableBehavior="all">
         <item
             android:id="@+id/menu_emulation_joystick_rel_center"

--- a/src/android/app/src/main/res/menu/menu_overlay_options.xml
+++ b/src/android/app/src/main/res/menu/menu_overlay_options.xml
@@ -87,8 +87,8 @@
         android:title="@string/emulation_control_opacity" />
 
     <item
-        android:id="@+id/menu_emulation_button_sliding_mode"
-        android:title="@string/emulation_button_sliding_mode">
+        android:id="@+id/menu_emulation_button_sliding"
+        android:title="@string/emulation_button_sliding">
     </item>
     <group android:checkableBehavior="all">
         <item

--- a/src/android/app/src/main/res/values-de/strings.xml
+++ b/src/android/app/src/main/res/values-de/strings.xml
@@ -397,10 +397,6 @@
     <string name="emulation_configure_controls">Steuerung konfigurieren</string>
     <string name="emulation_edit_layout">Anordnung bearbeiten</string>
     <string name="emulation_done">Fertig</string>
-    <string name="emulation_button_sliding_mode">Knopf-Gleiten</string>
-    <string name="emulation_button_sliding_mode_none">Aus</string>
-    <string name="emulation_button_sliding_mode_simple">Einfach</string>
-    <string name="emulation_button_sliding_mode_keep_first">Erster Knopf bleibt, über weitere Knöpfe gleiten</string>
     <string name="emulation_toggle_controls">Knöpfe ein-/ausschalten</string>
     <string name="emulation_control_scale">Größe anpassen</string>
     <string name="emulation_control_scale_global">Globale Skalierung</string>

--- a/src/android/app/src/main/res/values-de/strings.xml
+++ b/src/android/app/src/main/res/values-de/strings.xml
@@ -397,6 +397,10 @@
     <string name="emulation_configure_controls">Steuerung konfigurieren</string>
     <string name="emulation_edit_layout">Anordnung bearbeiten</string>
     <string name="emulation_done">Fertig</string>
+    <string name="emulation_button_sliding_mode">Knopf-Gleiten</string>
+    <string name="emulation_button_sliding_mode_none">Aus</string>
+    <string name="emulation_button_sliding_mode_simple">Einfach</string>
+    <string name="emulation_button_sliding_mode_keep_first">Erster Knopf bleibt, über weitere Knöpfe gleiten</string>
     <string name="emulation_toggle_controls">Knöpfe ein-/ausschalten</string>
     <string name="emulation_control_scale">Größe anpassen</string>
     <string name="emulation_control_scale_global">Globale Skalierung</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -419,9 +419,9 @@
     <string name="emulation_edit_layout">Edit Layout</string>
     <string name="emulation_done">Done</string>
     <string name="emulation_button_sliding_mode">Button Sliding</string>
-    <string name="emulation_button_sliding_mode_none">Off</string>
-    <string name="emulation_button_sliding_mode_simple">Simple</string>
-    <string name="emulation_button_sliding_mode_keep_first">Keep first button, slide over other buttons</string>
+    <string name="emulation_button_sliding_mode_disabled">Hold originally pressed button</string>
+    <string name="emulation_button_sliding_mode_enabled">Hold currently pressed button</string>
+    <string name="emulation_button_sliding_mode_alternative">Hold original and currently pressed button</string>
     <string name="emulation_toggle_controls">Toggle Controls</string>
     <string name="emulation_control_scale">Adjust Scale</string>
     <string name="emulation_control_scale_global">Global Scale</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -418,10 +418,10 @@
     <string name="emulation_configure_controls">Configure Controls</string>
     <string name="emulation_edit_layout">Edit Layout</string>
     <string name="emulation_done">Done</string>
-    <string name="emulation_button_sliding_mode">Button Sliding</string>
-    <string name="emulation_button_sliding_mode_disabled">Hold originally pressed button</string>
-    <string name="emulation_button_sliding_mode_enabled">Hold currently pressed button</string>
-    <string name="emulation_button_sliding_mode_alternative">Hold original and currently pressed button</string>
+    <string name="emulation_button_sliding">Button Sliding</string>
+    <string name="emulation_button_sliding_disabled">Hold originally pressed button</string>
+    <string name="emulation_button_sliding_enabled">Hold currently pressed button</string>
+    <string name="emulation_button_sliding_alternative">Hold original and currently pressed button</string>
     <string name="emulation_toggle_controls">Toggle Controls</string>
     <string name="emulation_control_scale">Adjust Scale</string>
     <string name="emulation_control_scale_global">Global Scale</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -418,6 +418,10 @@
     <string name="emulation_configure_controls">Configure Controls</string>
     <string name="emulation_edit_layout">Edit Layout</string>
     <string name="emulation_done">Done</string>
+    <string name="emulation_button_sliding_mode">Button Sliding</string>
+    <string name="emulation_button_sliding_mode_none">Off</string>
+    <string name="emulation_button_sliding_mode_simple">Simple</string>
+    <string name="emulation_button_sliding_mode_keep_first">Keep first button, slide over other buttons</string>
     <string name="emulation_toggle_controls">Toggle Controls</string>
     <string name="emulation_control_scale">Adjust Scale</string>
     <string name="emulation_control_scale_global">Global Scale</string>


### PR DESCRIPTION
Android: Added button sliding feature to button overlay

This PR addresses issue https://github.com/azahar-emu/azahar/issues/322

None: Button sliding disabled, buttons can only be triggered by pressing them directly.
Simple: Additionally to pressing buttons directly, they can be activated and released by sliding into and out of their area.
Keep First: The first button is kept activated until released, further buttons use the simple button sliding method.