### PR TITLE
qt: Explicitly set window icon

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -329,6 +329,8 @@ GMainWindow::GMainWindow(Core::System& system_)
     ui->setupUi(this);
     statusBar()->hide();
 
+    setWindowIcon(QIcon(QString::fromStdString(":/icons/azahar.png")));
+
     default_theme_paths = QIcon::themeSearchPaths();
     UpdateUITheme();
 


### PR DESCRIPTION
This fixes some previously known window icon issues on Linux

Will self-review due to the simplicity of the change.