### PR TITLE
Suppress MSVC warnings C4711 and C5045 during compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,13 @@ else()
     set(IS_RELEASE_BUILD ON)
 endif()
 
+if (MSVC)
+    add_compile_options(
+        /wd4711 # Suppresses `function 'xxxxx' selected for automatic inline expansion` messages
+        /wd5045 # Suppresses `Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified` messages
+    )
+endif()
+
 # LTO takes too much memory and time using MSVC.
 if (NOT MSVC AND IS_RELEASE_BUILD)
     set(DEFAULT_ENABLE_LTO ON)


### PR DESCRIPTION
These two warnings were being spammed throughout the entire build log to the extent that the build log for MSVC was roughly 4.5 times larger than the build log for MSYS2. This made the build log obnoxious to look at and even causes the GitHub web interface to slow down a bit.

Neither of these warnings are consequential.

Will self-review this PR because it makes no changes to the final compiled program and the results are easily visible via the actions build log.