### PR TITLE
qt: For Qt 6.9.0 and above, use QImage::flipped over QImage::mirrored

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -10,6 +10,7 @@
 #include <QWindow>
 #include "citra_qt/bootmanager.h"
 #include "citra_qt/citra_qt.h"
+#include "citra_qt/util/util.h"
 #include "common/color.h"
 #include "common/microprofile.h"
 #include "common/scm_rev.h"
@@ -714,7 +715,7 @@ void GRenderWindow::CaptureScreenshot(u32 res_scale, const QString& screenshot_p
         screenshot_image.bits(),
         [this, screenshot_path](bool invert_y) {
             const std::string std_screenshot_path = screenshot_path.toStdString();
-            if (screenshot_image.mirrored(false, invert_y).save(screenshot_path)) {
+            if (GetMirroredImage(screenshot_image, false, invert_y).save(screenshot_path)) {
                 LOG_INFO(Frontend, "Screenshot saved to \"{}\"", std_screenshot_path);
             } else {
                 LOG_ERROR(Frontend, "Failed to save screenshot to \"{}\"", std_screenshot_path);

--- a/src/citra_qt/camera/camera_util.cpp
+++ b/src/citra_qt/camera/camera_util.cpp
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <QImage>
 #include "citra_qt/camera/camera_util.h"
+#include "citra_qt/util/util.h"
 
 namespace CameraUtil {
 
@@ -213,9 +214,9 @@ std::vector<u16> ProcessImage(const QImage& image, int width, int height, bool o
     }
     QImage scaled =
         image.scaled(width, height, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
-    QImage transformed =
-        scaled.copy((scaled.width() - width) / 2, (scaled.height() - height) / 2, width, height)
-            .mirrored(flip_horizontal, flip_vertical);
+    QImage transformed = GetMirroredImage(
+        scaled.copy((scaled.width() - width) / 2, (scaled.height() - height) / 2, width, height),
+        flip_horizontal, flip_vertical);
     if (output_rgb) {
         QImage converted = transformed.convertToFormat(QImage::Format_RGB16);
         std::memcpy(buffer.data(), converted.bits(), width * height * sizeof(u16));

--- a/src/citra_qt/camera/camera_util.cpp
+++ b/src/citra_qt/camera/camera_util.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/citra_qt/util/util.cpp
+++ b/src/citra_qt/util/util.cpp
@@ -175,3 +175,19 @@ const std::string GetApplicationsDirectory() {
     return QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation).toStdString();
 #endif
 }
+
+QImage GetMirroredImage(QImage source_image, bool flip_horizontal, bool flip_vertical) {
+#if QT_VERSION < QT_VERSION_CHECK(6, 9, 0) // Fallback, uses deprecated method
+    return source_image.mirrored(flip_horizontal, flip_vertical);
+#else // New method
+    auto orientation_horizontal = static_cast<Qt::Orientations>(0x0);
+    auto orientation_vertical = static_cast<Qt::Orientations>(0x0);
+
+    if (flip_horizontal)
+        orientation_horizontal = Qt::Horizontal;
+    if (flip_vertical)
+        orientation_vertical = Qt::Vertical;
+
+    return source_image.flipped(orientation_horizontal | orientation_vertical);
+#endif
+}

--- a/src/citra_qt/util/util.cpp
+++ b/src/citra_qt/util/util.cpp
@@ -1,4 +1,4 @@
-// Copyright Citra Emulator Project / Lime3DS Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/citra_qt/util/util.h
+++ b/src/citra_qt/util/util.h
@@ -41,3 +41,11 @@ QPixmap GetQPixmapFromSMDH(const std::vector<u8>& smdh_data);
  * @return The user’s applications directory
  */
 [[nodiscard]] const std::string GetApplicationsDirectory();
+
+/**
+ * Imitates the deprecated `QImage::mirrored` function in a forwards-compatible manner
+ * @param flip_horizontal Whether the image should be flipped horizontally
+ * @param flip_vertical Whether the image should be flipped vertically
+ * @return QImage The mirrored image
+ */
+QImage GetMirroredImage(QImage source_image, bool flip_horizontal, bool flip_vertical);

--- a/src/citra_qt/util/util.h
+++ b/src/citra_qt/util/util.h
@@ -1,4 +1,4 @@
-// Copyright Citra Emulator Project / Lime3DS Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 


### PR DESCRIPTION
`QImage::mirrored` has been deprecated as of the newly released Qt 6.9.0, and is being replaced by `QImage::flipped` which was released in the same version.

MSYS2 just updated to Qt 6.9.0, so this is causing build failures in environments where deprecations warnings are treated as errors, such as our CI.

Because of how recently `QImage::flipped` was introduced, we can't just switch to the new method as it would cause build failures for basically any build attempted on a normal software setup, and even from our own CI environments for other platforms.

Instead, I have decided to address the issue by introducing a new function under `util.cpp` which abstracts away the process of flipping the image to use whatever method is appropriate for the present Qt version without making the existing code look gross.

Review notes
---

The version of Qt which is throwing issues is so new that it hasn't even been unmasked in Gentoo yet (the rolling-release Linux distro I run which has very bleeding-edge packages available), so I am unable to test this on my host OS.

I use Windows in a virtual machine, so I must test changes on Windows using the Software renderer, however it appears that the screenshot hotkey doesn't actually work for the Software renderer, even when using 2120.2, so I am unable to test this change. All I know is that the program compiles and runs.

As such, review will involve ensuring that the added `GetMirroredImage` function functions correctly with all possible inputs of `flip_horizontal` and `flip_vertical`.