### PR TITLE
Use common open source font on CHN/KOR/TWN

### DIFF
--- a/src/core/file_sys/archive_ncch.cpp
+++ b/src/core/file_sys/archive_ncch.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -133,6 +133,9 @@ ResultVal<std::unique_ptr<FileBackend>> NCCHArchive::OpenFile(const Path& path, 
         constexpr u32 region_manifest = 0x00010402;
         constexpr u32 ng_word_list = 0x00010302;
         constexpr u32 shared_font = 0x00014002;
+        constexpr u32 shared_font_CHN = 0x00014102;
+        constexpr u32 shared_font_KOR = 0x00014202;
+        constexpr u32 shared_font_TWN = 0x00014302;
 
         u32 high = static_cast<u32>(title_id >> 32);
         u32 low = static_cast<u32>(title_id & 0xFFFFFFFF);
@@ -156,6 +159,11 @@ ResultVal<std::unique_ptr<FileBackend>> NCCHArchive::OpenFile(const Path& path, 
                 LOG_WARNING(
                     Service_FS,
                     "Shared Font file missing. Loading open source replacement from memory");
+                archive_data =
+                    std::vector<u8>(std::begin(SHARED_FONT_DATA), std::end(SHARED_FONT_DATA));
+            } else if (low == shared_font_CHN || low == shared_font_KOR || low == shared_font_TWN) {
+                LOG_ERROR(Service_FS, "CHN/KOR/TWN shared font file missing. Loading open source "
+                                      "replacement, but text will not display properly");
                 archive_data =
                     std::vector<u8>(std::begin(SHARED_FONT_DATA), std::end(SHARED_FONT_DATA));
             }

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -229,10 +229,18 @@ bool Module::LoadSharedFont() {
 
     const char16_t* file_name[4] = {u"cbf_std.bcfnt.lz", u"cbf_zh-Hans-CN.bcfnt.lz",
                                     u"cbf_ko-Hang-KR.bcfnt.lz", u"cbf_zh-Hant-TW.bcfnt.lz"};
-    const RomFS::RomFSFile font_file =
+    RomFS::RomFSFile font_file =
         RomFS::GetFile(romfs_buffer.data(), {file_name[font_region_code - 1]});
-    if (font_file.Data() == nullptr)
-        return false;
+    if (font_file.Data() == nullptr) {
+        if (font_region_code != 1) {
+            font_file = RomFS::GetFile(romfs_buffer.data(), {file_name[0]});
+            if (font_file.Data() == nullptr) {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    }
 
     struct {
         u32_le status;


### PR DESCRIPTION
Uses the common open source font when the CHN/KOR/TWN fonts are requested.

Until now, requesting the CHN/KOR/TWN if system titles were not installed would cause a fatal error. Now, the common font will be returned, which makes all text show as `?` because of the missing glyphs. This is enough to complete the system files setup, and we can provide proper fonts in the future.