### PR TITLE
Fix ncch loader building wrong update title ID

### DIFF
--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -2104,7 +2104,7 @@ void Module::Interface::GetPatchTitleInfos(Kernel::HLERequestContext& ctx) {
             std::vector<u64> title_id_list;
 
             Result res{0};
-            std::vector<u8> out;
+            std::vector<TitleInfo> out;
             Kernel::MappedBuffer* title_id_list_buffer;
             Kernel::MappedBuffer* title_info_out;
         };
@@ -2144,7 +2144,7 @@ void Module::Interface::GetPatchTitleInfos(Kernel::HLERequestContext& ctx) {
                     return 0;
                 }
 
-                async_data->out.resize(title_infos->second);
+                async_data->out.resize(title_infos->second / sizeof(TitleInfo));
                 memcpy(async_data->out.data(), title_infos->first, title_infos->second);
                 return 0;
             },
@@ -2156,7 +2156,7 @@ void Module::Interface::GetPatchTitleInfos(Kernel::HLERequestContext& ctx) {
                     rb.PushMappedBuffer(*async_data->title_info_out);
                 } else {
                     async_data->title_info_out->Write(async_data->out.data(), 0,
-                                                      async_data->out.size());
+                                                      async_data->out.size() * sizeof(TitleInfo));
 
                     IPC::RequestBuilder rb(ctx, 1, 4);
                     rb.Push(async_data->res);

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -32,7 +32,7 @@
 namespace Loader {
 
 using namespace Common::Literals;
-static const u64 UPDATE_MASK = 0x0000000e00000000;
+static constexpr u64 UPDATE_TID_HIGH = 0x0004000e00000000;
 
 FileType AppLoader_NCCH::IdentifyType(FileUtil::IOFile& file) {
     u32 magic;
@@ -283,8 +283,9 @@ ResultStatus AppLoader_NCCH::Load(std::shared_ptr<Kernel::Process>& process) {
 
     LOG_INFO(Loader, "Program ID: {}", program_id);
 
-    update_ncch.OpenFile(Service::AM::GetTitleContentPath(Service::FS::MediaType::SDMC,
-                                                          ncch_program_id | UPDATE_MASK));
+    u64 update_tid = (ncch_program_id & 0xFFFFFFFFULL) | UPDATE_TID_HIGH;
+    update_ncch.OpenFile(
+        Service::AM::GetTitleContentPath(Service::FS::MediaType::SDMC, update_tid));
     result = update_ncch.Load();
     if (result == ResultStatus::Success) {
         overlay_ncch = &update_ncch;
@@ -371,8 +372,9 @@ ResultStatus AppLoader_NCCH::DumpRomFS(const std::string& target_path) {
 ResultStatus AppLoader_NCCH::DumpUpdateRomFS(const std::string& target_path) {
     u64 program_id;
     ReadProgramId(program_id);
+    u64 update_tid = (program_id & 0xFFFFFFFFULL) | UPDATE_TID_HIGH;
     update_ncch.OpenFile(
-        Service::AM::GetTitleContentPath(Service::FS::MediaType::SDMC, program_id | UPDATE_MASK));
+        Service::AM::GetTitleContentPath(Service::FS::MediaType::SDMC, update_tid));
     return update_ncch.DumpRomFS(target_path);
 }
 


### PR DESCRIPTION
FIxes the NCCH loader creating the wrong title ID to check for updates. The title ID high should be replaced with `0x0004000E`, not or'ed with `0x0000000E`.

Fixes StreetPass Mii Plaza not detecting its update data. 