### PR TITLE
Qt: set desktop filename and organization domain

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -3889,7 +3889,9 @@ void LaunchQtFrontend(int argc, char* argv[]) {
 
     // Init settings params
     QCoreApplication::setOrganizationName(QStringLiteral("Azahar Developers"));
+    QCoreApplication::setOrganizationDomain(QStringLiteral("azahar_emu.org"));
     QCoreApplication::setApplicationName(QStringLiteral("Azahar"));
+    QGuiApplication::setDesktopFileName(QStringLiteral("org.azahar_emu.Azahar"));
 
     auto rounding_policy = GetHighDpiRoundingPolicy();
     QApplication::setHighDpiScaleFactorRoundingPolicy(rounding_policy);


### PR DESCRIPTION
This fixes https://github.com/azahar-emu/azahar/issues/934 by setting the desktop filename and the organization domain. 
![image](https://github.com/user-attachments/assets/eb894bb9-b31c-42f9-b7fc-5d0915a046f3)
