### PR TITLE
Installer: Remove deletion of old shortcuts

### DIFF
--- a/src/installer/citra.nsi
+++ b/src/installer/citra.nsi
@@ -160,9 +160,6 @@ Section "Base"
   !insertmacro UPDATE_DISPLAYNAME
 
   ; Create start menu and desktop shortcuts
-  Delete "$SMPROGRAMS\${PRODUCT_NAME}\$DisplayName.lnk"
-  Delete "$SMPROGRAMS\${PRODUCT_NAME}\Uninstall $DisplayName.lnk"
-  RMDir "$SMPROGRAMS\${PRODUCT_NAME}"
   CreateShortCut "$SMPROGRAMS\$DisplayName.lnk" "$INSTDIR\azahar.exe"
   ${If} $DesktopShortcut == 1
     CreateShortCut "$DESKTOP\$DisplayName.lnk" "$INSTDIR\azahar.exe"
@@ -198,10 +195,6 @@ Section Uninstall
 
   Delete "$DESKTOP\$DisplayName.lnk"
   Delete "$SMPROGRAMS\$DisplayName.lnk"
-
-  Delete "$SMPROGRAMS\${PRODUCT_NAME}\$DisplayName.lnk"
-  Delete "$SMPROGRAMS\${PRODUCT_NAME}\Uninstall $DisplayName.lnk"
-  RMDir "$SMPROGRAMS\${PRODUCT_NAME}"
 
   ; Be a bit careful to not delete files a user may have put into the install directory.
   Delete "$INSTDIR\*.dll"


### PR DESCRIPTION
Removes the temporary step of deleting old Start Menu shortcuts of users that were upgrading from release candidate versions. Minor change in the .nsi file.

See #683 for context