### PR TITLE
Fallback to silence when no samples have been captured.

### DIFF
--- a/src/audio_core/cubeb_input.cpp
+++ b/src/audio_core/cubeb_input.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -144,6 +144,11 @@ Samples CubebInput::Read() {
     while (impl->sample_queue.Pop(queue)) {
         samples.insert(samples.end(), queue.begin(), queue.end());
     }
+
+    if (samples.empty()) {
+        samples = GenerateSilentSamples(parameters);
+    }
+
     return samples;
 }
 

--- a/src/audio_core/input.h
+++ b/src/audio_core/input.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -52,6 +52,22 @@ public:
      * conditions, but can be lax if the data is coming in from another source like a real mic.
      */
     virtual Samples Read() = 0;
+
+    /**
+     * Generates a buffer of silence.
+     * Takes into account the sample size and signedness of the input.
+     */
+    virtual Samples GenerateSilentSamples(const InputParameters& params) {
+        u8 silent_value = 0x00;
+
+        if (params.sample_size == 8) {
+            silent_value = params.sign == Signedness::Unsigned ? 0x80 : 0x00;
+            return std::vector<u8>(32, silent_value);
+        } else {
+            silent_value = params.sign == Signedness::Unsigned ? 0x80 : 0x00;
+            return std::vector<u8>(64, silent_value);
+        }
+    }
 
 protected:
     InputParameters parameters;

--- a/src/audio_core/null_input.h
+++ b/src/audio_core/null_input.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -30,10 +30,11 @@ public:
     void AdjustSampleRate(u32 sample_rate) override {}
 
     Samples Read() override {
-        return {};
+        return GenerateSilentSamples(parameters);
     }
 
 private:
+    InputParameters parameters;
     bool is_sampling = false;
 };
 

--- a/src/audio_core/openal_input.cpp
+++ b/src/audio_core/openal_input.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -106,6 +106,10 @@ Samples OpenALInput::Read() {
     if (error != ALC_NO_ERROR) {
         LOG_WARNING(Audio, "alcCaptureSamples failed: {}", error);
         return {};
+    }
+
+    if (samples.empty()) {
+        samples = GenerateSilentSamples(parameters);
     }
 
     return samples;


### PR DESCRIPTION
Added a few fallbacks to all the used sinks, if no samples have been recorded it should return a empty sound. This fixes a game ( Brain Age: Concentration Training ) from causing a panic break when no samples have been given.