### PR TITLE
Update room on web backend via PATCH request

### DIFF
--- a/src/web_service/announce_room_json.cpp
+++ b/src/web_service/announce_room_json.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/web_service/announce_room_json.cpp
+++ b/src/web_service/announce_room_json.cpp
@@ -114,7 +114,7 @@ Common::WebResult RoomJson::Update() {
         return Common::WebResult{Common::WebResult::Code::LibError, "Room is not registered"};
     }
     nlohmann::json json{{"players", room.members}};
-    return client.PostJson(fmt::format("/lobby/{}", room_id), json.dump(), false);
+    return client.PatchJson(fmt::format("/lobby/{}", room_id), json.dump(), false);
 }
 
 Common::WebResult RoomJson::Register() {

--- a/src/web_service/web_backend.cpp
+++ b/src/web_service/web_backend.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/web_service/web_backend.cpp
+++ b/src/web_service/web_backend.cpp
@@ -32,7 +32,7 @@ struct Client::Impl {
         }
     }
 
-    /// A generic function handles POST, GET and DELETE request together
+    /// A generic function handles POST, PATCH, GET and DELETE request together
     Common::WebResult GenericRequest(const std::string& method, const std::string& path,
                                      const std::string& data, bool allow_anonymous,
                                      const std::string& accept) {
@@ -181,6 +181,11 @@ Common::WebResult Client::GetJson(const std::string& path, bool allow_anonymous)
 Common::WebResult Client::DeleteJson(const std::string& path, const std::string& data,
                                      bool allow_anonymous) {
     return impl->GenericRequest("DELETE", path, data, allow_anonymous, "application/json");
+}
+
+Common::WebResult Client::PatchJson(const std::string& path, const std::string& data,
+                                    bool allow_anonymous) {
+    return impl->GenericRequest("PATCH", path, data, allow_anonymous, "application/json");
 }
 
 Common::WebResult Client::GetPlain(const std::string& path, bool allow_anonymous) {

--- a/src/web_service/web_backend.h
+++ b/src/web_service/web_backend.h
@@ -1,4 +1,4 @@
-// Copyright 2017 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/web_service/web_backend.h
+++ b/src/web_service/web_backend.h
@@ -54,7 +54,7 @@ public:
      * @return the result of the request.
      */
     Common::WebResult PatchJson(const std::string& path, const std::string& data,
-        bool allow_anonymous);
+                                bool allow_anonymous);
 
     /**
      * Gets a plain string from the specified path.

--- a/src/web_service/web_backend.h
+++ b/src/web_service/web_backend.h
@@ -47,6 +47,16 @@ public:
                                  bool allow_anonymous);
 
     /**
+     * Patches JSON to the specified path.
+     * @param path the URL segment after the host address.
+     * @param data String of JSON data to use for the body of the PATCH request.
+     * @param allow_anonymous If true, allow anonymous unauthenticated requests.
+     * @return the result of the request.
+     */
+    Common::WebResult PatchJson(const std::string& path, const std::string& data,
+        bool allow_anonymous);
+
+    /**
      * Gets a plain string from the specified path.
      * @param path the URL segment after the host address.
      * @param allow_anonymous If true, allow anonymous unauthenticated requests.


### PR DESCRIPTION
The room executable currently does POST requests to update the room's data on the web backend. However, the actual transaction we do is a partial update of the room's data for which a PATCH request makes more sense with regard to a REST API.
