### PR TITLE
Make argument of `--username` required for `azahar-room`

### DIFF
--- a/src/citra_room/citra_room.cpp
+++ b/src/citra_room/citra_room.cpp
@@ -193,7 +193,7 @@ void LaunchRoom(int argc, char** argv, bool called_by_option) {
         {"password", required_argument, 0, 'w'},
         {"preferred-app", required_argument, 0, 's'},
         {"preferred-app-id", required_argument, 0, 'i'},
-        {"username", optional_argument, 0, 'u'},
+        {"username", required_argument, 0, 'u'},
         {"token", required_argument, 0, 't'},
         {"web-api-url", required_argument, 0, 'a'},
         {"ban-list-file", required_argument, 0, 'b'},


### PR DESCRIPTION
The argument for `--username` was set to optional by mistake, which can lead to a null pointer exception here:
https://github.com/azahar-emu/azahar/blob/bac344d0592e42a9e781ff73e1fa27fe86687c07/src/citra_room/citra_room.cpp#L238-L239
I suspect the original intention was to mark it as an optional option, a feature `getopts` actually doesn't have.