### PR TITLE
android: Fix game being drawn in cutout area.

### DIFF
--- a/src/android/app/src/main/res/values/themes.xml
+++ b/src/android/app/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <style name="Theme.Citra.Splash.Main" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@color/citra_surface_blue</item>
@@ -17,6 +17,7 @@
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="sliderStyle">@style/CitraSlider</item>
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:targetApi="35">true</item>
     </style>
 
     <style name="Theme.Citra.Blue" parent="Theme.Citra">


### PR DESCRIPTION
close #923 

The above issue is a bug caused by the edge-to-edge enforcement by SDK version 35.

- Added API to disable edge-to-edge

before
![image](https://github.com/user-attachments/assets/c36f1df3-95af-40cf-b447-e4801c236a19)

after
![image](https://github.com/user-attachments/assets/f35d8a94-50ee-483e-8afa-98f0a79c9376)

