### PR TITLE
Fix off-by-one error in savestates that could cause crashes

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -1614,6 +1614,9 @@ void GMainWindow::UpdateSaveStates() {
         }
     }
     for (const auto& savestate : savestates) {
+        if (savestate.slot >= Core::SaveStateSlotCount) {
+            continue;
+        }
         const bool display_name =
             savestate.status == Core::SaveStateInfo::ValidationStatus::RevisionDismatch &&
             !savestate.build_name.empty();
@@ -1654,7 +1657,7 @@ void GMainWindow::UpdateSaveStates() {
     for (u32 i = 1; i < Core::SaveStateSlotCount; ++i) {
         if (!actions_load_state[i]->isEnabled()) {
             // Prefer empty slot
-            oldest_slot = i + 1;
+            oldest_slot = i;
             oldest_slot_time = 0;
             break;
         }


### PR DESCRIPTION
- FIxed an issue that would create a savestate on slot ID 11 (non-existant) caused by `oldest_slot` going out of bounds. 
- Added a check to prevent loading invalid slots, as the emulator will crash otherwise when launching the affected game.