### PR TITLE
Allow shader cache to switch to different titles at runtime

### DIFF
--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -215,7 +215,8 @@ static Core::System::ResultStatus RunCitra(const std::string& filepath) {
     LoadDiskCacheProgress(VideoCore::LoadCallbackStage::Prepare, 0, 0);
 
     std::unique_ptr<Frontend::GraphicsContext> cpu_context;
-    system.GPU().Renderer().Rasterizer()->LoadDiskResources(stop_run, &LoadDiskCacheProgress);
+    system.GPU().Renderer().Rasterizer()->LoadDefaultDiskResources(stop_run,
+                                                                   &LoadDiskCacheProgress);
 
     LoadDiskCacheProgress(VideoCore::LoadCallbackStage::Complete, 0, 0);
 

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -72,9 +72,14 @@ void EmuThread::run() {
                              std::size_t total) { emit LoadProgress(stage, value, total); });
     }
 
+    system.GPU().Renderer().Rasterizer()->SetSwitchDiskResourcesCallback(
+        [this](VideoCore::LoadCallbackStage stage, std::size_t value, std::size_t total) {
+            emit SwitchDiskResources(stage, value, total);
+        });
+
     emit LoadProgress(VideoCore::LoadCallbackStage::Prepare, 0, 0);
 
-    system.GPU().Renderer().Rasterizer()->LoadDiskResources(
+    system.GPU().Renderer().Rasterizer()->LoadDefaultDiskResources(
         stop_run, [this](VideoCore::LoadCallbackStage stage, std::size_t value, std::size_t total) {
             emit LoadProgress(stage, value, total);
         });

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -1,4 +1,4 @@
-// Copyright 2014 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -109,6 +109,9 @@ signals:
     void ErrorThrown(Core::System::ResultStatus, std::string);
 
     void LoadProgress(VideoCore::LoadCallbackStage stage, std::size_t value, std::size_t total);
+
+    void SwitchDiskResources(VideoCore::LoadCallbackStage stage, std::size_t value,
+                             std::size_t total);
 
     void HideLoadingScreen();
 };

--- a/src/citra_qt/citra_qt.h
+++ b/src/citra_qt/citra_qt.h
@@ -24,6 +24,7 @@
 #include "citra_qt/user_data_migration.h"
 #include "core/core.h"
 #include "core/savestate.h"
+#include "video_core/rasterizer_interface.h"
 
 // Needs to be included at the end due to https://bugreports.qt.io/browse/QTBUG-73263
 #include <filesystem>
@@ -299,6 +300,8 @@ private slots:
 #ifdef ENABLE_QT_UPDATE_CHECKER
     void OnEmulatorUpdateAvailable();
 #endif
+    void OnSwitchDiskResources(VideoCore::LoadCallbackStage stage, std::size_t value,
+                               std::size_t total);
 
 private:
     Q_INVOKABLE void OnMoviePlaybackCompleted();
@@ -334,6 +337,7 @@ private:
     QProgressBar* progress_bar = nullptr;
     QLabel* message_label = nullptr;
     bool show_artic_label = false;
+    QLabel* loading_shaders_label = nullptr;
     QLabel* artic_traffic_label = nullptr;
     QLabel* emu_speed_label = nullptr;
     QLabel* game_fps_label = nullptr;

--- a/src/citra_qt/loading_screen.cpp
+++ b/src/citra_qt/loading_screen.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -184,14 +184,7 @@ void LoadingScreen::OnLoadProgress(VideoCore::LoadCallbackStage stage, std::size
     }
 
     // update labels and progress bar
-    const auto& stg = tr(stage_translations.at(stage));
-    if (stage == VideoCore::LoadCallbackStage::Decompile ||
-        stage == VideoCore::LoadCallbackStage::Build ||
-        stage == VideoCore::LoadCallbackStage::Preload) {
-        ui->stage->setText(stg.arg(value).arg(total));
-    } else {
-        ui->stage->setText(stg);
-    }
+    ui->stage->setText(GetStageTranslation(stage, value, total));
     ui->value->setText(estimate);
     ui->progress_bar->setValue(static_cast<int>(value));
     previous_time = now;
@@ -203,6 +196,18 @@ void LoadingScreen::paintEvent(QPaintEvent* event) {
     QPainter p(this);
     style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
     QWidget::paintEvent(event);
+}
+
+QString LoadingScreen::GetStageTranslation(VideoCore::LoadCallbackStage stage, std::size_t value,
+                                           std::size_t total) {
+    const auto& stg = tr(stage_translations.at(stage));
+    if (stage == VideoCore::LoadCallbackStage::Decompile ||
+        stage == VideoCore::LoadCallbackStage::Build ||
+        stage == VideoCore::LoadCallbackStage::Preload) {
+        return stg.arg(value).arg(total);
+    } else {
+        return stg;
+    }
 }
 
 void LoadingScreen::Clear() {}

--- a/src/citra_qt/loading_screen.h
+++ b/src/citra_qt/loading_screen.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -48,6 +48,9 @@ public:
     // In order to use a custom widget with a stylesheet, you need to override the paintEvent
     // See https://wiki.qt.io/How_to_Change_the_Background_Color_of_QWidget
     void paintEvent(QPaintEvent* event) override;
+
+    QString GetStageTranslation(VideoCore::LoadCallbackStage stage, std::size_t value,
+                                std::size_t total);
 
 signals:
     void LoadProgress(VideoCore::LoadCallbackStage stage, std::size_t value, std::size_t total);

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -509,9 +509,7 @@ Result CIAFile::WriteTitleMetadata(std::span<const u8> tmd_data, std::size_t off
         return FileSys::ResultFileNotFound;
     }
 
-    PrepareToImportContent(tmd);
-
-    return ResultSuccess;
+    return PrepareToImportContent(tmd);
 }
 
 ResultVal<std::size_t> CIAFile::WriteContentData(u64 offset, std::size_t length, const u8* buffer) {

--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -21,6 +21,7 @@
 #include "video_core/gpu.h"
 #include "video_core/gpu_debugger.h"
 #include "video_core/pica/regs_lcd.h"
+#include "video_core/renderer_base.h"
 #include "video_core/right_eye_disabler.h"
 
 SERIALIZE_EXPORT_IMPL(Service::GSP::SessionData)
@@ -612,6 +613,8 @@ Result GSP_GPU::AcquireGpuRight(const Kernel::HLERequestContext& ctx,
         return {ErrorDescription::AlreadyDone, ErrorModule::GX, ErrorSummary::Success,
                 ErrorLevel::Success};
     }
+
+    gpu.Renderer().Rasterizer()->SwitchDiskResources(process->codeset->program_id);
 
     if (blocking) {
         // TODO: The thread should be put to sleep until acquired.

--- a/src/video_core/rasterizer_accelerated.cpp
+++ b/src/video_core/rasterizer_accelerated.cpp
@@ -9,6 +9,8 @@
 
 namespace VideoCore {
 
+DiskResourceLoadCallback RasterizerInterface::switch_disk_resources_callback{};
+
 using Pica::f24;
 
 static Common::Vec4f ColorRGBA8(const u32 color) {

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -1,4 +1,4 @@
-// Copyright 2015 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -78,8 +78,15 @@ public:
         return false;
     }
 
-    virtual void LoadDiskResources([[maybe_unused]] const std::atomic_bool& stop_loading,
-                                   [[maybe_unused]] const DiskResourceLoadCallback& callback) {}
+    virtual void LoadDefaultDiskResources(
+        [[maybe_unused]] const std::atomic_bool& stop_loading,
+        [[maybe_unused]] const DiskResourceLoadCallback& callback) {}
+
+    virtual void SwitchDiskResources([[maybe_unused]] u64 title_id) {}
+
+    static void SetSwitchDiskResourcesCallback(const DiskResourceLoadCallback& callback) {
+        switch_disk_resources_callback = callback;
+    }
 
     virtual void SyncEntireState() {}
 
@@ -89,5 +96,9 @@ public:
 
 protected:
     bool accurate_mul = false;
+
+    // Rasterizer gets destroyed on reboot, so make the callback
+    // static until a better solution is found.
+    static DiskResourceLoadCallback switch_disk_resources_callback;
 };
 } // namespace VideoCore

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -40,8 +40,9 @@ public:
     ~RasterizerOpenGL() override;
 
     void TickFrame();
-    void LoadDiskResources(const std::atomic_bool& stop_loading,
-                           const VideoCore::DiskResourceLoadCallback& callback) override;
+    void LoadDefaultDiskResources(const std::atomic_bool& stop_loading,
+                                  const VideoCore::DiskResourceLoadCallback& callback) override;
+    void SwitchDiskResources(u64 title_id) override;
 
     void DrawTriangles() override;
     void FlushAll() override;
@@ -137,7 +138,9 @@ private:
 private:
     Driver& driver;
     OpenGLState state;
-    ShaderProgramManager shader_manager;
+    Frontend::EmuWindow& render_window;
+    std::vector<std::shared_ptr<ShaderProgramManager>> shader_managers;
+    std::shared_ptr<ShaderProgramManager> curr_shader_manager{};
     TextureRuntime runtime;
     RasterizerCache res_cache;
 

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
@@ -1,3 +1,7 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
 // Copyright 2019 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
@@ -12,8 +16,6 @@
 #include "common/scm_rev.h"
 #include "common/settings.h"
 #include "common/zstd_compression.h"
-#include "core/core.h"
-#include "core/loader/loader.h"
 #include "video_core/renderer_opengl/gl_shader_disk_cache.h"
 
 namespace OpenGL {
@@ -103,8 +105,8 @@ bool ShaderDiskCacheRaw::Save(FileUtil::IOFile& file) const {
     return true;
 }
 
-ShaderDiskCache::ShaderDiskCache(bool separable)
-    : separable{separable}, transferable_file(AppendTransferableFile()),
+ShaderDiskCache::ShaderDiskCache(u64 program_id, bool separable)
+    : separable{separable}, program_id{program_id}, transferable_file(AppendTransferableFile()),
       // seperable shaders use the virtual precompile file, that already has a header.
       precompiled_file(AppendPrecompiledFile(!separable)) {}
 
@@ -568,15 +570,7 @@ std::string ShaderDiskCache::GetBaseDir() const {
     return FileUtil::GetUserPath(FileUtil::UserPath::ShaderDir) + DIR_SEP "opengl";
 }
 
-u64 ShaderDiskCache::GetProgramID() {
-    // Skip games without title id
-    if (program_id != 0) {
-        return program_id;
-    }
-    if (Core::System::GetInstance().GetAppLoader().ReadProgramId(program_id) !=
-        Loader::ResultStatus::Success) {
-        return 0;
-    }
+u64 ShaderDiskCache::GetProgramID() const {
     return program_id;
 }
 

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.h
@@ -1,3 +1,7 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
 // Copyright 2019 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
@@ -83,7 +87,7 @@ struct ShaderDiskCacheDump {
 
 class ShaderDiskCache {
 public:
-    explicit ShaderDiskCache(bool separable);
+    explicit ShaderDiskCache(u64 title_id, bool separable);
     ~ShaderDiskCache() = default;
 
     /// Loads transferable cache. If file has a old version or on failure, it deletes the file.
@@ -112,6 +116,9 @@ public:
 
     /// Serializes virtual precompiled shader cache file to real file
     void SaveVirtualPrecompiledFile();
+
+    /// Get current game's title id as u64
+    u64 GetProgramID() const;
 
 private:
     /// Loads the transferable cache. Returns empty on failure.
@@ -160,9 +167,6 @@ private:
 
     /// Get user's shader directory path
     std::string GetBaseDir() const;
-
-    /// Get current game's title id as u64
-    u64 GetProgramID();
 
     /// Get current game's title id
     std::string GetTitleID();

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -259,10 +259,10 @@ using FragmentShaders = ShaderCache<FSConfig, &GLSL::GenerateFragmentShader, GL_
 
 class ShaderProgramManager::Impl {
 public:
-    explicit Impl(const Driver& driver, bool separable)
+    explicit Impl(const Driver& driver, u64 title_id, bool separable)
         : separable(separable), programmable_vertex_shaders(separable),
           trivial_vertex_shader(driver, separable), fixed_geometry_shaders(separable),
-          fragment_shaders(separable), disk_cache(separable) {
+          fragment_shaders(separable), disk_cache(title_id, separable) {
         if (separable) {
             pipeline.Create();
         }
@@ -329,10 +329,10 @@ public:
 };
 
 ShaderProgramManager::ShaderProgramManager(Frontend::EmuWindow& emu_window_, const Driver& driver_,
-                                           bool separable)
+                                           u64 title_id, bool separable)
     : emu_window{emu_window_}, driver{driver_},
       strict_context_required{emu_window.StrictContextRequired()},
-      impl{std::make_unique<Impl>(driver_, separable)} {}
+      impl{std::make_unique<Impl>(driver_, title_id, separable)} {}
 
 ShaderProgramManager::~ShaderProgramManager() = default;
 
@@ -423,6 +423,10 @@ void ShaderProgramManager::ApplyTo(OpenGLState& state, bool accurate_mul) {
         }
         state.draw.shader_program = cached_program.handle;
     }
+}
+
+u64 ShaderProgramManager::GetProgramID() const {
+    return impl->disk_cache.GetProgramID();
 }
 
 void ShaderProgramManager::LoadDiskCache(const std::atomic_bool& stop_loading,

--- a/src/video_core/renderer_opengl/gl_shader_manager.h
+++ b/src/video_core/renderer_opengl/gl_shader_manager.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -34,7 +34,8 @@ enum UniformBindings {
 /// A class that manage different shader stages and configures them with given config data.
 class ShaderProgramManager {
 public:
-    ShaderProgramManager(Frontend::EmuWindow& emu_window, const Driver& driver, bool separable);
+    ShaderProgramManager(Frontend::EmuWindow& emu_window, const Driver& driver, u64 title_id,
+                         bool separable);
     ~ShaderProgramManager();
 
     void LoadDiskCache(const std::atomic_bool& stop_loading,
@@ -52,6 +53,8 @@ public:
     void UseFragmentShader(const Pica::RegsInternal& config, const Pica::Shader::UserConfig& user);
 
     void ApplyTo(OpenGLState& state, bool accurate_mul);
+
+    u64 GetProgramID() const;
 
 private:
     Frontend::EmuWindow& emu_window;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -143,8 +143,8 @@ void RasterizerVulkan::TickFrame() {
     res_cache.TickFrame();
 }
 
-void RasterizerVulkan::LoadDiskResources(const std::atomic_bool& stop_loading,
-                                         const VideoCore::DiskResourceLoadCallback& callback) {
+void RasterizerVulkan::LoadDefaultDiskResources(
+    const std::atomic_bool& stop_loading, const VideoCore::DiskResourceLoadCallback& callback) {
     pipeline_cache.LoadDiskCache();
 }
 

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -45,8 +45,8 @@ public:
     ~RasterizerVulkan() override;
 
     void TickFrame();
-    void LoadDiskResources(const std::atomic_bool& stop_loading,
-                           const VideoCore::DiskResourceLoadCallback& callback) override;
+    void LoadDefaultDiskResources(const std::atomic_bool& stop_loading,
+                                  const VideoCore::DiskResourceLoadCallback& callback) override;
 
     void DrawTriangles() override;
     void FlushAll() override;


### PR DESCRIPTION
Allows the OpenGL shader cache to switch to the title that called `GSPGPU::AcquireRight`.

Previously, the shader cache always went to the title that was launched from the game list. This has the inconvenience of apps launched from the home menu having its cache get stored/loaded in the home menu, instead of the app. Applets such as the keyboard would also have its cache stored in the wrong place (either home menu or the app launched from the app list).

Furthermore, any app that causes a jump to another title would reset the cache as it is not loaded from disk first.