### PR TITLE
Fix installing DLCs with encrypted flags for missing contents

### DIFF
--- a/src/core/file_sys/cia_container.cpp
+++ b/src/core/file_sys/cia_container.cpp
@@ -13,11 +13,11 @@
 namespace FileSys {
 
 Loader::ResultStatus CIAContainer::Load(const FileBackend& backend) {
-    std::vector<u8> header_data(sizeof(Header));
+    std::vector<u8> header_data(sizeof(CIAHeader));
 
     // Load the CIA Header
-    ResultVal<std::size_t> read_result = backend.Read(0, sizeof(Header), header_data.data());
-    if (read_result.Failed() || *read_result != sizeof(Header))
+    ResultVal<std::size_t> read_result = backend.Read(0, sizeof(CIAHeader), header_data.data());
+    if (read_result.Failed() || *read_result != sizeof(CIAHeader))
         return Loader::ResultStatus::Error;
 
     Loader::ResultStatus result = LoadHeader(header_data);
@@ -65,8 +65,8 @@ Loader::ResultStatus CIAContainer::Load(const std::string& filepath) {
         return Loader::ResultStatus::Error;
 
     // Load CIA Header
-    std::vector<u8> header_data(sizeof(Header));
-    if (file.ReadBytes(header_data.data(), sizeof(Header)) != sizeof(Header))
+    std::vector<u8> header_data(sizeof(CIAHeader));
+    if (file.ReadBytes(header_data.data(), sizeof(CIAHeader)) != sizeof(CIAHeader))
         return Loader::ResultStatus::Error;
 
     Loader::ResultStatus result = LoadHeader(header_data);
@@ -134,11 +134,12 @@ Loader::ResultStatus CIAContainer::Load(std::span<const u8> file_data) {
 }
 
 Loader::ResultStatus CIAContainer::LoadHeader(std::span<const u8> header_data, std::size_t offset) {
-    if (header_data.size() - offset < sizeof(Header)) {
+    if (header_data.size() - offset < sizeof(CIAHeader)) {
         return Loader::ResultStatus::Error;
     }
 
-    std::memcpy(&cia_header, header_data.data(), sizeof(Header));
+    std::memcpy(&cia_header, header_data.data(), sizeof(CIAHeader));
+    has_header = true;
 
     return Loader::ResultStatus::Success;
 }
@@ -264,5 +265,8 @@ void CIAContainer::Print() const {
     for (u16 i = 0; i < cia_tmd.GetContentCount(); i++) {
         LOG_DEBUG(Service_FS, "Content {:x} Offset:   0x{:08x} bytes", i, GetContentOffset(i));
     }
+}
+const CIAHeader* CIAContainer::GetHeader() {
+    return has_header ? &cia_header : nullptr;
 }
 } // namespace FileSys

--- a/src/core/file_sys/title_metadata.h
+++ b/src/core/file_sys/title_metadata.h
@@ -17,6 +17,8 @@ enum class ResultStatus;
 
 namespace FileSys {
 
+struct CIAHeader;
+
 enum TMDContentTypeFlag : u16 {
     Encrypted = 1 << 0,
     Disc = 1 << 2,
@@ -99,7 +101,7 @@ public:
     u64 GetContentSizeByIndex(std::size_t index) const;
     bool GetContentOptional(std::size_t index) const;
     std::array<u8, 16> GetContentCTRByIndex(std::size_t index) const;
-    bool HasEncryptedContent() const;
+    bool HasEncryptedContent(const CIAHeader* header = nullptr) const;
 
     void SetTitleID(u64 title_id);
     void SetTitleType(u32 type);


### PR DESCRIPTION
When GodMode9 builds a decrypted cia file, it only disables the encrypted flag in the TMD for the contents that are actually bundled into the cia. This causes cia files with optional contents (DLC) to have some encrypted flags set but no corresponding contents being present, which makes Azahar block the installation.

This has been fixed by allowing cia files with encrypted flags only if the corresponding contents do not exist in the cia file.