### PR TITLE
Updating minimum macOS target to 13.4 to avoid breaking macOS builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ if (APPLE)
         set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)
     else()
         # Minimum macOS 13
-        set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0")
+        set(CMAKE_OSX_DEPLOYMENT_TARGET "13.4")
     endif()
 endif()
 


### PR DESCRIPTION
A function call in the vulkan-headers dependency uses a feature requiring macOS 13.4.
More specifically, it calls std::format with a float which Apple didn't implement until 13.4.

I'm not quite sure why this broke, but I'm assuming it was an update to vulkan-headers. With the change I am able to build and run Azahar fine, but would probably be good if someone else could verify it as well. 