### PR TITLE
macos: Use non-native Qt menubar as a temporary workaround for missing entries in non-English languages

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -389,6 +389,11 @@ GMainWindow::GMainWindow(Core::System& system_)
     LOG_INFO(Frontend, "Host Swap: {:.2f} GiB", mem_info.total_swap_memory / f64{1_GiB});
     UpdateWindowTitle();
 
+#ifdef __APPLE__
+    // Workaround for https://github.com/azahar-emu/azahar/issues/933
+    ui->menubar->setNativeMenuBar(false);
+#endif
+
     show();
 
 #ifdef ENABLE_QT_UPDATE_CHECKER


### PR DESCRIPTION
This is a temporary bandaid fix for #933. See the original issue for additional context.

This commit is to be reverted once a proper fix is put in place.

Self reviewing due to the simplicity of the change.