### PR TITLE
renderer_vulkan: Update MoltenVK to 1.2.9

### DIFF
--- a/CMakeModules/DownloadExternals.cmake
+++ b/CMakeModules/DownloadExternals.cmake
@@ -171,16 +171,16 @@ endfunction()
 
 function(download_moltenvk)
     if (IOS)
-        set(MOLTENVK_PLATFORM "iOS")
+        set(MOLTENVK_PLATFORM "static/MoltenVK.xcframework/ios-arm64")
     else()
-        set(MOLTENVK_PLATFORM "macOS")
+        set(MOLTENVK_PLATFORM "dynamic/dylib/macOS")
     endif()
 
     set(MOLTENVK_DIR "${CMAKE_BINARY_DIR}/externals/MoltenVK")
     set(MOLTENVK_TAR "${CMAKE_BINARY_DIR}/externals/MoltenVK.tar")
     if (NOT EXISTS ${MOLTENVK_DIR})
         if (NOT EXISTS ${MOLTENVK_TAR})
-            file(DOWNLOAD https://github.com/KhronosGroup/MoltenVK/releases/download/v1.2.7-rc2/MoltenVK-all.tar
+            file(DOWNLOAD https://github.com/KhronosGroup/MoltenVK/releases/download/v1.2.9/MoltenVK-all.tar
                 ${MOLTENVK_TAR} SHOW_PROGRESS)
         endif()
 
@@ -189,7 +189,7 @@ function(download_moltenvk)
     endif()
 
     # Add the MoltenVK library path to the prefix so find_library can locate it.
-    list(APPEND CMAKE_PREFIX_PATH "${MOLTENVK_DIR}/MoltenVK/dylib/${MOLTENVK_PLATFORM}")
+    list(APPEND CMAKE_PREFIX_PATH "${MOLTENVK_DIR}/MoltenVK/${MOLTENVK_PLATFORM}")
     set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} PARENT_SCOPE)
 endfunction()
 


### PR DESCRIPTION
Updates the MoltenVK dependency used by macOS and iOS to 1.2.9. Exposes more features and includes bug fixes, which can be helpful for improving the emulator and fixing issues on those platforms. Also makes the iOS build follow some of the App Store rules more strictly. No regressions found. 

Release notes [here](https://github.com/KhronosGroup/MoltenVK/releases/tag/v1.2.8) and [here](https://github.com/KhronosGroup/MoltenVK/releases/tag/v1.2.9).

Changes how MoltenVK build paths are handled to facilitate changes with the iOS build, and switched the library that iOS uses to the static one (build fails with the new dynamic library). 