### PR TITLE
Fix savestates with the OpenGL renderer

### DIFF
--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -270,6 +270,9 @@ public:
     /// Retrieves a process from the current list of processes.
     std::shared_ptr<Process> GetProcessById(u32 process_id) const;
 
+    /// Retrieves a thread from the current list of threads.
+    std::shared_ptr<Thread> GetThreadByID(u32 thread_id) const;
+
     std::span<const std::shared_ptr<Process>> GetProcessList() const {
         return process_list;
     }

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -528,8 +528,20 @@ ThreadManager::~ThreadManager() {
     }
 }
 
-std::span<const std::shared_ptr<Thread>> ThreadManager::GetThreadList() {
+std::span<const std::shared_ptr<Thread>> ThreadManager::GetThreadList() const {
     return thread_list;
+}
+
+std::shared_ptr<Thread> KernelSystem::GetThreadByID(u32 thread_id) const {
+    for (u32 core_id = 0; core_id < Core::System::GetInstance().GetNumCores(); core_id++) {
+        const auto thread_list = GetThreadManager(core_id).GetThreadList();
+        for (auto& thread : thread_list) {
+            if (thread->thread_id == thread_id) {
+                return thread;
+            }
+        }
+    }
+    return nullptr;
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -124,7 +124,7 @@ public:
     /**
      * Get a const reference to the thread list for debug use
      */
-    std::span<const std::shared_ptr<Thread>> GetThreadList();
+    std::span<const std::shared_ptr<Thread>> GetThreadList() const;
 
     void SetCPU(Core::ARM_Interface& cpu_) {
         cpu = &cpu_;

--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -626,6 +626,7 @@ Result GSP_GPU::AcquireGpuRight(const Kernel::HLERequestContext& ctx,
     }
 
     active_thread_id = session_data->thread_id;
+    active_client_thread_id = ctx.ClientThread()->thread_id;
     return ResultSuccess;
 }
 
@@ -654,6 +655,7 @@ void GSP_GPU::ReleaseRight(const SessionData* session_data) {
     ASSERT_MSG(active_thread_id == session_data->thread_id,
                "Wrong thread tried to release GPU right");
     active_thread_id = std::numeric_limits<u32>::max();
+    active_client_thread_id = std::numeric_limits<u32>::max();
 }
 
 void GSP_GPU::ReleaseRight(Kernel::HLERequestContext& ctx) {
@@ -723,6 +725,7 @@ void GSP_GPU::serialize(Archive& ar, const unsigned int) {
     ar& boost::serialization::base_object<Kernel::SessionRequestHandler>(*this);
     ar & shared_memory;
     ar & active_thread_id;
+    ar & active_client_thread_id;
     ar & first_initialization;
     ar & used_thread_ids;
     ar & saved_vram;

--- a/src/core/hle/service/gsp/gsp_gpu.h
+++ b/src/core/hle/service/gsp/gsp_gpu.h
@@ -1,4 +1,4 @@
-// Copyright 2014 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -121,6 +121,13 @@ public:
      */
     u32 GetActiveThreadId() {
         return active_thread_id;
+    }
+
+    /**
+     * Retreives the ID of the client thread with GPU rights.
+     */
+    u32 GetActiveClientThreadId() {
+        return active_client_thread_id;
     }
 
 private:
@@ -377,6 +384,9 @@ private:
 
     /// Thread id that currently has GPU rights or std::numeric_limits<u32>::max() if none.
     u32 active_thread_id = std::numeric_limits<u32>::max();
+
+    /// Thread id of the client thread that has GPU rights
+    u32 active_client_thread_id = std::numeric_limits<u32>::max();
 
     bool first_initialization = true;
 


### PR DESCRIPTION
Fixes savestates crashing Azahar when loaded with the OpenGL renderer. This was caused because loading a savestate destroys the rasterizer, and the current title ID was not being set back again.