### PR TITLE
android: Fixed Turbo toast appearing in situations other than toggling Turbo

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/hotkeys/HotkeyUtility.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/hotkeys/HotkeyUtility.kt
@@ -25,7 +25,7 @@ class HotkeyUtility(
                 Hotkey.CYCLE_LAYOUT.button -> screenAdjustmentUtil.cycleLayouts()
                 Hotkey.CLOSE_GAME.button -> EmulationLifecycleUtil.closeGame()
                 Hotkey.PAUSE_OR_RESUME.button -> EmulationLifecycleUtil.pauseOrResume()
-                Hotkey.TURBO_LIMIT.button -> TurboHelper.setTurboEnabled(!TurboHelper.isTurboSpeedEnabled())
+                Hotkey.TURBO_LIMIT.button -> TurboHelper.toggleTurbo(true)
                 Hotkey.QUICKSAVE.button -> {
                     NativeLibrary.saveState(NativeLibrary.QUICKSAVE_SLOT)
                     Toast.makeText(context,

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsActivityPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsActivityPresenter.kt
@@ -67,7 +67,7 @@ class SettingsActivityPresenter(private val activityView: SettingsActivityView) 
             //added to ensure that layout changes take effect as soon as settings window closes
             NativeLibrary.reloadSettings()
             NativeLibrary.updateFramebuffer(NativeLibrary.isPortraitMode)
-            TurboHelper.reloadTurbo() // TODO: Can this go someone else? -OS
+            TurboHelper.reloadTurbo(false) // TODO: Can this go somewhere else? -OS
         }
         NativeLibrary.reloadSettings()
     }

--- a/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlay.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlay.kt
@@ -107,7 +107,7 @@ class InputOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(contex
             }
 
             if (button.id == NativeLibrary.ButtonType.BUTTON_TURBO && button.status == NativeLibrary.ButtonState.PRESSED) {
-                TurboHelper.setTurboEnabled((!TurboHelper.isTurboSpeedEnabled()))
+                TurboHelper.toggleTurbo(true)
             }
 
             NativeLibrary.onGamePadEvent(NativeLibrary.TouchScreenDevice, button.id, button.status)

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/TurboHelper.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/TurboHelper.kt
@@ -17,12 +17,7 @@ object TurboHelper {
         return turboSpeedEnabled
     }
 
-    fun setTurboEnabled(state: Boolean) {
-        turboSpeedEnabled = state
-        reloadTurbo()
-    }
-
-    fun reloadTurbo() {
+    fun reloadTurbo(showToast: Boolean) {
         val context = CitraApplication.appContext
         val toastMessage: String
 
@@ -34,6 +29,17 @@ object TurboHelper {
             toastMessage = context.getString(R.string.turbo_disabled_toast)
         }
 
-        Toast.makeText(context, toastMessage, Toast.LENGTH_SHORT).show()
+        if (showToast) {
+            Toast.makeText(context, toastMessage, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    fun setTurboEnabled(state: Boolean, showToast: Boolean) {
+        turboSpeedEnabled = state
+        reloadTurbo(showToast)
+    }
+
+    fun toggleTurbo(showToast: Boolean) {
+        setTurboEnabled(!TurboHelper.isTurboSpeedEnabled(), showToast)
     }
 }


### PR DESCRIPTION
Closes #1019 

The toast previously appeared whenever the Turbo setting was reloaded, meaning it could appear at inappropriate times (e.g. after closing the settings menu without changing anything related to Turbo).

This has been fixed by adding an extra boolean parameter to relevant functions which controls whether the toast is displayed.