### PR TITLE
Change per-application settings in code and add render thread delay to Luigi's Mansion: Dark Moon to improve performance

### DIFF
--- a/src/citra_qt/configuration/configure_per_game.cpp
+++ b/src/citra_qt/configuration/configure_per_game.cpp
@@ -22,8 +22,11 @@
 #include "citra_qt/configuration/configure_layout.h"
 #include "citra_qt/configuration/configure_per_game.h"
 #include "citra_qt/configuration/configure_system.h"
+#include "citra_qt/configuration/configuration_shared.h"
+#include "citra_qt/uisettings.h"
 #include "citra_qt/util/util.h"
 #include "common/file_util.h"
+#include "common/per_game_config.h"
 #include "core/core.h"
 #include "core/loader/loader.h"
 #include "core/loader/smdh.h"
@@ -148,6 +151,14 @@ void ConfigurePerGame::LoadConfiguration() {
 
     ui->display_title_id->setText(
         QStringLiteral("%1").arg(title_id, 16, 16, QLatin1Char{'0'}).toUpper());
+
+    // Apply default settings from per_game_config.h
+    const auto& default_settings = PerGameConfig::GetDefaultSettings(title_id);
+    for (const auto& [setting_name, value] : default_settings) {
+        if (setting_name == "delay_game_render_thread_us") {
+            Settings::values.delay_game_render_thread_us = value;
+        }
+    }
 
     std::unique_ptr<Loader::AppLoader> loader_ptr;
     Loader::AppLoader* loader;

--- a/src/common/per_game_config.h
+++ b/src/common/per_game_config.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <unordered_map>
+#include "common/settings.h"
+
+namespace PerGameConfig {
+
+// Map of title IDs to their default settings
+const std::unordered_map<u64, std::unordered_map<std::string, u16>> default_settings = {
+    // Title ID 00040000000CFF00
+    {0x00040000000CFF00, {
+        {"delay_game_render_thread_us", 9500}
+    }},
+    // Title ID 0004000000055F00
+    {0x0004000000055F00, {
+        {"delay_game_render_thread_us", 9500}
+    }},
+    // Title ID 0004000000076500
+    {0x0004000000076500, {
+        {"delay_game_render_thread_us", 9500}
+    }},
+    // Title ID 00040000000D0000
+    {0x00040000000D0000, {
+        {"delay_game_render_thread_us", 9500}
+    }}
+};
+
+// Function to get default settings for a title ID
+inline const std::unordered_map<std::string, u16>& GetDefaultSettings(u64 title_id) {
+    static const std::unordered_map<std::string, u16> empty;
+    auto it = default_settings.find(title_id);
+    return it != default_settings.end() ? it->second : empty;
+}
+
+} / namespace PerGameConfig


### PR DESCRIPTION
Added ability to change per-application settings before build time and added 9.5 ms application render thread delay for Luigi's Mansion: Dark Moon to reduce major stuttering