### PR TITLE
file_util.cpp: Use _stat64 instead of stat where appropriate

### DIFF
--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -45,12 +45,6 @@
 #define fileno _fileno
 #endif
 
-// 64 bit offsets for MSVC and MinGW. MinGW also needs this for using _wstat64
-#ifndef __MINGW64__
-#define stat _stat64
-#define fstat _fstat64
-#endif
-
 #else
 #ifdef __APPLE__
 #include <sys/param.h>

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -119,7 +119,7 @@ bool Exists(const std::string& filename) {
     StripTailDirSlashes(copy);
 
 #ifdef _WIN32
-    struct stat file_info;
+    struct _stat64 file_info;
     // Windows needs a slash to identify a driver root
     if (copy.size() != 0 && copy.back() == ':')
         copy += DIR_SEP_CHR;
@@ -140,18 +140,18 @@ bool IsDirectory(const std::string& filename) {
     return AndroidStorage::IsDirectory(filename);
 #endif
 
-    struct stat file_info;
-
     std::string copy(filename);
     StripTailDirSlashes(copy);
 
 #ifdef _WIN32
+    struct _stat64 file_info;
     // Windows needs a slash to identify a driver root
     if (copy.size() != 0 && copy.back() == ':')
         copy += DIR_SEP_CHR;
 
     int result = _wstat64(Common::UTF8ToUTF16W(copy).c_str(), &file_info);
 #else
+    struct stat file_info;
     int result = stat(copy.c_str(), &file_info);
 #endif
 
@@ -397,9 +397,11 @@ u64 GetSize(const std::string& filename) {
         LOG_ERROR(Common_Filesystem, "failed {}: is a directory", filename);
         return 0;
     }
-
+#ifndef _WIN32
     struct stat buf;
+#endif
 #ifdef _WIN32
+    struct _stat64 buf;
     if (_wstat64(Common::UTF8ToUTF16W(filename).c_str(), &buf) == 0)
 #elif ANDROID
     u64 result = AndroidStorage::GetSize(filename);


### PR DESCRIPTION
Closes #1040 

Avoids compile failures introduced in an MSYS2 update

Self reviewing because the change is minor and I have verified that the emulator works correctly after the change.