### PR TITLE
Add setting to toggle RPC server (disabled by default)

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
@@ -16,6 +16,7 @@ enum class BooleanSetting(
     ALLOW_PLUGIN_LOADER("allow_plugin_loader", Settings.SECTION_SYSTEM, true),
     SWAP_SCREEN("swap_screen", Settings.SECTION_LAYOUT, false),
     INSTANT_DEBUG_LOG("instant_debug_log", Settings.SECTION_DEBUG, false),
+    ENABLE_RPC_SERVER("enable_rpc_server", Settings.SECTION_DEBUG, false),
     CUSTOM_LAYOUT("custom_layout",Settings.SECTION_LAYOUT,false),
     OVERLAY_SHOW_FPS("overlay_show_fps", Settings.SECTION_LAYOUT, true),
     OVERLAY_SHOW_FRAMETIME("overlay_show_frame_time", Settings.SECTION_LAYOUT, false),

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -1607,6 +1607,15 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
             )
             add(
                 SwitchSetting(
+                    BooleanSetting.ENABLE_RPC_SERVER,
+                    R.string.enable_rpc_server,
+                    R.string.enable_rpc_server_desc,
+                    BooleanSetting.ENABLE_RPC_SERVER.key,
+                    BooleanSetting.ENABLE_RPC_SERVER.defaultValue
+                )
+            )
+            add(
+                SwitchSetting(
                     BooleanSetting.DELAY_START_LLE_MODULES,
                     R.string.delay_start_lle_modules,
                     R.string.delay_start_lle_modules_description,

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -293,6 +293,7 @@ void Config::ReadValues() {
     ReadSetting("Debugging", Settings::values.use_gdbstub);
     ReadSetting("Debugging", Settings::values.gdbstub_port);
     ReadSetting("Debugging", Settings::values.instant_debug_log);
+    ReadSetting("Debugging", Settings::values.enable_rpc_server);
 
     for (const auto& service_module : Service::service_module_map) {
         bool use_lle = sdl2_config->GetBoolean("Debugging", "LLE\\" + service_module.name, false);

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -445,6 +445,10 @@ gdbstub_port=24689
 # Immediately commits the debug log to file. Use this if Azahar crashes and the log output is being cut.
 instant_debug_log =
 
+# Enable RPC server for scripting purposes. Allows accessing guest memory remotely.
+# 0 (default): Off, 1: On
+enable_rpc_server =
+
 # Delay the start of apps when LLE modules are enabled
 # 0: Off, 1 (default): On
 delay_start_for_lle_modules =

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -321,7 +321,7 @@
     <string name="enable_rpc_server">Enable RPC Server</string>
     <string name="enable_rpc_server_desc">Enables the RPC server on port 45987. This allows remotely reading/writing guest memory.</string>
 
-  <!-- Layout settings strings -->
+    <!-- Layout settings strings -->
     <string name="layout_screen_orientation">Screen Orientation</string>
     <string name="layout_screen_orientation_auto_sensor">Automatic</string>
     <string name="layout_screen_orientation_landscape">Landscape</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -318,8 +318,10 @@
     <string name="delay_start_lle_modules_description">Delays the start of the app when LLE modules are enabled.</string>
     <string name="deterministic_async_operations">Deterministic Async Operations</string>
     <string name="deterministic_async_operations_description">Makes async operations deterministic for debugging. Enabling this may cause freezes.</string>
+    <string name="enable_rpc_server">Enable RPC Server</string>
+    <string name="enable_rpc_server_desc">Enables the RPC server on port 45987. This allows remotely reading/writing guest memory.</string>
 
-    <!-- Layout settings strings -->
+  <!-- Layout settings strings -->
     <string name="layout_screen_orientation">Screen Orientation</string>
     <string name="layout_screen_orientation_auto_sensor">Automatic</string>
     <string name="layout_screen_orientation_landscape">Landscape</string>

--- a/src/citra_qt/configuration/configure_debug.cpp
+++ b/src/citra_qt/configuration/configure_debug.cpp
@@ -104,6 +104,11 @@ void ConfigureDebug::SetConfiguration() {
         Settings::values.delay_start_for_lle_modules.GetValue());
     ui->deterministic_async_operations->setChecked(
         Settings::values.deterministic_async_operations.GetValue());
+    ui->enable_rpc_server->setChecked(Settings::values.enable_rpc_server.GetValue());
+#ifndef ENABLE_SCRIPTING
+    ui->enable_rpc_server->setVisible(false);
+#endif // !ENABLE_SCRIPTING
+
     ui->toggle_renderer_debug->setChecked(Settings::values.renderer_debug.GetValue());
     ui->toggle_dump_command_buffers->setChecked(Settings::values.dump_command_buffers.GetValue());
 
@@ -141,6 +146,7 @@ void ConfigureDebug::ApplyConfiguration() {
     Settings::values.delay_start_for_lle_modules = ui->delay_start_for_lle_modules->isChecked();
     Settings::values.deterministic_async_operations =
         ui->deterministic_async_operations->isChecked();
+    Settings::values.enable_rpc_server = ui->enable_rpc_server->isChecked();
     Settings::values.renderer_debug = ui->toggle_renderer_debug->isChecked();
     Settings::values.dump_command_buffers = ui->toggle_dump_command_buffers->isChecked();
     Settings::values.instant_debug_log = ui->instant_debug_log->isChecked();
@@ -164,6 +170,7 @@ void ConfigureDebug::SetupPerGameUI() {
 
     ui->groupBox->setVisible(false);
     ui->groupBox_2->setVisible(false);
+    ui->enable_rpc_server->setVisible(false);
     ui->toggle_cpu_jit->setVisible(false);
 }
 

--- a/src/citra_qt/configuration/configure_debug.ui
+++ b/src/citra_qt/configuration/configure_debug.ui
@@ -279,6 +279,16 @@
         </property>
        </widget>
       </item>
+      <item row="3" column="0">
+        <widget class="QCheckBox" name="enable_rpc_server">
+          <property name="text">
+            <string>Enable RPC server</string>
+          </property>
+          <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enables the RPC server on port 45987. This allows remotely reading/writing guest memory, do not enable if you don't know what you are doing.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+        </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -596,6 +596,7 @@ struct Values {
     Setting<bool> use_gdbstub{false, "use_gdbstub"};
     Setting<u16> gdbstub_port{24689, "gdbstub_port"};
     Setting<bool> instant_debug_log{false, "instant_debug_log"};
+    Setting<bool> enable_rpc_server{false, "enable_rpc_server"};
 
     // Miscellaneous
     Setting<std::string> log_filter{"*:Info", "log_filter"};

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -503,7 +503,9 @@ System::ResultStatus System::Init(Frontend::EmuWindow& emu_window,
     dsp_core->EnableStretching(Settings::values.enable_audio_stretching.GetValue());
 
 #ifdef ENABLE_SCRIPTING
-    rpc_server = std::make_unique<RPC::Server>(*this);
+    if (Settings::values.enable_rpc_server.GetValue()) {
+        rpc_server = std::make_unique<RPC::Server>(*this);
+    }
 #endif
 
     service_manager = std::make_unique<Service::SM::ServiceManager>(*this);


### PR DESCRIPTION
Adds a setting to toggle the RPC server, which allows reading/writing the emulated process memory through port 45897. The setting is now disabled by default.