### PR TITLE
Allow SPIR-V when using Shadow2D texture mapping

### DIFF
--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -440,7 +440,7 @@ void PipelineCache::UseFragmentShader(const Pica::RegsInternal& regs,
     if (new_shader) {
         workers.QueueWork([fs_config, this, &shader]() {
             const bool use_spirv = Settings::values.spirv_shader_gen.GetValue();
-            if (use_spirv && !fs_config.UsesShadowPipeline()) {
+            if (use_spirv && !fs_config.UsesSpirvIncompatibleConfig()) {
                 const std::vector code = SPIRV::GenerateFragmentShader(fs_config, profile);
                 shader.module = CompileSPV(code, instance.GetDevice());
             } else {

--- a/src/video_core/shader/generator/pica_fs_config.h
+++ b/src/video_core/shader/generator/pica_fs_config.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -174,10 +174,9 @@ struct FSConfig {
                framebuffer.alpha_blend.eq != Pica::FramebufferRegs::BlendEquation::Add;
     }
 
-    [[nodiscard]] bool UsesShadowPipeline() const {
+    [[nodiscard]] bool UsesSpirvIncompatibleConfig() const {
         const auto texture0_type = texture.texture0_type.Value();
-        return texture0_type == Pica::TexturingRegs::TextureConfig::Shadow2D ||
-               texture0_type == Pica::TexturingRegs::TextureConfig::ShadowCube ||
+        return texture0_type == Pica::TexturingRegs::TextureConfig::ShadowCube ||
                framebuffer.shadow_rendering.Value();
     }
 

--- a/src/video_core/shader/generator/spv_fs_shader_gen.cpp
+++ b/src/video_core/shader/generator/spv_fs_shader_gen.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -755,8 +755,12 @@ Id FragmentModule::CompareShadow(Id pixel, Id z) {
 }
 
 Id FragmentModule::SampleShadow() {
-    const Id texcoord0{OpLoad(vec_ids.Get(2), texcoord_id[0])};
+    Id texcoord0{OpLoad(vec_ids.Get(2), texcoord_id[0])};
     const Id texcoord0_w{OpLoad(f32_id, texcoord0_w_id)};
+    if (!config.texture.shadow_texture_orthographic) {
+        const Id div{OpCompositeConstruct(vec_ids.Get(2), texcoord0_w, texcoord0_w)};
+        texcoord0 = OpFDiv(vec_ids.Get(2), texcoord0, div);
+    }
     const Id abs_min_w{OpFMul(f32_id, OpFMin(f32_id, OpFAbs(f32_id, texcoord0_w), ConstF32(1.f)),
                               ConstF32(16777215.f))};
     const Id shadow_texture_bias{GetShaderDataMember(i32_id, ConstS32(17))};


### PR DESCRIPTION
Allows the use of the SPIR-V shader generator when using the Shadow2D texture mapping. While Shadow2D mapping mode support in SPIR-V was implemented some time ago, the check to fallback to GLSL was not removed, so games using this mapping mode were using the slower GLSL generator.

Enabling SPIR-V for this mapping mode exposed a bug that is fixed in this commit as well.

Considerably reduces stuttering in some games by using the Vulkan backend, such as Luigi's Mansion 2 and Resident Evil Revelations.

**NOTE: This PR is prone to causing new graphical bugs, we should take this in mind if new issues appear!**

This fix wouldn't have been possible without the help of an anonymous collaborator.