### PR TITLE
Add shortcuts for Configure{, Current Application}

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -793,6 +793,10 @@ void GMainWindow::InitializeHotkeys() {
     link_action_shortcut(ui->action_Show_Room, QStringLiteral("Multiplayer Show Current Room"));
     link_action_shortcut(ui->action_Leave_Room, QStringLiteral("Multiplayer Leave Room"));
 
+    link_action_shortcut(ui->action_Configure, QStringLiteral("Configure"));
+    link_action_shortcut(ui->action_Configure_Current_Game,
+                         QStringLiteral("Configure Current Application"));
+
     // QShortcut Hotkeys
     const auto connect_shortcut = [&](const QString& action_name, const auto& function) {
         const auto* hotkey = hotkey_registry.GetHotkey(main_window, action_name, this);

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -54,12 +54,14 @@ const std::array<std::array<int, 5>, Settings::NativeAnalog::NumAnalogs> QtConfi
 // This must be in alphabetical order according to action name as it must have the same order as
 // UISetting::values.shortcuts, which is alphabetically ordered.
 // clang-format off
-const std::array<UISettings::Shortcut, 38> QtConfig::default_hotkeys {{
+const std::array<UISettings::Shortcut, 40> QtConfig::default_hotkeys {{
      {QStringLiteral("Advance Frame"),            QStringLiteral("Main Window"), {QStringLiteral(""),       Qt::ApplicationShortcut}},
      {QStringLiteral("Audio Mute/Unmute"),        QStringLiteral("Main Window"), {QStringLiteral("Ctrl+M"), Qt::WindowShortcut}},
      {QStringLiteral("Audio Volume Down"),        QStringLiteral("Main Window"), {QStringLiteral(""),       Qt::WindowShortcut}},
      {QStringLiteral("Audio Volume Up"),          QStringLiteral("Main Window"), {QStringLiteral(""),       Qt::WindowShortcut}},
      {QStringLiteral("Capture Screenshot"),       QStringLiteral("Main Window"), {QStringLiteral("Ctrl+P"), Qt::WidgetWithChildrenShortcut}},
+     {QStringLiteral("Configure"),                QStringLiteral("Main Window"), {QStringLiteral("Ctrl+,"), Qt::WindowShortcut}},
+     {QStringLiteral("Configure Current Application"),        QStringLiteral("Main Window"), {QStringLiteral("Ctrl+."), Qt::WindowShortcut}},
      {QStringLiteral("Continue/Pause Emulation"), QStringLiteral("Main Window"), {QStringLiteral("F4"),     Qt::WindowShortcut}},
      {QStringLiteral("Decrease 3D Factor"),       QStringLiteral("Main Window"), {QStringLiteral("Ctrl+-"), Qt::ApplicationShortcut}},
      {QStringLiteral("Decrease Speed Limit"),     QStringLiteral("Main Window"), {QStringLiteral("-"),      Qt::ApplicationShortcut}},

--- a/src/citra_qt/configuration/config.h
+++ b/src/citra_qt/configuration/config.h
@@ -26,7 +26,7 @@ public:
 
     static const std::array<int, Settings::NativeButton::NumButtons> default_buttons;
     static const std::array<std::array<int, 5>, Settings::NativeAnalog::NumAnalogs> default_analogs;
-    static const std::array<UISettings::Shortcut, 38> default_hotkeys;
+    static const std::array<UISettings::Shortcut, 40> default_hotkeys;
 
 private:
     void Initialize(const std::string& config_name);

--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -18,7 +18,7 @@
     <normaloff>dist/azahar.png</normaloff>dist/azahar.png</iconset>
   </property>
   <property name="tabShape">
-   <enum>QTabWidget::Rounded</enum>
+   <enum>QTabWidget::TabShape::Rounded</enum>
   </property>
   <property name="dockNestingEnabled">
    <bool>true</bool>
@@ -136,20 +136,10 @@
      <property name="title">
       <string>Screen Layout</string>
      </property>
-     <addaction name="action_Screen_Layout_Default"/>
-     <addaction name="action_Screen_Layout_Single_Screen"/>
-     <addaction name="action_Screen_Layout_Large_Screen"/>
-     <addaction name="action_Screen_Layout_Side_by_Side"/>
-     <addaction name="action_Screen_Layout_Separate_Windows"/>
-     <addaction name="action_Screen_Layout_Hybrid_Screen"/>
-     <addaction name="action_Screen_Layout_Custom_Layout"/>
-     <addaction name="separator"/>
-     <addaction name="action_Screen_Layout_Upright_Screens"/>
-     <addaction name="action_Screen_Layout_Swap_Screens"/>
      <widget class="QMenu" name="menu_Small_Screen_Position">
       <property name="enabled">
-     <bool>true</bool>
-    </property>
+       <bool>true</bool>
+      </property>
       <property name="title">
        <string>Small Screen Position</string>
       </property>
@@ -162,6 +152,16 @@
       <addaction name="action_Small_Screen_Above"/>
       <addaction name="action_Small_Screen_Below"/>
      </widget>
+     <addaction name="action_Screen_Layout_Default"/>
+     <addaction name="action_Screen_Layout_Single_Screen"/>
+     <addaction name="action_Screen_Layout_Large_Screen"/>
+     <addaction name="action_Screen_Layout_Side_by_Side"/>
+     <addaction name="action_Screen_Layout_Separate_Windows"/>
+     <addaction name="action_Screen_Layout_Hybrid_Screen"/>
+     <addaction name="action_Screen_Layout_Custom_Layout"/>
+     <addaction name="separator"/>
+     <addaction name="action_Screen_Layout_Upright_Screens"/>
+     <addaction name="action_Screen_Layout_Swap_Screens"/>
      <addaction name="menu_Small_Screen_Position"/>
     </widget>
     <addaction name="action_Fullscreen"/>
@@ -238,14 +238,14 @@
    </property>
   </action>
   <action name="action_Connect_Artic">
-    <property name="text">
-      <string>Connect to Artic Base...</string>
-    </property>
+   <property name="text">
+    <string>Connect to Artic Base...</string>
+   </property>
   </action>
   <action name="action_Setup_System_Files">
-    <property name="text">
-      <string>Set Up System Files...</string>
-    </property>
+   <property name="text">
+    <string>Set Up System Files...</string>
+   </property>
   </action>
   <action name="action_Boot_Home_Menu_JPN">
    <property name="text">
@@ -329,7 +329,7 @@
     <string>About Azahar</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::AboutRole</enum>
+    <enum>QAction::MenuRole::AboutRole</enum>
    </property>
   </action>
   <action name="action_Single_Window_Mode">
@@ -365,7 +365,7 @@
     <string>Configure...</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::PreferencesRole</enum>
+    <enum>QAction::MenuRole::PreferencesRole</enum>
    </property>
   </action>
   <action name="action_Display_Dock_Widget_Headers">
@@ -408,11 +408,11 @@
    </property>
   </action>
   <action name="action_Close_Movie">
-   <property name="text">
-    <string>Close</string>
-   </property>
    <property name="enabled">
     <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Close</string>
    </property>
   </action>
   <action name="action_Save_Movie">
@@ -689,7 +689,7 @@
     <string>Configure Current Application...</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::NoRole</enum>
+    <enum>QAction::MenuRole::NoRole</enum>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Defaults to Ctrl+Comma and Ctrl+Period respectively. The former is a
de-facto standard on macOS and is really the only "common" configure
hotkey. Ctrl+Period was chosen due to its proximity.

Signed-off-by: swurl <swurl@swurl.xyz>
