### PR TITLE
android: Enable `android:windowOptOutEdgeToEdgeEnforcement` for Android 15+

### DIFF
--- a/src/android/app/src/main/res/values-v35/themes.xml
+++ b/src/android/app/src/main/res/values-v35/themes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.V35.Citra" parent="Theme.Citra">
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+
+    <style name="Theme.Citra.Main" parent="Theme.V35.Citra" />
+</resources>


### PR DESCRIPTION
Closes #923 (kind of, read below)

Based on #972

Despite `android:windowOptOutEdgeToEdgeEnforcement` being introduced in Android 15, it was then immediately deprecated for Android 16, so adding this property is really just a stop-gap measure which buys us some time to figure out how to fix this properly later.

Self-reviewing because this change is very simple and I have verified that it works correctly.