### PR TITLE
update_checker.cpp: Add `alpha` and `beta` substrings to prerelease detection logic

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -400,7 +400,9 @@ GMainWindow::GMainWindow(Core::System& system_)
     if (UISettings::values.check_for_update_on_start) {
         update_future = QtConcurrent::run([]() -> QString {
             const bool is_prerelease = // TODO: This can be done better -OS
-                (strstr(Common::g_build_fullname, "rc") != NULL);
+                ((strstr(Common::g_build_fullname, "alpha") != NULL) ||
+                 (strstr(Common::g_build_fullname, "beta") != NULL) ||
+                 (strstr(Common::g_build_fullname, "rc") != NULL));
             const std::optional<std::string> latest_release_tag =
                 UpdateChecker::GetLatestRelease(is_prerelease);
             if (latest_release_tag && latest_release_tag.value() != Common::g_build_fullname) {


### PR DESCRIPTION
This allows us to create prereleases with the `-alpha` and `-beta` suffixes without the build's update checker erroneously considering itself to be a stable release. Previously only builds with the `-rc` suffix would consider itself to be a prerelease.

Pre-release detection should be re-implemented at a later date to not use the build's version string for this purpose, as this is pretty hacky.