### PR TITLE
video_core: Use SIMD on RasterizerAccelerated::AnalyzeVertexArray

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,8 @@ option(USE_DISCORD_PRESENCE "Enables Discord Rich Presence" OFF)
 
 option(ENABLE_MICROPROFILE "Enables microprofile capabilities" OFF)
 
+option(ENABLE_SSE42 "Enable SSE4.2 optimizations on x86_64" ON)
+
 # Compile options
 CMAKE_DEPENDENT_OPTION(COMPILE_WITH_DWARF "Add DWARF debugging information" ${IS_DEBUG_BUILD} "MINGW" OFF)
 option(ENABLE_LTO "Enable link time optimization" ${DEFAULT_ENABLE_LTO})
@@ -124,6 +126,15 @@ if (ENABLE_ROOM)
 endif()
 if (ENABLE_SDL2_FRONTEND)
     add_definitions(-DENABLE_SDL2_FRONTEND)
+endif()
+
+if(ENABLE_SSE42 AND (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64"))
+    message(STATUS "SSE4.2 enabled for x86_64")
+    if(MSVC)
+        SET(SSE42_COMPILE_OPTION /arch:SSE4.2)
+    else()
+        SET(SSE42_COMPILE_OPTION -msse4.1 -msse4.2)
+    endif()
 endif()
 
 include(CitraHandleSystemLibs)

--- a/src/citra_meta/CMakeLists.txt
+++ b/src/citra_meta/CMakeLists.txt
@@ -77,6 +77,10 @@ if (CITRA_USE_PRECOMPILED_HEADERS)
     target_precompile_headers(citra_meta PRIVATE precompiled_headers.h)
 endif()
 
+if (SSE42_COMPILE_OPTION)
+    target_compile_definitions(citra_meta PRIVATE CITRA_HAS_SSE42)
+endif()
+
 # Bundle in-place on MSVC so dependencies can be resolved by builds.
 if (ENABLE_QT AND MSVC)
     include(BundleTarget)

--- a/src/citra_meta/main.cpp
+++ b/src/citra_meta/main.cpp
@@ -21,7 +21,60 @@ __declspec(dllexport) unsigned long NvOptimusEnablement = 0x00000001;
 }
 #endif
 
+#if CITRA_HAS_SSE42
+#if defined(_WIN32)
+#include <windows.h>
+#if defined(_MSC_VER)
+#include <intrin.h>
+#else
+#include <cpuid.h>
+#endif // _MSC_VER
+#else
+#include <cpuid.h>
+#endif // _WIN32
+
+static bool CpuSupportsSSE42() {
+    uint32_t ecx;
+
+#if defined(_MSC_VER)
+    int cpu_info[4];
+    __cpuid(cpu_info, 1);
+    ecx = static_cast<uint32_t>(cpu_info[2]);
+#elif defined(__GNUC__) || defined(__clang__)
+    uint32_t eax, ebx, edx;
+    if (!__get_cpuid(1, &eax, &ebx, &ecx, &edx)) {
+        return false;
+    }
+#else
+#error "Unsupported compiler"
+#endif
+
+    // Bit 20 of ECX indicates SSE4.2
+    return (ecx & (1 << 20)) != 0;
+}
+
+static bool CheckAndReportSSE42() {
+    if (!CpuSupportsSSE42()) {
+        const std::string error_msg =
+            "This application requires a CPU with SSE4.2 support or higher.\nTo run on unsupported "
+            "systems, recompile the application with the ENABLE_SSE42 option disabled.";
+#if defined(_WIN32)
+        MessageBoxA(nullptr, error_msg.c_str(), "Incompatible CPU", MB_OK | MB_ICONERROR);
+#endif
+        std::cerr << "Error: " << error_msg << std::endl;
+        return false;
+    }
+    return true;
+}
+#endif
+
 int main(int argc, char* argv[]) {
+#if CITRA_HAS_SSE42
+    if (!CheckAndReportSSE42()) {
+        return 1;
+    }
+#endif
+
 #if ENABLE_ROOM
     bool launch_room = false;
     for (int i = 1; i < argc; i++) {

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -206,3 +206,8 @@ if (BACKTRACE_LIBRARY AND ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND CMAKE_CXX_CO
     target_link_libraries(citra_common PRIVATE ${BACKTRACE_LIBRARY} dl)
     target_compile_definitions(citra_common PRIVATE CITRA_LINUX_GCC_BACKTRACE)
 endif()
+
+if (SSE42_COMPILE_OPTION)
+    target_compile_definitions(citra_common PRIVATE CITRA_HAS_SSE42)
+    target_compile_options(citra_common PRIVATE ${SSE42_COMPILE_OPTION})
+endif()

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -103,6 +103,7 @@ add_library(citra_common STATIC
     logging/text_formatter.cpp
     logging/text_formatter.h
     logging/types.h
+    math_util.cpp
     math_util.h
     memory_detect.cpp
     memory_detect.h

--- a/src/common/math_util.cpp
+++ b/src/common/math_util.cpp
@@ -1,0 +1,151 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include "math_util.h"
+
+#if defined(CITRA_HAS_SSE42)
+#include <emmintrin.h>
+#include <smmintrin.h>
+#endif
+
+#if defined(__aarch64__) || defined(__ARM_NEON)
+#define CITRA_HAS_NEON
+#include <arm_neon.h>
+#endif
+
+#if defined(_MSC_VER)
+#define DISABLE_VECTORIZE __pragma(loop(no_vector))
+#elif defined(__clang__)
+#define DISABLE_VECTORIZE _Pragma("clang loop vectorize(disable)")
+#elif defined(__GNUC__)
+#define DISABLE_VECTORIZE _Pragma("GCC novector")
+#else
+#define DISABLE_VECTORIZE
+#endif
+
+namespace Common {
+std::pair<u8, u8> FindMinMax(const std::span<const u8>& data) {
+    const size_t count = data.size();
+    const u8* data_ptr = data.data();
+    u8 final_min, final_max;
+#if defined(CITRA_HAS_SSE42) || defined(CITRA_HAS_NEON)
+    u8 simd_min = 0xFF;
+    u8 simd_max = 0;
+    size_t i = 0;
+    constexpr size_t simd_line_count = 16;
+    constexpr size_t count_threshold = simd_line_count * 2;
+    if (count >= count_threshold) {
+#if defined(CITRA_HAS_SSE42)
+        __m128i vmin = _mm_set1_epi8(static_cast<char>(0xFF));
+        __m128i vmax = _mm_setzero_si128();
+        for (; i + simd_line_count <= count; i += simd_line_count) {
+            __m128i vals = _mm_loadu_si128(reinterpret_cast<const __m128i*>(data_ptr + i));
+            vmin = _mm_min_epu8(vmin, vals);
+            vmax = _mm_max_epu8(vmax, vals);
+        }
+        alignas(16) u8 tmp[simd_line_count];
+        _mm_storeu_si128(reinterpret_cast<__m128i*>(tmp), vmin);
+        simd_min = *std::min_element(tmp, tmp + simd_line_count);
+        _mm_storeu_si128(reinterpret_cast<__m128i*>(tmp), vmax);
+        simd_max = *std::max_element(tmp, tmp + simd_line_count);
+#elif defined(CITRA_HAS_NEON)
+        uint8x16_t vmin = vdupq_n_u8(0xFF);
+        uint8x16_t vmax = vdupq_n_u8(0);
+        for (; i + simd_line_count <= count; i += simd_line_count) {
+            uint8x16_t vals = vld1q_u8(data_ptr + i);
+            vmin = vminq_u8(vmin, vals);
+            vmax = vmaxq_u8(vmax, vals);
+        }
+        alignas(16) uint8_t tmp[simd_line_count];
+        vst1q_u8(tmp, vmin);
+        simd_min = *std::min_element(tmp, tmp + simd_line_count);
+        vst1q_u8(tmp, vmax);
+        simd_max = *std::max_element(tmp, tmp + simd_line_count);
+#endif // CITRA_HAS_SSE42
+    }
+    DISABLE_VECTORIZE
+    for (; i < count; ++i) {
+        const u8 val = data_ptr[i];
+        simd_min = std::min(simd_min, val);
+        simd_max = std::max(simd_max, val);
+    }
+
+    final_min = simd_min;
+    final_max = simd_max;
+
+#else
+    // Scalar fallback
+    for (size_t i = 0; i < count; ++i) {
+        const u8 val = data_ptr[i];
+        final_min = std::min(final_min, val);
+        final_max = std::max(final_max, val);
+    }
+#endif // CITRA_HAS_SSE42 || CITRA_HAS_NEON
+
+    return {final_min, final_max};
+}
+
+std::pair<u16, u16> FindMinMax(const std::span<const u16>& data) {
+    const size_t count = data.size();
+    const u16* data_ptr = data.data();
+    u16 final_min, final_max;
+
+#if defined(CITRA_HAS_SSE42) || defined(CITRA_HAS_NEON)
+    u16 simd_min = 0xFFFF;
+    u16 simd_max = 0;
+    size_t i = 0;
+    constexpr size_t simd_line_count = 8;
+    constexpr size_t count_threshold = simd_line_count * 2;
+    if (count >= count_threshold) {
+#if defined(CITRA_HAS_SSE42)
+        __m128i vmin = _mm_set1_epi16(static_cast<short>(0xFFFF));
+        __m128i vmax = _mm_setzero_si128();
+        for (; i + simd_line_count <= count; i += simd_line_count) {
+            __m128i vals = _mm_loadu_si128(reinterpret_cast<const __m128i*>(data_ptr + i));
+            vmin = _mm_min_epu16(vmin, vals);
+            vmax = _mm_max_epu16(vmax, vals);
+        }
+        alignas(16) u16 tmp[simd_line_count];
+        _mm_storeu_si128(reinterpret_cast<__m128i*>(tmp), vmin);
+        simd_min = *std::min_element(tmp, tmp + simd_line_count);
+        _mm_storeu_si128(reinterpret_cast<__m128i*>(tmp), vmax);
+        simd_max = *std::max_element(tmp, tmp + simd_line_count);
+#elif defined(CITRA_HAS_NEON)
+        uint16x8_t vmin = vdupq_n_u16(static_cast<u16>(0xFFFF));
+        uint16x8_t vmax = vdupq_n_u16(0);
+        for (; i + simd_line_count <= count; i += simd_line_count) {
+            uint16x8_t vals = vld1q_u16(data_ptr + i);
+            vmin = vminq_u16(vmin, vals);
+            vmax = vmaxq_u16(vmax, vals);
+        }
+        alignas(16) uint16_t tmp[simd_line_count];
+        vst1q_u16(tmp, vmin);
+        simd_min = *std::min_element(tmp, tmp + simd_line_count);
+        vst1q_u16(tmp, vmax);
+        simd_max = *std::max_element(tmp, tmp + simd_line_count);
+#endif // CITRA_HAS_SSE42
+    }
+    DISABLE_VECTORIZE
+    for (; i < count; ++i) {
+        const u16 val = data_ptr[i];
+        simd_min = std::min(simd_min, val);
+        simd_max = std::max(simd_max, val);
+    }
+
+    final_min = simd_min;
+    final_max = simd_max;
+
+#else
+    // Scalar fallback
+    for (u32 i = 0; i < count; ++i) {
+        const u16 val = data_ptr[i];
+        final_min = std::min(final_min, val);
+        final_max = std::max(final_max, val);
+    }
+#endif // CITRA_HAS_SSE42 || CITRA_HAS_NEON
+
+    return {final_min, final_max};
+}
+} // namespace Common

--- a/src/common/math_util.h
+++ b/src/common/math_util.h
@@ -9,7 +9,10 @@
 #pragma once
 
 #include <cstdlib>
+#include <span>
 #include <type_traits>
+#include <utility>
+#include "common_types.h"
 
 namespace Common {
 
@@ -72,5 +75,8 @@ struct Rectangle {
 
 template <typename T>
 Rectangle(T, T, T, T) -> Rectangle<T>;
+
+std::pair<u8, u8> FindMinMax(const std::span<const u8>& data);
+std::pair<u16, u16> FindMinMax(const std::span<const u16>& data);
 
 } // namespace Common


### PR DESCRIPTION
Enables the use of SSE4.2 instructions on x64 CPUs, allowing compilers to automatically vectorize some loops. A CMake toggle ENABLE_SSE42 (ON by default) has been added to enable this behaviour.

This change breaks compatibility with CPUs that do not have SSE4.2 instructions. All modern CPUs (from 2011 onwards) should always have these instructions. Manual compilation will be needed for older CPUs.

A message has been added to show if the CPU is incompatible when starting the emulator.

Uses SIMD operations on the RasterizerAccelerated::AnalyzeVertexArray function, which is hot code. Slightly reduces GPU processing time on all games (about 0.3ms on my machine).

This idea was suggested by an anonymous contributor.