### PR TITLE
video_core: Remove assert in AccelerateTextureCopy

### DIFF
--- a/src/video_core/rasterizer_cache/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache/rasterizer_cache.h
@@ -244,7 +244,13 @@ bool RasterizerCache<T>::AccelerateTextureCopy(const Pica::DisplayTransferConfig
         return false;
     }
 
-    ASSERT(src_rect.GetWidth() == dst_rect.GetWidth());
+    if (src_rect.GetWidth() != dst_rect.GetWidth()) {
+        LOG_ERROR(
+            HW_GPU,
+            "Surface source and destination width mismatch, skipping... src_width={}, dst_width={}",
+            src_rect.GetWidth(), dst_rect.GetHeight());
+        return false;
+    }
 
     const TextureCopy texture_copy = {
         .src_level = src_surface.LevelOf(src_params.addr),


### PR DESCRIPTION
Removes an ASSERT in AccelerateTextureCopy and replaces it with an if + error message.

Prevents `The Binding Of Isaac: Rebirth` from crashing the entire emulator when starting a run.