### PR TITLE
android: Fix crash when user directory permissions are lost

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/SelectUserDirectoryDialogFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/SelectUserDirectoryDialogFragment.kt
@@ -27,7 +27,7 @@ class SelectUserDirectoryDialogFragment : DialogFragment() {
             .setTitle(R.string.select_citra_user_folder)
             .setMessage(R.string.selecting_user_directory_without_write_permissions)
             .setPositiveButton(android.R.string.ok) { _: DialogInterface, _: Int ->
-                mainActivity?.openCitraDirectory?.launch(null)
+                mainActivity?.openCitraDirectoryLostPermission?.launch(null)
             }
             .show()
     }

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
@@ -478,7 +478,7 @@ class SetupFragment : Fragment() {
             return@registerForActivityResult
         }
 
-        CitraDirectoryHelper(requireActivity()).showCitraDirectoryDialog(result, pageButtonCallback, checkForButtonState)
+        CitraDirectoryHelper(requireActivity(), true).showCitraDirectoryDialog(result, pageButtonCallback, checkForButtonState)
     }
 
     private val getGamesDirectory =

--- a/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
@@ -322,7 +322,6 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
     }
 
     val openCitraDirectory = createOpenCitraDirectoryLauncher(permissionsLost = false)
-
     val openCitraDirectoryLostPermission = createOpenCitraDirectoryLauncher(permissionsLost = true)
 
     val ciaFileInstaller = registerForActivityResult(

--- a/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
@@ -12,6 +12,7 @@ import android.view.ViewGroup.MarginLayoutParams
 import android.view.WindowManager
 import android.view.animation.PathInterpolator
 import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -307,15 +308,22 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
             windowInsets
         }
 
-    val openCitraDirectory = registerForActivityResult(
-        ActivityResultContracts.OpenDocumentTree()
-    ) { result: Uri? ->
-        if (result == null) {
-            return@registerForActivityResult
-        }
+    private fun createOpenCitraDirectoryLauncher(
+        permissionsLost: Boolean
+    ): ActivityResultLauncher<Uri?> {
+        return registerForActivityResult(ActivityResultContracts.OpenDocumentTree()) { result: Uri? ->
+            if (result == null) {
+                return@registerForActivityResult
+            }
 
-        CitraDirectoryHelper(this@MainActivity).showCitraDirectoryDialog(result, buttonState = {})
+            CitraDirectoryHelper(this@MainActivity, permissionsLost)
+                .showCitraDirectoryDialog(result, buttonState = {})
+        }
     }
+
+    val openCitraDirectory = createOpenCitraDirectoryLauncher(permissionsLost = false)
+
+    val openCitraDirectoryLostPermission = createOpenCitraDirectoryLauncher(permissionsLost = true)
 
     val ciaFileInstaller = registerForActivityResult(
         OpenFileResultContract()

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/CitraDirectoryHelper.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/CitraDirectoryHelper.kt
@@ -16,7 +16,7 @@ import org.citra.citra_emu.viewmodel.HomeViewModel
 /**
  * Citra directory initialization ui flow controller.
  */
-class CitraDirectoryHelper(private val fragmentActivity: FragmentActivity) {
+class CitraDirectoryHelper(private val fragmentActivity: FragmentActivity, private val lostPermission: Boolean) {
     fun showCitraDirectoryDialog(result: Uri, callback: SetupCallback? = null, buttonState: () -> Unit) {
         val citraDirectoryDialog = CitraDirectoryDialogFragment.newInstance(
             fragmentActivity,
@@ -24,7 +24,7 @@ class CitraDirectoryHelper(private val fragmentActivity: FragmentActivity) {
             CitraDirectoryDialogFragment.Listener { moveData: Boolean, path: Uri ->
                 val previous = PermissionsHandler.citraDirectory
                 // Do noting if user select the previous path.
-                if (path == previous) {
+                if (path == previous && !lostPermission) {
                     return@Listener
                 }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/PermissionsHandler.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/PermissionsHandler.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -34,7 +34,8 @@ object PermissionsHandler {
 
             context.contentResolver.releasePersistableUriPermission(uri, takeFlags)
         } catch (e: Exception) {
-            Log.error("[PermissionsHandler]: Cannot check citra data directory permission, error: " + e.message)
+            // Do not use native library logging, as the native library may not be loaded yet
+            android.util.Log.e("PermissionsHandler", "Cannot check citra data directory permission, error: ${e.message}")
         }
         return false
     }


### PR DESCRIPTION
When Azahar tries to check for write permissions, it uses `takePersistableUriPermission`. This may return a `SecurityException` if we don't have permissions, which is expected. However in the exception handling, we try to use `Log.error`, which calls the native library that may not loaded at this point yet, so we get a crash.

Another problem was fixed that caused the application list not populating when re-obtaining permissions.

Fixes the app crashing when re-launched on some devices, such as the Retroid Pocket 5 (however the app losing permissions is a problem to be fixed on their end as well).

Closes #1052