### PR TITLE
android: Address several deprecation warnings

### DIFF
--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 val autoVersion = (((System.currentTimeMillis() / 1000) - 1451606400) / 10).toInt()
 val abiFilter = listOf("arm64-v8a", "x86_64")
 
-val downloadedJniLibsPath = "${buildDir}/downloadedJniLibs"
+val downloadedJniLibsPath = "${layout.buildDirectory}/downloadedJniLibs"
 
 @Suppress("UnstableApiUsage")
 android {
@@ -188,7 +188,7 @@ dependencies {
 // Download Vulkan Validation Layers from the KhronosGroup GitHub.
 val downloadVulkanValidationLayers = tasks.register<Download>("downloadVulkanValidationLayers") {
     src("https://github.com/KhronosGroup/Vulkan-ValidationLayers/releases/download/vulkan-sdk-1.4.304.1/android-binaries-1.4.304.1.zip")
-    dest(file("${buildDir}/tmp/Vulkan-ValidationLayers.zip"))
+    dest(file("${layout.buildDirectory}/tmp/Vulkan-ValidationLayers.zip"))
     onlyIfModified(true)
 }
 

--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -51,6 +51,7 @@ android {
 
     buildFeatures {
         viewBinding = true
+        buildConfig = true
     }
 
     lint {

--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -125,7 +125,6 @@ android {
             applicationIdSuffix = ".debug"
             versionNameSuffix = "-debug"
             signingConfig = signingConfigs.getByName("debug")
-            isMinifyEnabled = true
             isShrinkResources = true
             isDebuggable = true
             isJniDebuggable = true

--- a/src/android/gradle.properties
+++ b/src/android/gradle.properties
@@ -14,6 +14,5 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 android.native.buildOutput=verbose
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false


### PR DESCRIPTION
This PR addresses three deprecation warnings which were brought up by Android Studio. Each of them are self-explanatory.

I will be self-reviewing this as the changes are simple and I have verified that the build process runs correctly.