### PR TITLE
app/build.gradle.kts: Fixed incorrect usage of `layout.buildDirectory`

### DIFF
--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 val autoVersion = (((System.currentTimeMillis() / 1000) - 1451606400) / 10).toInt()
 val abiFilter = listOf("arm64-v8a", "x86_64")
 
-val downloadedJniLibsPath = "${layout.buildDirectory}/downloadedJniLibs"
+val downloadedJniLibsPath = "${layout.buildDirectory.get().asFile.path}/downloadedJniLibs"
 
 @Suppress("UnstableApiUsage")
 android {
@@ -187,7 +187,7 @@ dependencies {
 // Download Vulkan Validation Layers from the KhronosGroup GitHub.
 val downloadVulkanValidationLayers = tasks.register<Download>("downloadVulkanValidationLayers") {
     src("https://github.com/KhronosGroup/Vulkan-ValidationLayers/releases/download/vulkan-sdk-1.4.304.1/android-binaries-1.4.304.1.zip")
-    dest(file("${layout.buildDirectory}/tmp/Vulkan-ValidationLayers.zip"))
+    dest(file("${layout.buildDirectory.get().asFile.path}/tmp/Vulkan-ValidationLayers.zip"))
     onlyIfModified(true)
 }
 


### PR DESCRIPTION
One of the changes introduced in #1112, while building fine both locally and in CI, was silently misusing the `layout.buildDirectory` value. This resulted in file paths with strange names being created instead of those which are intended.

Self-reviewing as the fix here is simple and I have verified it to address the issue.