### PR TITLE
emulate suspend and close (and save the game progress) without home menu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 # CMake 3.12 required for 20 to be a valid value for CXX_STANDARD
 cmake_minimum_required(VERSION 3.15)
+cmake_policy(SET CMP0167 NEW)
 
 # Don't override the warning flags in MSVC:
 cmake_policy(SET CMP0092 NEW)

--- a/src/citra_sdl/citra_sdl.cpp
+++ b/src/citra_sdl/citra_sdl.cpp
@@ -170,8 +170,126 @@ static void OnStatusMessageReceived(const Network::StatusMessageEntry& msg) {
         std::cout << std::endl << "* " << message << std::endl << std::endl;
 }
 
+// #include <ncurses.h>
+#include "core/hle/service/apt/apt.h"
+#include "core/hle/service/apt/applet_manager.h"
+#include "input_common/keyboard.h"
+#include <SDL2/SDL.h>
+
+void send(int s) {
+
+    auto& system = Core::System::GetInstance();
+using namespace Service::APT;
+auto apt = GetModule(system);
+    auto am = apt->GetAppletManager();
+
+     am->SendParameter({
+    .sender_id = AppletId(0),
+    .destination_id = AppletId(0x300),
+    .signal = SignalType(s),
+    // .signal = SignalType::WakeupByCancel,
+});
+
+// auto id = AppletId(0x300);
+// auto id = AppletId::Application;
+}
+
+void sendarg(int a) {
+
+// Set deliver arg so that System Settings goes to the update screen directly
+Service::APT::DeliverArg arg;
+// arg.param.push_back(0x7a);
+arg.param.push_back(a);
+
+    auto& system = Core::System::GetInstance();
+using namespace Service::APT;
+auto apt = GetModule(system);
+    auto am = apt->GetAppletManager();
+am->SetDeliverArg(arg);
+ 
+}
+
+void input (){
+    // if (fork() > 0) return;
+    int c;
+    auto& system = Core::System::GetInstance();
+    // auto& svm = system.ServiceManager();
+    // auto apt = svm.GetService<Service::APT::Module::APTInterface>("APT:A");
+    // while ((c=getch()) != ERR) {
+    // while ((c=getchar()) != "\n") {
+    while ((c=getchar())) {
+        if (c == '\n') continue;
+        printf("pressed %c\n", c); 
+        if (c == 'r')
+            system.RequestReset();
+            // system.Reset();
+        if (c == 'p')
+            system.frame_limiter.SetFrameAdvancing(true);
+        if (c == 'q') {
+            // emu_window->RequestClose();
+            system.RequestShutdown();
+            break;
+        }
+
+            auto* kb = InputCommon::GetKeyboard();
+        if (c == 'a') {
+            // int a = Settings::NativeButton::A;
+            int a = SDL_SCANCODE_A;
+            kb->PressKey(a);
+            sleep(1);
+            kb->ReleaseKey(a);
+        }
+
+        if (c == 'b') {
+            int a = SDL_SCANCODE_B;
+            kb->PressKey(a);
+            sleep(1);
+            kb->ReleaseKey(a);
+        }
+
+        if (c == 'z') {
+            int a = SDL_SCANCODE_Z;
+            kb->PressKey(a);
+            sleep(1);
+            kb->ReleaseKey(a);
+        }
+            
+using namespace Service::APT;
+auto apt = GetModule(system);
+    auto am = apt->GetAppletManager();
+
+    // jump to home 
+// send parameters 0x10
+// receive parameters 3
+        if (c == 'j') {
+            send(0x10);
+        }
+
+        if (c == 'c') {
+            // am->PrepareToCloseApplication(true);
+            am->OrderToCloseApplication();
+            // Result r = am->OrderToCloseApplication();
+            // am->GlanceParameter(AppletId(0x300));
+            // am->GlanceParameter(AppletId::Application);
+            sleep(2);
+            am->ReceiveParameter(AppletId(0x300));
+        }
+
+        if (c == 'u') {
+        // auto id = am->GetAppletSlot(AppletSlot::Application)->applet_id;
+        auto slot = am->GetAppletSlotFromId(AppletId::Application);
+        printf("app slot=%d\n", slot); 
+        }
+
+        if (c == 's') {
+            send(0xc);
+        }
+    }
+}
+
 /// Application entry point
 void LaunchSdlFrontend(int argc, char** argv) {
+    std::thread i(input);
     Common::Log::Initialize();
     Common::Log::SetColorConsoleBackendEnabled(true);
     Common::Log::Start();

--- a/src/citra_sdl/citra_sdl.cpp
+++ b/src/citra_sdl/citra_sdl.cpp
@@ -477,7 +477,7 @@ void LaunchSdlFrontend(int argc, char** argv) {
     });
 
     std::atomic_bool stop_run;
-    system.GPU().Renderer().Rasterizer()->LoadDiskResources(
+    system.GPU().Renderer().Rasterizer()->LoadDefaultDiskResources(
         stop_run, [](VideoCore::LoadCallbackStage stage, std::size_t value, std::size_t total) {
             LOG_DEBUG(Frontend, "Loading stage {} progress {} {}", static_cast<u32>(stage), value,
                       total);

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -630,6 +630,12 @@ void System::RegisterImageInterface(std::shared_ptr<Frontend::ImageInterface> im
 }
 
 void System::Shutdown(bool is_deserializing) {
+    LOG_DEBUG(Core, "Shutdown ");
+
+    if (auto apt = Service::APT::GetModule(*this)) {
+// apt->GetAppletManager()->PrepareToCloseApplication(true);
+apt->GetAppletManager()->OrderToCloseApplication();
+}
 
     // Shutdown emulation session
     is_powered_on = false;

--- a/src/core/hle/service/apt/applet_manager.h
+++ b/src/core/hle/service/apt/applet_manager.h
@@ -402,7 +402,7 @@ public:
     TargetPlatform GetTargetPlatform();
     ApplicationRunningMode GetApplicationRunningMode();
 
-private:
+// private:
     /// APT lock retrieved via GetLockHandle.
     std::shared_ptr<Kernel::Mutex> lock;
 

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -428,7 +428,7 @@ void Module::APTInterface::IsRegistered(Kernel::HLERequestContext& ctx) {
     rb.Push(ResultSuccess); // No error
     rb.Push(apt->applet_manager->IsRegistered(app_id));
 
-    LOG_DEBUG(Service_APT, "called app_id={:#010X}", app_id);
+    LOG_TRACE(Service_APT, "called app_id={:#010X}", app_id);
 }
 
 void Module::APTInterface::GetAttribute(Kernel::HLERequestContext& ctx) {
@@ -527,6 +527,7 @@ void Module::APTInterface::GlanceParameter(Kernel::HLERequestContext& ctx) {
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
         rb.Push(next_parameter.Code());
     } else {
+    LOG_CRITICAL(Service_APT, "glance success ");
         const auto size = std::min(static_cast<u32>(next_parameter->buffer.size()), buffer_size);
         next_parameter->buffer.resize(
             buffer_size); // APT always push a buffer with the maximum size
@@ -611,6 +612,7 @@ void Module::APTInterface::SendDeliverArg(Kernel::HLERequestContext& ctx) {
     const auto hmac = rp.PopStaticBuffer();
 
     LOG_DEBUG(Service_APT, "called param_size={:08X}, hmac_size={:08X}", param_size, hmac_size);
+    // LOG_DEBUG(Service_APT, "param={}", param);
 
     apt->applet_manager->SetDeliverArg(DeliverArg{param, hmac});
 
@@ -626,6 +628,8 @@ void Module::APTInterface::ReceiveDeliverArg(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_APT, "called param_size={:08X}, hmac_size={:08X}", param_size, hmac_size);
 
     auto arg = apt->applet_manager->ReceiveDeliverArg().value_or(DeliverArg{});
+    // auto a = std::copy(0, 8, arg.param);
+    // LOG_DEBUG(Service_APT, "param={}", a);
     arg.param.resize(param_size);
     arg.hmac.resize(std::min<std::size_t>(hmac_size, 0x20));
 

--- a/src/core/hle/service/sm/srv.cpp
+++ b/src/core/hle/service/sm/srv.cpp
@@ -180,7 +180,7 @@ void SRV::GetServiceHandle(Kernel::HLERequestContext& ctx) {
     std::shared_ptr<Kernel::ClientSession> session;
     result = client_port->Connect(std::addressof(session));
     if (result.IsSuccess()) {
-        LOG_DEBUG(Service_SRV, "called service={} -> session={}", name, session->GetObjectId());
+        LOG_TRACE(Service_SRV, "called service={} -> session={}", name, session->GetObjectId());
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
         rb.Push(result);
         rb.PushMoveObjects(std::move(session));


### PR DESCRIPTION
apps get a smooth start but a rough end akin to pulling the plug. there is no graceful exit. luckily most games save occasionally during gameplay but not all

I found a game that only save on exit called shifting worlds by Anthony Lavelle . despite a message about in game saves he never implement it. I almost solved it but need some help with the last step

0xc trigger the save but only when suspended by the home menu. no combination of signals works with out the home menu so far so it's time to ask you for help

 # build everything and test

run my sig branch john-peterson/azahar@sig from the terminal it listens to getchar

get home menu and shifting worlds product code CTR-N-HMMP and CTR-P-ASZP

~~~
cmake -B out -DCMAKE_BUILD_TYPE=Debug  -DENABLE_QT_TRANSLATION=OFF -DENABLE_ROOM=OFF -DUSE_DISCORD_PRESENCE=OFF -DENABLE_QT=OFF -DENABLE_TESTS=OFF -DENABLE_WEB_SERVICE=OFF -DENABLE_SCRIPTING=OFF -DENABLE_CUBEB=OFF -DENABLE_LIBUSB=OFF -DENABLE_OPENGL=OFF -DENABLE_VULKAN=ON -DENABLE_SDL2_FRONTEND=ON -DUSE_SYSTEM_SDL2=ON -DUSE_SYSTEM_BOOST=ON
make -j8 -C out && out/bin/Release/azahar -n home.app
~~~

remove all other games

press a when the music start to launch the game

press b when you see the save file shift_3ds.bin and the game music start

press C to simulate close or z to let the home menu close

you should observe this game logic from start to finish

~~~
signal 1
music start read save file
fs_user/savedata_archive

b home button
SaveData.dat Service.FS OpenFile

press c in test build
order to close id=101 pos=2
sending C from 101 to 300
signal
glance id=300
SendDeliverArg
 ReceiveParameter from 101 to 300

*** saving *** <- the goal is to reach this function

 prepare to close target=2
sending A from 101 to 300
~~~

this is the best log filter to show save file access and the app manager

~~~
log_filter = *:Critical Service:Trace Service.APT:Trace Service.SRV:Trace Service.FS:Trace Common.Filesystem:Trace
~~~

 # test app

instead of the game you can use my signal demo john-peterson/3ds-examples@sig

~~~
git remote add jsp https://github.com/john-peterson/3ds-examples
git fetch jsp sig
~~~

I essentially get the events 0xc and 0x10 but I want all events and more complete example

~~~
tail -f ~/.local/share/azahar-emu/sdmc/log
_aptDebug(2,c)
_aptDebug(22,0)
~~~

this is from libctru

~~~
APTCMD_WAKEUP_CANCEL      = 12, ///< Applet wakes up due to being cancelled.
APTCMD_SYSAPPLET_REQUEST  = 16, ///< Request for sysapplet (?).
~~~

message me on Google chat if you are interested in this and made some progress

  # other projects  restore fast file access in android

  I am also going to restore the normal Linux file access in android with

  ~~~
	<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
  ~~~

	it is ten times faster than android file access. it is so slow it reminds me of my 24 meg Pentium 90 from 1995. loading a save in Zelda takes over a minute.  it should take ten seconds