### PR TITLE
Also distribute individual x64 and ARM64 macOS builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,12 +87,19 @@ jobs:
       - name: Build
         run: ./.ci/macos.sh
       - name: Prepare outputs for caching
-        run: mv build/bundle $OS-$TARGET
+        run: cp -R build/bundle $OS-$TARGET
       - name: Cache outputs for universal build
         uses: actions/cache/save@v4
         with:
           path: ${{ env.OS }}-${{ env.TARGET }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Pack
+        run: ./.ci/pack.sh
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.OS }}-${{ env.TARGET }}
+          path: artifacts/
   macos-universal:
     runs-on: macos-14
     needs: macos


### PR DESCRIPTION
Also distribute individual x86_64 and ARM64 artifacts for macOS, in addition to the Universal, so that users can choose to download the ones specifically for their architecture and save space. Users can save around 50 MB compared to the Universal distribution. This also prepares for Apple's inevitable ARM-only future.

