### PR TITLE
android: Fix accurate multiplication setting using async shader value

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -879,7 +879,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
             )
             add(
                 SwitchSetting(
-                    BooleanSetting.ASYNC_SHADERS,
+                    BooleanSetting.SHADERS_ACCURATE_MUL,
                     R.string.shaders_accurate_mul,
                     R.string.shaders_accurate_mul_description,
                     BooleanSetting.SHADERS_ACCURATE_MUL.key,


### PR DESCRIPTION
Fixes a regression introduced in the 2122 prereleases where the Accurate Multiplication setting on Android was unintentionally tied to the value of the Asynchronous Shader Compilation setting.

Closes #1136