### PR TITLE
gl_shader_decompiler: Fix min NaN edge case mix operand order

### DIFF
--- a/src/video_core/shader/generator/glsl_shader_decompiler.cpp
+++ b/src/video_core/shader/generator/glsl_shader_decompiler.cpp
@@ -476,7 +476,8 @@ private:
             case OpCode::Id::MAX: {
                 if (sanitize_mul) {
                     SetDest(swizzle, dest_reg,
-                            fmt::format("mix({1}, {0}, greaterThan({0}, {1}))", src1, src2), 4, 4);
+                            fmt::format("mix({}, {}, greaterThan({}, {}))", src2, src1, src1, src2),
+                            4, 4);
                 } else {
                     SetDest(swizzle, dest_reg, fmt::format("max({}, {})", src1, src2), 4, 4);
                 }
@@ -486,7 +487,8 @@ private:
             case OpCode::Id::MIN: {
                 if (sanitize_mul) {
                     SetDest(swizzle, dest_reg,
-                            fmt::format("mix({1}, {0}, lessThan({0}, {1}))", src1, src2), 4, 4);
+                            fmt::format("mix({}, {}, lessThan({}, {}))", src1, src2, src1, src2), 4,
+                            4);
                 } else {
                     SetDest(swizzle, dest_reg, fmt::format("min({}, {})", src1, src2), 4, 4);
                 }


### PR DESCRIPTION
This fix resolves a visual rendering issue in the **Cut the Rope: Triple Treat** game selection menu, specifically affecting the star rendering. The problem was caused by a `min` in NaN edge case in the shader decompilation process, where the operand order in a `mix` instruction led to inconsistent behaviour across GPU vendors and graphics backends. The previous [fix](https://github.com/azahar-emu/azahar/commit/cab0ad50f00837014cd910f7406eed9e6281360f) addressed the issue on some platforms, but others continued to show incorrect rendering.

By adjusting the operand order in the `mix` instruction, this update ensures correct behaviour on nearly all tested platforms. The fix has been confirmed across major desktop and mobile GPUs and is expected to behave consistently elsewhere.

I also updated the operand formatting for better code clarity and readability.

---

### GPU Backend Test Summary (Master):
| GPU Vendor  | OpenGL     | Vulkan     | OpenGLES   |
|-------------|------------|------------|------------|
| AMD         | ✅ Correct | ✅ Correct | —          |
| Intel       | ❌ Incorrect | ✅ Correct | —          |
| Nvidia      | ✅ Correct | ❌ Incorrect | —          |
| Mali        | —          | ❌ Incorrect | ❌ Incorrect |
| Adreno      | —          | ⚠️ Crash†   | ✅ Correct |

### GPU Backend Test Summary (This PR):
| GPU Vendor  | OpenGL     | Vulkan     | OpenGLES   |
|-------------|------------|------------|------------|
| AMD         | ✅ Correct | ✅ Correct | —          |
| Intel       | ✅ Correct | ✅ Correct | —          |
| Nvidia      | ✅ Correct | ✅ Correct | —          |
| Mali        | —          | ✅ Correct | ✅ Correct |
| Adreno      | —          | ⚠️ Crash†  | ✅ Correct |

* †Adreno Vulkan testing resulted in a crash and could not be evaluated.
* All desktop GPU testing was performed on **Windows** only.
* iOS devices are currently **untested**