### PR TITLE
cmake: Bump min version to 3.25 globally and bump Android CI CMake to 3.30.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,6 +232,9 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install ccache apksigner -y
+      - name: Update Android SDK CMake version
+        run: |
+          echo "y" | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "cmake;3.30.3"
       - name: Build
         run: JAVA_HOME=$JAVA_HOME_17_X64 ./.ci/android.sh
         env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
-# CMake 3.12 required for 20 to be a valid value for CXX_STANDARD
-cmake_minimum_required(VERSION 3.15)
+# CMake >=3.12 required for 20 to be a valid value for CXX_STANDARD,
+# and >=3.25 required to make LTO work on Android.
+cmake_minimum_required(VERSION 3.25)
 
 # Don't override the warning flags in MSVC:
 cmake_policy(SET CMP0092 NEW)

--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -150,7 +150,7 @@ android {
 
     externalNativeBuild {
         cmake {
-            version = "3.22.1"
+            version = "3.30.3"
             path = file("../../../CMakeLists.txt")
         }
     }

--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -150,7 +150,7 @@ android {
 
     externalNativeBuild {
         cmake {
-            version = "3.30.3"
+            version = "3.25.0+"
             path = file("../../../CMakeLists.txt")
         }
     }


### PR DESCRIPTION
Bumps the minimum versions of CMake. This fixes a long standing issue of CMake incorrectly trying to use the gold linker instead of lld, which effectively disabled link time optimizations (LTO) on Android builds, worsening performance.

**NOTE: If we ever update the SDK and the version of CMake that comes with it is something bigger than 3.30.3, then we can safely remove the change in build.yml**