### PR TITLE
Create Azahar folder as default in initial setup

### DIFF
--- a/src/android/app/src/main/AndroidManifest.xml
+++ b/src/android/app/src/main/AndroidManifest.xml
@@ -29,6 +29,8 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" android:minSdkVersion="30" />
 
     <application
         android:name="org.citra.citra_emu.CitraApplication"


### PR DESCRIPTION
Create Azahar folder as default one, asking for permissions, suggest it for user folder and create Games subfolder inside.

In folder permission setup step, create Azahar folder with Games subfolder in it to use it a default folder.

In my case before this it was using Downloads folder instead, throwing config, gpu_drivers and logs inside.

I think its more clear like this.

Tested in Android 10, 12 and 13.