### PR TITLE
Fix aac_decoder memory leak

### DIFF
--- a/src/audio_core/hle/aac_decoder.cpp
+++ b/src/audio_core/hle/aac_decoder.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/audio_core/hle/aac_decoder.cpp
+++ b/src/audio_core/hle/aac_decoder.cpp
@@ -56,12 +56,15 @@ BinaryMessage AACDecoder::ProcessRequest(const BinaryMessage& request) {
             NeAACDecClose(decoder);
             decoder = nullptr;
         }
+        decoderInitialized = false;
 
         decoder = NeAACDecOpen();
         if (decoder == nullptr) {
             LOG_CRITICAL(Audio_DSP, "Could not open FAAD2 decoder.");
             response.header.result = ResultStatus::Error;
+            return response;
         }
+
         auto config = NeAACDecGetCurrentConfiguration(decoder);
         config->defObjectType = LC;
         config->outputFormat = FAAD_FMT_16BIT;
@@ -70,8 +73,8 @@ BinaryMessage AACDecoder::ProcessRequest(const BinaryMessage& request) {
             NeAACDecClose(decoder);
             decoder = nullptr;
             response.header.result = ResultStatus::Error;
+            return response;
         }
-        decoderInitialized = false;
         return response;
     }
     case DecoderCommand::EncodeDecode: {

--- a/src/audio_core/hle/aac_decoder.cpp
+++ b/src/audio_core/hle/aac_decoder.cpp
@@ -7,8 +7,7 @@
 
 namespace AudioCore::HLE {
 
-AACDecoder::AACDecoder(Memory::MemorySystem& memory) : memory(memory) {
-}
+AACDecoder::AACDecoder(Memory::MemorySystem& memory) : memory(memory) {}
 
 AACDecoder::~AACDecoder() {
     if (decoder) {

--- a/src/audio_core/hle/aac_decoder.cpp
+++ b/src/audio_core/hle/aac_decoder.cpp
@@ -7,7 +7,9 @@
 
 namespace AudioCore::HLE {
 
-AACDecoder::AACDecoder(Memory::MemorySystem& memory) : memory(memory) {}
+AACDecoder::AACDecoder(Memory::MemorySystem& memory) : memory(memory) {
+    OpenNewDecoder();
+}
 
 AACDecoder::~AACDecoder() {
     if (decoder) {

--- a/src/audio_core/hle/aac_decoder.h
+++ b/src/audio_core/hle/aac_decoder.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/audio_core/hle/aac_decoder.h
+++ b/src/audio_core/hle/aac_decoder.h
@@ -18,10 +18,11 @@ public:
 
 private:
     BinaryMessage Decode(const BinaryMessage& request);
+    bool OpenNewDecoder();
 
     Memory::MemorySystem& memory;
     NeAACDecHandle decoder = nullptr;
-    bool decoderInitialized = false;
+    bool decoder_initialized = false;
 };
 
 } // namespace AudioCore::HLE

--- a/src/audio_core/hle/aac_decoder.h
+++ b/src/audio_core/hle/aac_decoder.h
@@ -21,6 +21,7 @@ private:
 
     Memory::MemorySystem& memory;
     NeAACDecHandle decoder = nullptr;
+    bool decoderInitialized = false;
 };
 
 } // namespace AudioCore::HLE


### PR DESCRIPTION
As discussed in [this issue](https://github.com/azahar-emu/azahar/issues/90), some games such as Pokemon X/Y suffer from a memory leak due to NeAACDecInit being called over and over again on each aac frame, when instead it should only be initialized once for each aac stream.

After some testing it seems that a DecoderCommand::Init request is issued whenever a new piece of background music is played, so that should be when we reinitialize the decoder.