### PR TITLE
Readme: replace citra in build badge and mention both installer and portable Win builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: citra-build
+name: azahar-build
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The goal of this project is to be the de-facto platform for future development.
 
 Download the latest release from [Releases](https://github.com/azahar-emu/azahar/releases).
 
+Both an installer and a portable version are available.
+
 If you are unsure of whether you want to use MSYS2 or MSVC, use MSYS2.
 
 ---


### PR DESCRIPTION
Two changes to README.md:
- Replace citra with azahar in the build badge (no breaking change)
<img width="138" alt="Screenshot 2025-06-25 at 02 15 39" src="https://github.com/user-attachments/assets/a578413d-6851-48d7-9b2d-f118f2cea851" />  <img width="146" alt="Screenshot 2025-06-25 at 02 24 31" src="https://github.com/user-attachments/assets/91762052-2a80-42e8-8f1e-b633606b7942" />




- Mention the availability of both an installer and a portable version for Windows