### PR TITLE
citra_sdl: Fix compile failure due to use of removed function

### DIFF
--- a/src/citra_sdl/citra_sdl.cpp
+++ b/src/citra_sdl/citra_sdl.cpp
@@ -1,4 +1,4 @@
-// Copyright Citra Emulator Project / Lime3DS Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -477,7 +477,7 @@ void LaunchSdlFrontend(int argc, char** argv) {
     });
 
     std::atomic_bool stop_run;
-    system.GPU().Renderer().Rasterizer()->LoadDiskResources(
+    system.GPU().Renderer().Rasterizer()->LoadDefaultDiskResources(
         stop_run, [](VideoCore::LoadCallbackStage stage, std::size_t value, std::size_t total) {
             LOG_DEBUG(Frontend, "Loading stage {} progress {} {}", static_cast<u32>(stage), value,
                       total);


### PR DESCRIPTION
When the `LoadDiskResources` function was dropped a couple of months ago, this line of the SDL frontend's code wasn't updated to acommodate. This caused compilation to fail if the `ENABLE_SDL2_FRONTEND` CMake flag was enabled.

This is understandable, as the SDL frontend is currently completely unmaintained and disabled by default, and even with this change it doesn't even run, but at least it compiles properly now.