### PR TITLE
renderer_vulkan: Disable FIFO when refresh rate is lower than ~60hz or Apple low power mode is enabled

### DIFF
--- a/.ci/license-header.rb
+++ b/.ci/license-header.rb
@@ -17,7 +17,7 @@ puts 'done'
 print 'Checking files...'
 issue_files = []
 branch_changed_files.each do |file_name|
-   if file_name.end_with?('.cpp', '.h', '.kt', '.kts') and File.file?(file_name)
+   if file_name.end_with?('.cpp', '.h', '.kt', '.kts', '.m', '.mm') and File.file?(file_name)
       file_content = File.read(file_name, mode: 'r:bom|utf-8')
       if not file_content.start_with?(license_header)
          issue_files.push(file_name)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,11 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/externals/cmake-modul
 include(DownloadExternals)
 include(CMakeDependentOption)
 
-project(citra LANGUAGES C CXX ASM)
+if (APPLE)
+    project(citra LANGUAGES C CXX OBJC OBJCXX ASM)
+else()
+    project(citra LANGUAGES C CXX ASM)
+endif()
 
 # Some submodules like to pick their own default build type if not specified.
 # Make sure we default to Release build type always, unless the generator has custom types.
@@ -124,6 +128,9 @@ if (ENABLE_QT_TRANSLATION)
 endif()
 if (ENABLE_ROOM)
     add_definitions(-DENABLE_ROOM)
+endif()
+if (ENABLE_SDL2)
+    add_definitions(-DENABLE_SDL2)
 endif()
 if (ENABLE_SDL2_FRONTEND)
     add_definitions(-DENABLE_SDL2_FRONTEND)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -165,10 +165,12 @@ if (UNIX AND NOT APPLE)
 endif()
 
 if (APPLE)
-    target_sources(citra_common PUBLIC
-        apple_authorization.h
-        apple_authorization.cpp
-    )
+  target_sources(citra_common PUBLIC
+    apple_authorization.h
+    apple_authorization.cpp
+    apple_utils.h
+    apple_utils.mm
+  )
 endif()
 
 if (MSVC)

--- a/src/common/apple_utils.h
+++ b/src/common/apple_utils.h
@@ -1,0 +1,9 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+namespace AppleUtils {
+
+int IsLowPowerModeEnabled();
+
+}

--- a/src/common/apple_utils.mm
+++ b/src/common/apple_utils.mm
@@ -1,0 +1,13 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#import <Foundation/Foundation.h>
+
+namespace AppleUtils {
+
+int IsLowPowerModeEnabled() {
+    return (int)[NSProcessInfo processInfo].lowPowerModeEnabled;
+}
+
+} // namespace AppleUtils

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -203,6 +203,10 @@ if (ENABLE_VULKAN)
     target_link_libraries(video_core PRIVATE vulkan-headers vma sirit SPIRV glslang)
 endif()
 
+if(ENABLE_SDL2)
+    target_link_libraries(video_core PRIVATE SDL2::SDL2)
+endif()
+
 add_dependencies(video_core host_shaders)
 target_include_directories(video_core PRIVATE ${HOST_SHADERS_INCLUDE})
 

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -58,7 +58,8 @@ constexpr static std::array<vk::DescriptorSetLayoutBinding, 1> PRESENT_BINDINGS 
     {0, vk::DescriptorType::eCombinedImageSampler, 3, vk::ShaderStageFlagBits::eFragment},
 }};
 
-bool IsLowRefreshRate() {
+namespace {
+static bool IsLowRefreshRate() {
 #ifdef ENABLE_SDL2
     const auto sdl_init_status = SDL_Init(SDL_INIT_VIDEO);
     if (sdl_init_status < 0) {
@@ -91,6 +92,7 @@ bool IsLowRefreshRate() {
 
     return false;
 }
+} // Anonymous namespace
 
 RendererVulkan::RendererVulkan(Core::System& system, Pica::PicaCore& pica_,
                                Frontend::EmuWindow& window, Frontend::EmuWindow* secondary_window)

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -22,6 +22,14 @@
 
 #include <vk_mem_alloc.h>
 
+#ifdef __APPLE__
+#include "common/apple_utils.h"
+#endif
+
+#ifdef ENABLE_SDL2
+#include <SDL.h>
+#endif
+
 MICROPROFILE_DEFINE(Vulkan_RenderFrame, "Vulkan", "Render Frame", MP_RGB(128, 128, 64));
 
 namespace Vulkan {
@@ -50,11 +58,46 @@ constexpr static std::array<vk::DescriptorSetLayoutBinding, 1> PRESENT_BINDINGS 
     {0, vk::DescriptorType::eCombinedImageSampler, 3, vk::ShaderStageFlagBits::eFragment},
 }};
 
+bool IsLowRefreshRate() {
+#ifdef ENABLE_SDL2
+    const auto sdl_init_status = SDL_Init(SDL_INIT_VIDEO);
+    if (sdl_init_status < 0) {
+        LOG_ERROR(Render_Vulkan, "SDL failed to initialize, unable to check refresh rate");
+    } else {
+        SDL_DisplayMode cur_display_mode;
+        SDL_GetCurrentDisplayMode(0, &cur_display_mode); // TODO: Multimonitor handling. -OS
+        const auto cur_refresh_rate = cur_display_mode.refresh_rate;
+        SDL_Quit();
+
+        if (cur_refresh_rate < SCREEN_REFRESH_RATE) {
+            LOG_WARNING(Render_Vulkan,
+                        "Detected refresh rate lower than the emulated 3DS screen: {}hz. FIFO will "
+                        "be disabled",
+                        cur_refresh_rate);
+            return true;
+        }
+    }
+#endif
+
+#ifdef __APPLE__
+    // Apple's low power mode sometimes limits applications to 30fps without changing the refresh
+    // rate, meaning the above code doesn't catch it.
+    if (AppleUtils::IsLowPowerModeEnabled()) {
+        LOG_WARNING(Render_Vulkan, "Apple's low power mode is enabled, assuming low application "
+                                   "framerate. FIFO will be disabled");
+        return true;
+    }
+#endif
+
+    return false;
+}
+
 RendererVulkan::RendererVulkan(Core::System& system, Pica::PicaCore& pica_,
                                Frontend::EmuWindow& window, Frontend::EmuWindow* secondary_window)
     : RendererBase{system, window, secondary_window}, memory{system.Memory()}, pica{pica_},
       instance{window, Settings::values.physical_device.GetValue()}, scheduler{instance},
-      renderpass_cache{instance, scheduler}, main_window{window, instance, scheduler},
+      renderpass_cache{instance, scheduler},
+      main_window{window, instance, scheduler, IsLowRefreshRate()},
       vertex_buffer{instance, scheduler, vk::BufferUsageFlagBits::eVertexBuffer,
                     VERTEX_BUFFER_SIZE},
       update_queue{instance},
@@ -66,7 +109,8 @@ RendererVulkan::RendererVulkan(Core::System& system, Pica::PicaCore& pica_,
     BuildLayouts();
     BuildPipelines();
     if (secondary_window) {
-        second_window = std::make_unique<PresentWindow>(*secondary_window, instance, scheduler);
+        second_window = std::make_unique<PresentWindow>(*secondary_window, instance, scheduler,
+                                                        IsLowRefreshRate());
     }
 }
 
@@ -841,7 +885,8 @@ void RendererVulkan::SwapBuffers() {
         ASSERT(secondary_window);
         const auto& secondary_layout = secondary_window->GetFramebufferLayout();
         if (!second_window) {
-            second_window = std::make_unique<PresentWindow>(*secondary_window, instance, scheduler);
+            second_window = std::make_unique<PresentWindow>(*secondary_window, instance, scheduler,
+                                                            IsLowRefreshRate());
         }
         RenderToWindow(*second_window, secondary_layout, false);
         secondary_window->PollEvents();

--- a/src/video_core/renderer_vulkan/vk_present_window.cpp
+++ b/src/video_core/renderer_vulkan/vk_present_window.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -98,11 +98,12 @@ bool CanBlitToSwapchain(const vk::PhysicalDevice& physical_device, vk::Format fo
 } // Anonymous namespace
 
 PresentWindow::PresentWindow(Frontend::EmuWindow& emu_window_, const Instance& instance_,
-                             Scheduler& scheduler_)
+                             Scheduler& scheduler_, bool low_refresh_rate_)
     : emu_window{emu_window_}, instance{instance_}, scheduler{scheduler_},
+      low_refresh_rate{low_refresh_rate_},
       surface{CreateSurface(instance.GetInstance(), emu_window)}, next_surface{surface},
       swapchain{instance, emu_window.GetFramebufferLayout().width,
-                emu_window.GetFramebufferLayout().height, surface},
+                emu_window.GetFramebufferLayout().height, surface, low_refresh_rate_},
       graphics_queue{instance.GetGraphicsQueue()}, present_renderpass{CreateRenderpass()},
       vsync_enabled{Settings::values.use_vsync_new.GetValue()},
       blit_supported{
@@ -355,7 +356,7 @@ void PresentWindow::CopyToSwapchain(Frame* frame) {
 #endif
         std::scoped_lock submit_lock{scheduler.submit_mutex};
         graphics_queue.waitIdle();
-        swapchain.Create(frame->width, frame->height, surface);
+        swapchain.Create(frame->width, frame->height, surface, low_refresh_rate);
     };
 
 #ifndef ANDROID

--- a/src/video_core/renderer_vulkan/vk_present_window.h
+++ b/src/video_core/renderer_vulkan/vk_present_window.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -37,7 +37,7 @@ struct Frame {
 class PresentWindow final {
 public:
     explicit PresentWindow(Frontend::EmuWindow& emu_window, const Instance& instance,
-                           Scheduler& scheduler);
+                           Scheduler& scheduler, bool low_refresh_rate);
     ~PresentWindow();
 
     /// Waits for all queued frames to finish presenting.
@@ -74,6 +74,7 @@ private:
     Frontend::EmuWindow& emu_window;
     const Instance& instance;
     Scheduler& scheduler;
+    bool low_refresh_rate;
     vk::SurfaceKHR surface;
     vk::SurfaceKHR next_surface{};
     Swapchain swapchain;

--- a/src/video_core/renderer_vulkan/vk_swapchain.h
+++ b/src/video_core/renderer_vulkan/vk_swapchain.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -16,11 +16,12 @@ class Scheduler;
 
 class Swapchain {
 public:
-    explicit Swapchain(const Instance& instance, u32 width, u32 height, vk::SurfaceKHR surface);
+    explicit Swapchain(const Instance& instance, u32 width, u32 height, vk::SurfaceKHR surface,
+                       bool low_refresh_rate);
     ~Swapchain();
 
     /// Creates (or recreates) the swapchain with a given size.
-    void Create(u32 width, u32 height, vk::SurfaceKHR surface);
+    void Create(u32 width, u32 height, vk::SurfaceKHR surface, bool low_refresh_rate);
 
     /// Acquires the next image in the swapchain.
     bool AcquireNextImage();
@@ -105,6 +106,7 @@ private:
     u32 image_index = 0;
     u32 frame_index = 0;
     bool needs_recreation = true;
+    bool low_refresh_rate;
 };
 
 } // namespace Vulkan


### PR DESCRIPTION
Closes #1187

Vulkan's FIFO present mode, which is used when using the Vulkan renderer with vsync enabled, limits the application framerate to the current monitor's refresh rate.

This is accounted for when the emulation speed is set above 100%, as the emulator switches to the Mailbox present mode which isn't limited to the monitor's refresh rate, however the current code didn't account for if the refresh rate of the monitor was set below ~60hz. If the monitor's refresh rate is slower than that of the emulated 3DS, the emulation speed becomes limited.

To address this, I had added code to the Vulkan renderer which uses SDL to check the monitor's refresh rate, and if it goes below the refresh rate of the emulated 3DS, it falls back to the code which is already present for handling increased emulation speeds. As this code relies on SDL, this fix is disabled if the `ENABLE_SDL2` CMake flag is disabled. To my knowledge there isn't an elegant cross-platform way of doing this without SDL or another similar library.

In addition to checking the monitor's refresh rate, this new code also checks for low power mode being enabled on Apple devices. This is because I have observed low power mode limiting the framerate of Azahar to 30fps while it is enabled, which causes the emulation speed to be capped at 50% due to FIFO being used. It doesn't seem that the refresh rate is what's being changed here, as SDL still reports a refresh rate of 60hz, so this additional code which uses Apple's API is necessary.
To my knowledge, there is no way of accessing this API without introducing Objective-C code (the `.mm` file), but luckily our existing build system already supports it, and this Objective-C code is only ever touched in our MacOS and iOS builds.

### Limitations:

- This code relies on the low refresh rate or low power mode being enabled before the renderer is created. If either are enabled *during* emulation, the emulation speed may become limited as it was before this PR.
- Currently, this code only checks the refresh rate of the primary monitor, ignoring any secondary monitors which the emulator may be running on. Extra checks can be implemented for multimonitor setups, but I'd rather leave that for a subsequent PR.
- A lot of the code in this PR just passes the `low_refresh_rate` value around the codebase. This is because it is impossible to perform the refresh rate check on anything other than the main thread due to SDL limitations, so it must be performed before the renderer is created and then passed as a parameter to the place where it is needed.

### Testing:

- I have tested the MacOS low power mode detection locally, and have verified that it is correctly detected and that the applied fix works as expected, increasing the emulation speed back to 100% where it was previously stuck at 50%.
- I have not managed to test the low refresh rate check, as my monitor doesn't support going below 60hz, however I did simulate a low refresh rate environment by altering the code to artificially reduce the detected refresh rate of my monitor, and in that case the detection code appeared to work as expected. It more than likely works fine in this scenario as well.