### PR TITLE
video_core: Fix LCD color fill

### DIFF
--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -62,7 +62,8 @@ private:
     void RenderToMailbox(const Layout::FramebufferLayout& layout,
                          std::unique_ptr<Frontend::TextureMailbox>& mailbox, bool flipped);
     void ConfigureFramebufferTexture(TextureInfo& texture,
-                                     const Pica::FramebufferConfig& framebuffer);
+                                     const Pica::FramebufferConfig& framebuffer,
+                                     const Pica::ColorFill& color_fill);
     void DrawScreens(const Layout::FramebufferLayout& layout, bool flipped);
     void ApplySecondLayerOpacity(bool isPortrait = false);
     void ResetSecondLayerOpacity(bool isPortrait = false);
@@ -78,8 +79,7 @@ private:
 
     // Loads framebuffer from emulated memory into the display information structure
     void LoadFBToScreenInfo(const Pica::FramebufferConfig& framebuffer, ScreenInfo& screen_info,
-                            bool right_eye);
-    void FillScreen(Common::Vec3<u8> color, TextureInfo& texture);
+                            bool right_eye, const Pica::ColorFill& color_fill);
 
 private:
     Pica::PicaCore& pica;

--- a/src/video_core/renderer_software/renderer_software.h
+++ b/src/video_core/renderer_software/renderer_software.h
@@ -38,7 +38,7 @@ public:
 
 private:
     void PrepareRenderTarget();
-    void LoadFBToScreenInfo(int i);
+    void LoadFBToScreenInfo(int i, const Pica::ColorFill& color_fill);
 
 private:
     Memory::MemorySystem& memory;

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -455,7 +455,6 @@ void RendererVulkan::ConfigureFramebufferTexture(TextureInfo& texture,
 }
 
 void RendererVulkan::FillScreen(Common::Vec3<u8> color, const TextureInfo& texture) {
-    return;
     const vk::ClearColorValue clear_color = {
         .float32 =
             std::array{


### PR DESCRIPTION
Fixes the LCD color fill functionality in all render backends. It wasn't working properly in any of them.