### PR TITLE
[GSP] Set correct stop flag

### DIFF
--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -444,7 +444,7 @@ void GSP_GPU::TriggerCmdReqQueue(Kernel::HLERequestContext& ctx) {
         system.perf_stats->EndGPUProcessing();
 
         if (command.stop) {
-            command_buffer->should_stop.Assign(1);
+            command_buffer->status.Assign(CommandBuffer::STATUS_STOPPED);
         }
     }
 


### PR DESCRIPTION
Relative GSP code:

![image](https://github.com/user-attachments/assets/a9a1a464-f0af-41b8-971d-21eb3c24720c)

Indeed, GSP never sets `command_buffer->should_stop`, which is intended for application use.

In theory this shouldn't affect anything, as I believe games don't have fine grained control over GSP shared memory, and libctru doesn't support this functionality at all. Nonetheless, I've tested steeldivers with the patch, and it worked fine.