### PR TITLE
video_core: Remove assert in OpenGL LoadProgram and better logging

### DIFF
--- a/src/video_core/renderer_opengl/gl_blit_helper.cpp
+++ b/src/video_core/renderer_opengl/gl_blit_helper.cpp
@@ -1,4 +1,4 @@
-// Copyright Citra Emulator Project / Lime3DS Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -43,8 +43,9 @@ OGLSampler CreateSampler(GLenum filter) {
     return sampler;
 }
 
-OGLProgram CreateProgram(std::string_view frag) {
+OGLProgram CreateProgram(std::string_view frag, std::string_view debug_name) {
     OGLProgram program;
+    program.SetDebugName(debug_name);
     program.Create(HostShaders::FULL_SCREEN_TRIANGLE_VERT, frag);
     glProgramUniform2f(program.handle, 0, 1.f, 1.f);
     glProgramUniform2f(program.handle, 1, 0.f, 0.f);
@@ -56,15 +57,15 @@ OGLProgram CreateProgram(std::string_view frag) {
 BlitHelper::BlitHelper(const Driver& driver_)
     : driver{driver_}, linear_sampler{CreateSampler(GL_LINEAR)},
       nearest_sampler{CreateSampler(GL_NEAREST)},
-      bicubic_program{CreateProgram(HostShaders::BICUBIC_FRAG)},
-      scale_force_program{CreateProgram(HostShaders::SCALE_FORCE_FRAG)},
-      xbrz_program{CreateProgram(HostShaders::XBRZ_FREESCALE_FRAG)},
-      mmpx_program{CreateProgram(HostShaders::MMPX_FRAG)},
-      gradient_x_program{CreateProgram(HostShaders::X_GRADIENT_FRAG)},
-      gradient_y_program{CreateProgram(HostShaders::Y_GRADIENT_FRAG)},
-      refine_program{CreateProgram(HostShaders::REFINE_FRAG)},
-      d24s8_to_rgba8{CreateProgram(HostShaders::D24S8_TO_RGBA8_FRAG)},
-      rgba4_to_rgb5a1{CreateProgram(HostShaders::RGBA4_TO_RGB5A1_FRAG)} {
+      bicubic_program{CreateProgram(HostShaders::BICUBIC_FRAG, "BICUBIC_FRAG")},
+      scale_force_program{CreateProgram(HostShaders::SCALE_FORCE_FRAG, "SCALE_FORCE_FRAG")},
+      xbrz_program{CreateProgram(HostShaders::XBRZ_FREESCALE_FRAG, "XBRZ_FREESCALE_FRAG")},
+      mmpx_program{CreateProgram(HostShaders::MMPX_FRAG, "MMPX_FRAG")},
+      gradient_x_program{CreateProgram(HostShaders::X_GRADIENT_FRAG, "X_GRADIENT_FRAG")},
+      gradient_y_program{CreateProgram(HostShaders::Y_GRADIENT_FRAG, "Y_GRADIENT_FRAG")},
+      refine_program{CreateProgram(HostShaders::REFINE_FRAG, "REFINE_FRAG")},
+      d24s8_to_rgba8{CreateProgram(HostShaders::D24S8_TO_RGBA8_FRAG, "D24S8_TO_RGBA8_FRAG")},
+      rgba4_to_rgb5a1{CreateProgram(HostShaders::RGBA4_TO_RGB5A1_FRAG, "RGBA4_TO_RGB5A1_FRAG")} {
     vao.Create();
     draw_fbo.Create();
     state.draw.vertex_array = vao.handle;

--- a/src/video_core/renderer_opengl/gl_resource_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_resource_manager.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -110,7 +110,7 @@ void OGLShader::Create(std::string_view source, GLenum type) {
         return;
 
     MICROPROFILE_SCOPE(OpenGL_ResourceCreation);
-    handle = LoadShader(source, type);
+    handle = LoadShader(source, type, debug_name);
 }
 
 void OGLShader::Release() {
@@ -127,11 +127,13 @@ void OGLProgram::Create(bool separable_program, std::span<const GLuint> shaders)
         return;
 
     MICROPROFILE_SCOPE(OpenGL_ResourceCreation);
-    handle = LoadProgram(separable_program, shaders);
+    handle = LoadProgram(separable_program, shaders, debug_name);
 }
 
 void OGLProgram::Create(std::string_view vert_shader, std::string_view frag_shader) {
     OGLShader vert, frag;
+    vert.SetDebugName(debug_name + "_vert");
+    frag.SetDebugName(debug_name + "_frag");
     vert.Create(vert_shader, GL_VERTEX_SHADER);
     frag.Create(frag_shader, GL_FRAGMENT_SHADER);
 

--- a/src/video_core/renderer_opengl/gl_resource_manager.h
+++ b/src/video_core/renderer_opengl/gl_resource_manager.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <span>
+#include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
@@ -111,7 +112,14 @@ public:
 
     void Release();
 
+    void SetDebugName(std::string_view debug_name) {
+        this->debug_name = debug_name;
+    }
+
     GLuint handle = 0;
+
+private:
+    std::string debug_name = "Unk";
 };
 
 class OGLProgram : private NonCopyable {
@@ -139,7 +147,14 @@ public:
     /// Deletes the internal OpenGL resource
     void Release();
 
+    void SetDebugName(std::string_view debug_name) {
+        this->debug_name = debug_name;
+    }
+
     GLuint handle = 0;
+
+private:
+    std::string debug_name = "Unk";
 };
 
 class OGLPipeline : private NonCopyable {

--- a/src/video_core/renderer_opengl/gl_shader_util.h
+++ b/src/video_core/renderer_opengl/gl_shader_util.h
@@ -1,4 +1,4 @@
-// Copyright 2014 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -13,15 +13,18 @@ namespace OpenGL {
  * Utility function to create and compile an OpenGL GLSL shader
  * @param source String of the GLSL shader program
  * @param type Type of the shader (GL_VERTEX_SHADER, GL_GEOMETRY_SHADER or GL_FRAGMENT_SHADER)
+ * @param debug_name debug name to show in logs
  */
-GLuint LoadShader(std::string_view source, GLenum type);
+GLuint LoadShader(std::string_view source, GLenum type, const std::string& debug_name);
 
 /**
  * Utility function to create and link an OpenGL GLSL shader program
  * @param separable_program whether to create a separable program
  * @param shaders ID of shaders to attach to the program
+ * @param debug_name debug name to show in logs
  * @returns Handle of the newly created OpenGL program object
  */
-GLuint LoadProgram(bool separable_program, std::span<const GLuint> shaders);
+GLuint LoadProgram(bool separable_program, std::span<const GLuint> shaders,
+                   const std::string& debug_name);
 
 } // namespace OpenGL


### PR DESCRIPTION
Removes an ASSERT in OpenGL LoadProgram and replaces it with a log message. Now if a shader fails to link, it will cause graphical issues instead of crashing the entire emulator.

Added a debug name to shaders, so that they can be identified easier in the log. For now this is only used in BlitHelper host shaders.

This PR aims to "fix" or gather more info on Samsung A55 devices, which fail to compile and link the BlitHelper shaders for some reason, without the driver providing any logs, causing the emulator to crash immediately when opening any game.