### PR TITLE
loader: Add compressed ROM support

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -214,8 +214,29 @@ else()
     set(ZSTD_BUILD_PROGRAMS OFF)
     set(ZSTD_BUILD_SHARED OFF)
     add_subdirectory(zstd/build/cmake EXCLUDE_FROM_ALL)
-    target_include_directories(libzstd_static INTERFACE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/externals/zstd/lib>)
+
+    target_include_directories(libzstd_static INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/externals/zstd/lib>
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/externals/zstd/lib/common>
+    )
+
+    add_library(zstd_seekable STATIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/zstd/contrib/seekable_format/zstdseek_compress.c>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/zstd/contrib/seekable_format/zstdseek_decompress.c>
+    )
+    target_include_directories(zstd_seekable PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/zstd/contrib/seekable_format>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/zstd/lib/common>
+    )
+    target_link_libraries(zstd_seekable PUBLIC libzstd_static)
+
+    target_link_libraries(libzstd_static INTERFACE zstd_seekable)
+
     add_library(zstd ALIAS libzstd_static)
+
+    install(TARGETS zstd_seekable
+        EXPORT zstdExports
+    )
 endif()
 
 # ENet

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
@@ -48,7 +48,8 @@ enum class BooleanSetting(
     DEBUG_RENDERER("renderer_debug", Settings.SECTION_DEBUG, false),
     DISABLE_RIGHT_EYE_RENDER("disable_right_eye_render", Settings.SECTION_RENDERER, false),
     USE_ARTIC_BASE_CONTROLLER("use_artic_base_controller", Settings.SECTION_CONTROLS, false),
-    UPRIGHT_SCREEN("upright_screen", Settings.SECTION_LAYOUT, false);
+    UPRIGHT_SCREEN("upright_screen", Settings.SECTION_LAYOUT, false),
+    COMPRESS_INSTALLED_CIA_CONTENT("compress_cia_installs", Settings.SECTION_STORAGE, false);
 
     override var boolean: Boolean = defaultValue
 
@@ -80,7 +81,8 @@ enum class BooleanSetting(
             CPU_JIT,
             ASYNC_CUSTOM_LOADING,
             SHADERS_ACCURATE_MUL,
-            USE_ARTIC_BASE_CONTROLLER
+            USE_ARTIC_BASE_CONTROLLER,
+            COMPRESS_INSTALLED_CIA_CONTENT,
         )
 
         fun from(key: String): BooleanSetting? =

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/Settings.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/Settings.kt
@@ -112,6 +112,7 @@ class Settings {
         const val SECTION_CUSTOM_LANDSCAPE = "Custom Landscape Layout"
         const val SECTION_CUSTOM_PORTRAIT = "Custom Portrait Layout"
         const val SECTION_PERFORMANCE_OVERLAY = "Performance Overlay"
+        const val SECTION_STORAGE = "Storage"
 
         const val KEY_BUTTON_A = "button_a"
         const val KEY_BUTTON_B = "button_b"
@@ -237,6 +238,7 @@ class Settings {
                     SECTION_CONTROLS,
                     SECTION_RENDERER,
                     SECTION_LAYOUT,
+                    SECTION_STORAGE,
                     SECTION_UTILITY,
                     SECTION_AUDIO,
                     SECTION_DEBUG

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -565,6 +565,16 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     BooleanSetting.ALLOW_PLUGIN_LOADER.defaultValue
                 )
             )
+            add(HeaderSetting(R.string.storage))
+            add(
+                SwitchSetting(
+                    BooleanSetting.COMPRESS_INSTALLED_CIA_CONTENT,
+                    R.string.compress_cia_installs,
+                    R.string.compress_cia_installs_description,
+                    BooleanSetting.COMPRESS_INSTALLED_CIA_CONTENT.key,
+                    BooleanSetting.COMPRESS_INSTALLED_CIA_CONTENT.defaultValue
+                )
+            )
         }
     }
 

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -218,6 +218,9 @@ void Config::ReadValues() {
     ReadSetting("Layout", Settings::values.custom_portrait_bottom_width);
     ReadSetting("Layout", Settings::values.custom_portrait_bottom_height);
 
+    // Storage
+    ReadSetting("Storage", Settings::values.compress_cia_installs);
+
     // Utility
     ReadSetting("Utility", Settings::values.dump_textures);
     ReadSetting("Utility", Settings::values.custom_textures);

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -210,6 +210,11 @@ disable_right_eye_render =
 # 5: Custom Layout
 layout_option =
 
+[Storage]
+# Whether to compress the installed CIA contents
+# 0 (default): Do not compress, 1: Compress
+compress_cia_installs =
+
 # Position of the performance overlay
 # 0: Top Left
 # 1: Center Top

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -214,6 +214,9 @@
     <string name="region_mismatch">Region Mismatch Warning</string>
     <string name="region_mismatch_emulated">The country setting is not valid for the selected emulated region.</string>
     <string name="region_mismatch_console">The country setting is not valid for the current linked console.</string>
+    <string name="storage">Storage</string>
+    <string name="compress_cia_installs">Compress installed CIA content</string>
+    <string name="compress_cia_installs_description">Compresses the content of CIA files when installed to the emulated SD card. Only affects CIA content which is installed while the setting is enabled.</string>
 
     <!-- Camera settings strings -->
     <string name="inner_camera">Inner Camera</string>

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -3081,7 +3081,7 @@ void GMainWindow::OnCompressFile() {
                 compress_info.recommended_compressed_extension = "zcia";
                 compress_info.recommended_uncompressed_extension = "cia";
                 compress_info.underlying_magic = std::array<u8, 4>({'C', 'I', 'A', '\0'});
-                frame_size = FileUtil::Z3DSWriteIOFile::MAX_FRAME_SIZE;
+                frame_size = FileUtil::Z3DSWriteIOFile::DEFAULT_CIA_FRAME_SIZE;
             }
         }
     }

--- a/src/citra_qt/citra_qt.h
+++ b/src/citra_qt/citra_qt.h
@@ -141,6 +141,7 @@ signals:
 
     void UpdateProgress(std::size_t written, std::size_t total);
     void CIAInstallReport(Service::AM::InstallStatus status, QString filepath);
+    void CompressFinished(bool is_compress, bool success);
     void CIAInstallFinished();
     // Signal that tells widgets to update icons to use the current theme
     void UpdateThemedIcons();
@@ -248,6 +249,7 @@ private slots:
     void OnMenuBootHomeMenu(u32 region);
     void OnUpdateProgress(std::size_t written, std::size_t total);
     void OnCIAInstallReport(Service::AM::InstallStatus status, QString filepath);
+    void OnCompressFinished(bool is_compress, bool success);
     void OnCIAInstallFinished();
     void OnMenuRecentFile();
     void OnConfigure();
@@ -281,6 +283,8 @@ private slots:
     void OnSaveMovie();
     void OnCaptureScreenshot();
     void OnDumpVideo();
+    void OnCompressFile();
+    void OnDecompressFile();
 #ifdef _WIN32
     void OnOpenFFmpeg();
 #endif

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -475,6 +475,7 @@ void QtConfig::ReadDataStorageValues() {
 
     ReadBasicSetting(Settings::values.use_virtual_sd);
     ReadBasicSetting(Settings::values.use_custom_storage);
+    ReadBasicSetting(Settings::values.compress_cia_installs);
 
     const std::string nand_dir =
         ReadSetting(QStringLiteral("nand_directory"), QStringLiteral("")).toString().toStdString();
@@ -1045,6 +1046,7 @@ void QtConfig::SaveDataStorageValues() {
 
     WriteBasicSetting(Settings::values.use_virtual_sd);
     WriteBasicSetting(Settings::values.use_custom_storage);
+    WriteBasicSetting(Settings::values.compress_cia_installs);
     WriteSetting(QStringLiteral("nand_directory"),
                  QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir)),
                  QStringLiteral(""));

--- a/src/citra_qt/configuration/configure_storage.cpp
+++ b/src/citra_qt/configuration/configure_storage.cpp
@@ -77,6 +77,7 @@ void ConfigureStorage::SetConfiguration() {
 
     ui->toggle_virtual_sd->setChecked(Settings::values.use_virtual_sd.GetValue());
     ui->toggle_custom_storage->setChecked(Settings::values.use_custom_storage.GetValue());
+    ui->toggle_compress_cia->setChecked(Settings::values.compress_cia_installs.GetValue());
 
     ui->storage_group->setEnabled(!is_powered_on);
 }
@@ -84,6 +85,7 @@ void ConfigureStorage::SetConfiguration() {
 void ConfigureStorage::ApplyConfiguration() {
     Settings::values.use_virtual_sd = ui->toggle_virtual_sd->isChecked();
     Settings::values.use_custom_storage = ui->toggle_custom_storage->isChecked();
+    Settings::values.compress_cia_installs = ui->toggle_compress_cia->isChecked();
 
     if (!Settings::values.use_custom_storage) {
         FileUtil::UpdateUserPath(FileUtil::UserPath::NANDDir,

--- a/src/citra_qt/configuration/configure_storage.ui
+++ b/src/citra_qt/configuration/configure_storage.ui
@@ -179,6 +179,20 @@
           </layout>
          </widget>
         </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_5">
+          <item>
+           <widget class="QCheckBox" name="toggle_compress_cia">
+            <property name="text">
+             <string>Compress installed CIA contents</string>
+            </property>
+            <property name="toolTip">
+              <string>Enables compressing the contents of CIA files when they are installed to the emulated SD.</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
        </layout>
       </widget>
      </item>

--- a/src/citra_qt/configuration/configure_storage.ui
+++ b/src/citra_qt/configuration/configure_storage.ui
@@ -184,10 +184,10 @@
           <item>
            <widget class="QCheckBox" name="toggle_compress_cia">
             <property name="text">
-             <string>Compress installed CIA contents</string>
+             <string>Compress installed CIA content</string>
             </property>
             <property name="toolTip">
-              <string>Enables compressing the contents of CIA files when they are installed to the emulated SD.</string>
+              <string>Compresses the content of CIA files when installed to the emulated SD card. Only affects CIA content which is installed while the setting is enabled.</string>
             </property>
            </widget>
           </item>

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -1039,8 +1039,10 @@ void GameList::LoadInterfaceLayout() {
 }
 
 const QStringList GameList::supported_file_extensions = {
-    QStringLiteral("3dsx"), QStringLiteral("elf"), QStringLiteral("axf"),
-    QStringLiteral("cci"),  QStringLiteral("cxi"), QStringLiteral("app")};
+    QStringLiteral("3dsx"),  QStringLiteral("elf"),  QStringLiteral("axf"),
+    QStringLiteral("cci"),   QStringLiteral("cxi"),  QStringLiteral("app"),
+    QStringLiteral("z3dsx"), QStringLiteral("zcci"), QStringLiteral("zcxi"),
+};
 
 void GameList::RefreshGameDirectory() {
     if (!UISettings::values.game_dirs.isEmpty() && current_worker != nullptr) {

--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -208,6 +208,9 @@
     <addaction name="separator"/>
     <addaction name="action_Capture_Screenshot"/>
     <addaction name="action_Dump_Video"/>
+    <addaction name="separator"/>
+    <addaction name="action_Compress_ROM_File"/>
+    <addaction name="action_Decompress_ROM_File"/>
    </widget>
    <widget class="QMenu" name="menu_Help">
     <property name="title">
@@ -456,6 +459,16 @@
    </property>
    <property name="text">
     <string>Dump Video</string>
+   </property>
+  </action>
+  <action name="action_Compress_ROM_File">
+   <property name="text">
+    <string>Compress ROM File...</string>
+   </property>
+  </action>
+  <action name="action_Decompress_ROM_File">
+   <property name="text">
+    <string>Decompress ROM File...</string>
    </property>
   </action>
   <action name="action_View_Lobby">

--- a/src/citra_sdl/config.cpp
+++ b/src/citra_sdl/config.cpp
@@ -213,6 +213,7 @@ void SdlConfig::ReadValues() {
     // Data Storage
     ReadSetting("Data Storage", Settings::values.use_virtual_sd);
     ReadSetting("Data Storage", Settings::values.use_custom_storage);
+    ReadSetting("Data Storage", Settings::values.compress_cia_installs);
 
     if (Settings::values.use_custom_storage) {
         FileUtil::UpdateUserPath(FileUtil::UserPath::NANDDir,

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -468,6 +468,7 @@ struct Values {
     // Data Storage
     Setting<bool> use_virtual_sd{true, "use_virtual_sd"};
     Setting<bool> use_custom_storage{false, "use_custom_storage"};
+    Setting<bool> compress_cia_installs{false, "compress_cia_installs"};
 
     // System
     SwitchableSetting<s32> region_value{REGION_VALUE_AUTO_SELECT, "region_value"};

--- a/src/common/zstd_compression.cpp
+++ b/src/common/zstd_compression.cpp
@@ -115,9 +115,13 @@ Z3DSMetadata::Z3DSMetadata(const std::span<u8>& source_data) {
     while (!in.eof()) {
         Item item;
         ReadFromIStream(in, &item, sizeof(Item));
+        // If end item is reached, stop processing
+        if (item.type == Item::TYPE_END) {
+            break;
+        }
         // Only binary type supported for now
         if (item.type != Item::TYPE_BINARY) {
-            break;
+            continue;
         }
         std::string name(item.name_len, '\0');
         std::vector<u8> data(item.data_len);
@@ -144,6 +148,10 @@ std::vector<u8> Z3DSMetadata::AsBinary() {
         WriteToOStream(out, it.first.data(), item.name_len);
         WriteToOStream(out, it.second.data(), item.data_len);
     }
+
+    // Write end item
+    Item end{};
+    WriteToOStream(out, &end, sizeof(end));
 
     std::string out_str = out.str();
     return std::vector<u8>(out_str.begin(), out_str.end());

--- a/src/common/zstd_compression.cpp
+++ b/src/common/zstd_compression.cpp
@@ -1,15 +1,30 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
 // Copyright 2019 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <chrono>
+#include <ctime>
+#include <format>
+#include <mutex>
+#include <sstream>
 #include <zstd.h>
+#include <zstd/contrib/seekable_format/zstd_seekable.h>
 
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/unique_ptr.hpp>
+#include "common/alignment.h"
+#include "common/archives.h"
+#include "common/assert.h"
 #include "common/logging/log.h"
+#include "common/scm_rev.h"
 #include "common/zstd_compression.h"
 
 namespace Common::Compression {
-
 std::vector<u8> CompressDataZSTD(std::span<const u8> source, s32 compression_level) {
     compression_level = std::clamp(compression_level, ZSTD_minCLevel(), ZSTD_maxCLevel());
     const std::size_t max_compressed_size = ZSTD_compressBound(source.size());
@@ -71,3 +86,676 @@ std::vector<u8> DecompressDataZSTD(std::span<const u8> compressed) {
 }
 
 } // namespace Common::Compression
+
+namespace FileUtil {
+
+template <typename T>
+void ReadFromIStream(std::istringstream& s, T* out, size_t out_size) {
+    s.read(reinterpret_cast<char*>(out), out_size);
+}
+
+template <typename T>
+void WriteToOStream(std::ostringstream& s, const T* out, size_t out_size) {
+    s.write(reinterpret_cast<const char*>(out), out_size);
+}
+
+Z3DSMetadata::Z3DSMetadata(const std::span<u8>& source_data) {
+    if (source_data.empty())
+        return;
+    std::string buf(reinterpret_cast<const char*>(source_data.data()), source_data.size());
+    std::istringstream in(buf, std::ios::binary);
+
+    u8 version;
+    ReadFromIStream(in, &version, sizeof(version));
+
+    if (version != METADATA_VERSION) {
+        return;
+    }
+
+    while (!in.eof()) {
+        Item item;
+        ReadFromIStream(in, &item, sizeof(Item));
+        // Only binary type supported for now
+        if (item.type != Item::TYPE_BINARY) {
+            break;
+        }
+        std::string name(item.name_len, '\0');
+        std::vector<u8> data(item.data_len);
+        ReadFromIStream(in, name.data(), name.size());
+        ReadFromIStream(in, data.data(), data.size());
+        items.insert({std::move(name), std::move(data)});
+    }
+}
+
+std::vector<u8> Z3DSMetadata::AsBinary() {
+    if (items.empty())
+        return {};
+    std::ostringstream out;
+    u8 version = METADATA_VERSION;
+    WriteToOStream(out, &version, sizeof(u8));
+
+    for (const auto& it : items) {
+        Item item{
+            .type = Item::TYPE_BINARY,
+            .name_len = static_cast<u8>(std::min<size_t>(0xFF, it.first.size())),
+            .data_len = static_cast<u16>(std::min<size_t>(0xFFFF, it.second.size())),
+        };
+        WriteToOStream(out, &item, sizeof(item));
+        WriteToOStream(out, it.first.data(), item.name_len);
+        WriteToOStream(out, it.second.data(), item.data_len);
+    }
+
+    std::string out_str = out.str();
+    return std::vector<u8>(out_str.begin(), out_str.end());
+}
+
+struct Z3DSWriteIOFile::Z3DSWriteIOFileImpl {
+    Z3DSWriteIOFileImpl() {}
+    Z3DSWriteIOFileImpl(size_t frame_size) {
+        zstd_frame_size = frame_size;
+        cstream = ZSTD_seekable_createCStream();
+        size_t init_result = ZSTD_seekable_initCStream(cstream, ZSTD_CLEVEL_DEFAULT, 0,
+                                                       static_cast<unsigned int>(frame_size));
+        if (ZSTD_isError(init_result)) {
+            LOG_ERROR(Common_Filesystem, "ZSTD_seekable_initCStream() error : {}",
+                      ZSTD_getErrorName(init_result));
+        }
+
+        write_header.magic = Z3DSFileHeader::EXPECTED_MAGIC;
+        write_header.version = Z3DSFileHeader::EXPECTED_VERSION;
+        write_header.header_size = sizeof(Z3DSFileHeader);
+        next_input_size_hint = ZSTD_CStreamInSize();
+    }
+
+    bool WriteHeader(IOFile* file) {
+        file->Seek(0, SEEK_SET);
+        return file->WriteBytes(&write_header, sizeof(write_header)) == sizeof(write_header);
+    }
+
+    bool WriteMetadata(IOFile* file, const std::span<u8>& data) {
+        std::array<u8, 0x10> tmp_data{};
+        size_t total_size = Common::AlignUp(data.size(), 0x10);
+        write_header.metadata_size = static_cast<u32>(total_size);
+        size_t res_written = file->WriteBytes(data.data(), data.size());
+        res_written += file->WriteBytes(tmp_data.data(), total_size - data.size());
+        return res_written == total_size;
+    }
+
+    size_t Write(IOFile* file, const void* data, std::size_t length) {
+        size_t ret = length;
+
+        const size_t out_size = ZSTD_CStreamOutSize();
+        const size_t in_size = ZSTD_CStreamInSize();
+
+        if (write_buffer.size() < out_size) {
+            write_buffer.resize(out_size);
+        }
+
+        ZSTD_inBuffer input = {data, length, 0};
+        while (input.pos < input.size) {
+            ZSTD_outBuffer output = {write_buffer.data(), write_buffer.size(), 0};
+            next_input_size_hint = ZSTD_seekable_compressStream(cstream, &output, &input);
+            if (ZSTD_isError(next_input_size_hint)) {
+                LOG_ERROR(Common_Filesystem, "ZSTD_seekable_compressStream() error : {}",
+                          ZSTD_getErrorName(next_input_size_hint));
+                ret = 0;
+                next_input_size_hint = ZSTD_CStreamInSize();
+                break;
+            }
+            if (next_input_size_hint > in_size) {
+                next_input_size_hint = in_size;
+            }
+            if (file->WriteBytes(static_cast<u8*>(output.dst), output.pos) != output.pos) {
+                ret = 0;
+                break;
+            }
+            written_compressed += output.pos;
+        }
+        return ret;
+    }
+
+    bool Close(IOFile* file, size_t written_uncompressed) {
+        const size_t out_size = ZSTD_CStreamOutSize();
+
+        if (write_buffer.size() < out_size) {
+            write_buffer.resize(out_size);
+        }
+
+        size_t remaining;
+        do {
+            ZSTD_outBuffer output = {write_buffer.data(), write_buffer.size(), 0};
+            remaining = ZSTD_seekable_endStream(cstream, &output); /* close stream */
+            if (ZSTD_isError(remaining)) {
+                LOG_ERROR(Common_Filesystem, "ZSTD_seekable_endStream() error : {}",
+                          ZSTD_getErrorName(remaining));
+                return false;
+            }
+
+            if (file->WriteBytes(static_cast<u8*>(output.dst), output.pos) != output.pos) {
+                return false;
+            }
+            written_compressed += output.pos;
+        } while (remaining);
+
+        write_header.compressed_size = written_compressed;
+        write_header.uncompressed_size = written_uncompressed;
+
+        ZSTD_seekable_freeCStream(cstream);
+
+        return WriteHeader(file);
+    }
+
+    std::vector<u8> write_buffer;
+    size_t next_input_size_hint = 0;
+    size_t zstd_frame_size = 0;
+    u64 written_compressed = 0;
+
+    ZSTD_seekable_CStream* cstream{};
+    Z3DSFileHeader write_header{};
+};
+
+Z3DSWriteIOFile::Z3DSWriteIOFile()
+    : IOFile(), file{std::make_unique<IOFile>()}, impl{std::make_unique<Z3DSWriteIOFileImpl>()} {}
+
+Z3DSWriteIOFile::Z3DSWriteIOFile(std::unique_ptr<IOFile>&& underlying_file,
+                                 const std::array<u8, 4>& underlying_magic, size_t frame_size)
+    : IOFile(), file{std::move(underlying_file)},
+      impl{std::make_unique<Z3DSWriteIOFileImpl>(frame_size)} {
+    ASSERT_MSG(!file->IsCompressed(), "Underlying file is already compressed!");
+    impl->write_header.underlying_magic = underlying_magic;
+    impl->WriteHeader(file.get());
+
+    Metadata().Add("compressor", std::string("Azahar ") + Common::g_build_fullname);
+
+    std::time_t tt = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    std::tm tm{};
+#if defined(_WIN32)
+    gmtime_s(&tm, &tt);
+#else
+    gmtime_r(&tt, &tm);
+#endif
+    char buf[0x20];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm);
+    Metadata().Add("date", buf);
+
+    Metadata().Add(
+        "maxframesize",
+        std::to_string(frame_size ? frame_size : ZSTD_SEEKABLE_MAX_FRAME_DECOMPRESSED_SIZE));
+}
+
+Z3DSWriteIOFile::~Z3DSWriteIOFile() {
+    this->Close();
+}
+
+bool Z3DSWriteIOFile::Close() {
+    impl->Close(file.get(), written_uncompressed);
+    return file->Close();
+}
+
+u64 Z3DSWriteIOFile::GetSize() const {
+    return written_uncompressed;
+}
+
+bool Z3DSWriteIOFile::Resize(u64 size) {
+    // Stubbed
+    UNIMPLEMENTED();
+    return false;
+}
+
+bool Z3DSWriteIOFile::Flush() {
+    return file->Flush();
+}
+
+void Z3DSWriteIOFile::Clear() {
+    return file->Clear();
+}
+
+bool Z3DSWriteIOFile::IsCrypto() {
+    return file->IsCrypto();
+}
+
+const std::string& Z3DSWriteIOFile::Filename() const {
+    return file->Filename();
+}
+
+bool Z3DSWriteIOFile::IsOpen() const {
+    return file->IsOpen();
+}
+
+bool Z3DSWriteIOFile::IsGood() const {
+    return file->IsGood();
+}
+
+int Z3DSWriteIOFile::GetFd() const {
+    return file->GetFd();
+}
+
+bool Z3DSWriteIOFile::Open() {
+    if (is_serializing) {
+        return true;
+    }
+    // Stubbed
+    UNIMPLEMENTED();
+    return false;
+}
+
+std::size_t Z3DSWriteIOFile::ReadImpl(void* data, std::size_t length, std::size_t data_size) {
+    // Stubbed
+    UNIMPLEMENTED();
+    return 0;
+}
+
+std::size_t Z3DSWriteIOFile::ReadAtImpl(void* data, std::size_t length, std::size_t data_size,
+                                        std::size_t offset) {
+    // Stubbed
+    UNIMPLEMENTED();
+    return 0;
+}
+
+std::size_t Z3DSWriteIOFile::WriteImpl(const void* data, std::size_t length,
+                                       std::size_t data_size) {
+    if (!metadata_written) {
+        metadata_written = true;
+        auto metadata_binary = metadata.AsBinary();
+        if (!metadata_binary.empty()) {
+            impl->WriteMetadata(file.get(), metadata_binary);
+        }
+    }
+
+    size_t ret = impl->Write(file.get(), data, length * data_size);
+    written_uncompressed += ret;
+    return ret;
+}
+
+bool Z3DSWriteIOFile::SeekImpl(s64 off, int origin) {
+    if (is_serializing) {
+        return true;
+    }
+    // Stubbed
+    UNIMPLEMENTED();
+    return false;
+}
+
+u64 Z3DSWriteIOFile::TellImpl() const {
+    return written_uncompressed;
+}
+
+size_t Z3DSWriteIOFile::GetNextWriteHint() {
+    return impl->next_input_size_hint;
+}
+
+template <class Archive>
+void Z3DSWriteIOFile::serialize(Archive& ar, const unsigned int) {
+    is_serializing = true;
+    ar& boost::serialization::base_object<IOFile>(*this);
+
+    ar & file;
+    ar & written_uncompressed;
+    ar & metadata_written;
+    ar & metadata;
+
+    Z3DSFileHeader hd;
+    size_t frame_size;
+    u64 written_compressed;
+    if (Archive::is_loading::value) {
+        ar & hd;
+        ar & frame_size;
+        ar & written_compressed;
+        impl = std::make_unique<Z3DSWriteIOFileImpl>(frame_size);
+        impl->write_header = hd;
+        impl->written_compressed = written_compressed;
+    } else {
+        ar & impl->write_header;
+        ar & impl->zstd_frame_size;
+        ar & impl->written_compressed;
+    }
+    is_serializing = false;
+}
+
+struct Z3DSReadIOFile::Z3DSReadIOFileImpl {
+    Z3DSReadIOFileImpl() {}
+    Z3DSReadIOFileImpl(IOFile* file, bool load_metadata = true) {
+        curr_file = file;
+        m_good = file->ReadAtBytes(&header, sizeof(header), 0) == sizeof(header);
+        m_good &= header.magic == Z3DSFileHeader::EXPECTED_MAGIC &&
+                  header.version == Z3DSFileHeader::EXPECTED_VERSION;
+
+        if (!m_good) {
+            return;
+        }
+
+        if (header.metadata_size && load_metadata) {
+            std::vector<u8> buff(header.metadata_size);
+            file->ReadAtBytes(buff.data(), buff.size(), header.header_size);
+            metadata = Z3DSMetadata(buff);
+        }
+
+        seekable = ZSTD_seekable_create();
+
+        ZSTD_seekable_customFile custom_file{
+            .opaque = this,
+            .read = [](void* opaque, void* buffer, size_t n) -> int {
+                return reinterpret_cast<Z3DSReadIOFileImpl*>(opaque)->OnZSTDRead(buffer, n);
+            },
+            .seek = [](void* opaque, long long offset, int origin) -> int {
+                return reinterpret_cast<Z3DSReadIOFileImpl*>(opaque)->OnZSTDSeek(offset, origin);
+            },
+        };
+        size_t init_result = ZSTD_seekable_initAdvanced(seekable, custom_file);
+        if (ZSTD_isError(init_result)) {
+            LOG_ERROR(Common_Filesystem, "ZSTD_seekable_initCStream() error : {}",
+                      ZSTD_getErrorName(init_result));
+            m_good = false;
+        }
+    }
+
+    int OnZSTDRead(void* buffer, size_t n) {
+        const size_t read = curr_file->ReadBytes(reinterpret_cast<uint8_t*>(buffer), n);
+        if (read != n) {
+            return -1;
+        }
+        return 0;
+    }
+
+    int OnZSTDSeek(long long offset, int origin) {
+        if (origin == SEEK_SET) {
+            offset += static_cast<long long>(header.metadata_size) + header.header_size;
+        }
+        const bool res = curr_file->Seek(offset, origin);
+        return res ? 0 : -1;
+    }
+
+    size_t Read(void* data, std::size_t length) {
+        if (!m_good)
+            return 0;
+        size_t result = ZSTD_seekable_decompress(seekable, data, length, uncompressed_pos);
+        if (ZSTD_isError(result)) {
+            LOG_ERROR(Common_Filesystem, "ZSTD_seekable_decompress() error : {}",
+                      ZSTD_getErrorName(result));
+            return 0;
+        }
+        uncompressed_pos += result;
+        return result;
+    }
+
+    size_t ReadAt(void* data, std::size_t length, size_t pos) {
+        if (!m_good)
+            return 0;
+        // ReadAt should be thread safe, but seekable compression is not,
+        // so we are forced to use a lock.
+        std::scoped_lock lock(read_mutex);
+
+        size_t result = ZSTD_seekable_decompress(seekable, data, length, pos);
+        if (ZSTD_isError(result)) {
+            LOG_ERROR(Common_Filesystem, "ZSTD_seekable_decompress() error : {}",
+                      ZSTD_getErrorName(result));
+            return 0;
+        }
+        return result;
+    }
+
+    bool Seek(s64 off, int origin) {
+        s64 start = 0;
+        switch (origin) {
+        case SEEK_SET:
+            start = 0;
+            break;
+        case SEEK_CUR:
+            start = static_cast<s64>(uncompressed_pos);
+            break;
+        case SEEK_END:
+            start = static_cast<s64>(header.uncompressed_size);
+            break;
+        default:
+            return false;
+        }
+        s64 new_pos = start + off;
+        if (new_pos < 0)
+            return false;
+        uncompressed_pos = static_cast<u64>(new_pos);
+        return true;
+    }
+
+    void Close() {
+        ZSTD_seekable_free(seekable);
+    }
+
+    Z3DSFileHeader header{};
+    ZSTD_seekable* seekable = nullptr;
+    bool m_good = true;
+    IOFile* curr_file = nullptr;
+    std::mutex read_mutex;
+    u64 uncompressed_pos = 0;
+    Z3DSMetadata metadata;
+};
+
+std::optional<u32> Z3DSReadIOFile::GetUnderlyingFileMagic(IOFile* underlying_file) {
+    Z3DSFileHeader header{};
+    underlying_file->ReadAtBytes(&header, sizeof(header), 0);
+    if (header.magic != Z3DSFileHeader::EXPECTED_MAGIC ||
+        header.version != Z3DSFileHeader::EXPECTED_VERSION) {
+        return std::nullopt;
+    }
+
+    return MakeMagic(header.underlying_magic[0], header.underlying_magic[1],
+                     header.underlying_magic[2], header.underlying_magic[3]);
+}
+
+Z3DSReadIOFile::Z3DSReadIOFile()
+    : IOFile(), file{std::make_unique<IOFile>()}, impl{std::make_unique<Z3DSReadIOFileImpl>()} {}
+
+Z3DSReadIOFile::Z3DSReadIOFile(std::unique_ptr<IOFile>&& underlying_file)
+    : IOFile(), file{std::move(underlying_file)},
+      impl{std::make_unique<Z3DSReadIOFileImpl>(file.get())} {
+    ASSERT_MSG(!file->IsCompressed(), "Underlying file is already compressed!");
+}
+
+Z3DSReadIOFile::~Z3DSReadIOFile() {
+    this->Close();
+}
+
+bool Z3DSReadIOFile::Close() {
+    impl->Close();
+    return file->Close();
+}
+
+u64 Z3DSReadIOFile::GetSize() const {
+    return impl->header.uncompressed_size;
+}
+
+bool Z3DSReadIOFile::Resize(u64 size) {
+    // Stubbed
+    UNIMPLEMENTED();
+    return false;
+}
+
+bool Z3DSReadIOFile::Flush() {
+    return file->Flush();
+}
+
+void Z3DSReadIOFile::Clear() {
+    return file->Clear();
+}
+
+bool Z3DSReadIOFile::IsCrypto() {
+    return file->IsCrypto();
+}
+
+const std::string& Z3DSReadIOFile::Filename() const {
+    return file->Filename();
+}
+
+bool Z3DSReadIOFile::IsOpen() const {
+    return file->IsOpen();
+}
+
+bool Z3DSReadIOFile::IsGood() const {
+    return file->IsGood() && impl->m_good;
+}
+
+int Z3DSReadIOFile::GetFd() const {
+    return file->GetFd();
+}
+
+bool Z3DSReadIOFile::Open() {
+    if (is_serializing) {
+        return true;
+    }
+    // Stubbed
+    UNIMPLEMENTED();
+    return false;
+}
+
+std::size_t Z3DSReadIOFile::ReadImpl(void* data, std::size_t length, std::size_t data_size) {
+    return impl->Read(data, length * data_size);
+}
+
+std::size_t Z3DSReadIOFile::ReadAtImpl(void* data, std::size_t length, std::size_t data_size,
+                                       std::size_t offset) {
+    return impl->ReadAt(data, length * data_size, offset);
+}
+
+std::size_t Z3DSReadIOFile::WriteImpl(const void* data, std::size_t length, std::size_t data_size) {
+    // Stubbed
+    UNIMPLEMENTED();
+    return 0;
+}
+
+bool Z3DSReadIOFile::SeekImpl(s64 off, int origin) {
+    if (is_serializing) {
+        return true;
+    }
+    return impl->Seek(off, origin);
+}
+
+u64 Z3DSReadIOFile::TellImpl() const {
+    return impl->uncompressed_pos;
+}
+
+std::array<u8, 4> Z3DSReadIOFile::GetFileMagic() {
+    return impl->header.underlying_magic;
+}
+
+const Z3DSMetadata& Z3DSReadIOFile::Metadata() {
+    return impl->metadata;
+}
+
+template <class Archive>
+void Z3DSReadIOFile::serialize(Archive& ar, const unsigned int) {
+    is_serializing = true;
+    ar& boost::serialization::base_object<IOFile>(*this);
+
+    ar & file;
+
+    if (Archive::is_loading::value) {
+        impl = std::make_unique<Z3DSReadIOFileImpl>(file.get(), false);
+    }
+    ar & impl->uncompressed_pos;
+    ar & impl->metadata;
+    is_serializing = false;
+}
+
+bool CompressZ3DSFile(const std::string& src_file_name, const std::string& dst_file_name,
+                      const std::array<u8, 4>& underlying_magic, size_t frame_size,
+                      std::function<ProgressCallback>&& update_callback) {
+
+    IOFile in_file(src_file_name, "rb");
+    if (!in_file.IsOpen()) {
+        LOG_ERROR(Common_Filesystem, "Failed to open source file: {}", src_file_name);
+        return false;
+    }
+
+    std::unique_ptr<IOFile> out_file = std::make_unique<IOFile>(dst_file_name, "wb");
+    if (!out_file->IsOpen()) {
+        LOG_ERROR(Common_Filesystem, "Failed to open destination file: {}", dst_file_name);
+        return false;
+    }
+
+    if (Z3DSReadIOFile::GetUnderlyingFileMagic(&in_file) != std::nullopt) {
+        LOG_ERROR(Common_Filesystem, "Source file is already compressed, nothing to do: {}",
+                  src_file_name);
+        return false;
+    }
+
+    Z3DSWriteIOFile out_compress_file(std::move(out_file), underlying_magic, frame_size);
+
+    size_t next_chunk = out_compress_file.GetNextWriteHint();
+    std::vector<u8> buffer(next_chunk);
+    size_t in_size = in_file.GetSize();
+    size_t written = 0;
+
+    while (written != in_size) {
+        size_t to_read = ((in_size - written) > next_chunk) ? next_chunk : (in_size - written);
+        if (buffer.size() < to_read) {
+            buffer.resize(to_read);
+        }
+        if (in_file.ReadBytes(buffer.data(), to_read) != to_read) {
+            LOG_ERROR(Common_Filesystem, "Failed to read from source file");
+            return false;
+        }
+        if (out_compress_file.WriteBytes(buffer.data(), to_read) != to_read) {
+            LOG_ERROR(Common_Filesystem, "Failed to write to destination file");
+        }
+        written += to_read;
+        next_chunk = out_compress_file.GetNextWriteHint();
+        if (update_callback) {
+            update_callback(written, in_size);
+        }
+    }
+    LOG_INFO(Common_Filesystem, "File {} compressed successfully to {}", src_file_name,
+             dst_file_name);
+    return true;
+}
+
+bool DeCompressZ3DSFile(const std::string& src_file_name, const std::string& dst_file_name,
+                        std::function<ProgressCallback>&& update_callback) {
+
+    std::unique_ptr<IOFile> in_file = std::make_unique<IOFile>(src_file_name, "rb");
+    if (!in_file->IsOpen()) {
+        LOG_ERROR(Common_Filesystem, "Failed to open source file: {}", src_file_name);
+        return false;
+    }
+
+    IOFile out_file(dst_file_name, "wb");
+    if (!out_file.IsOpen()) {
+        LOG_ERROR(Common_Filesystem, "Failed to open destination file: {}", dst_file_name);
+        return false;
+    }
+
+    if (Z3DSReadIOFile::GetUnderlyingFileMagic(in_file.get()) == std::nullopt) {
+        LOG_ERROR(Common_Filesystem,
+                  "Source file is not compressed or is invalid, nothing to do: {}", src_file_name);
+        return false;
+    }
+
+    Z3DSReadIOFile in_compress_file(std::move(in_file));
+    size_t next_chunk = 64 * 1024 * 1024;
+    std::vector<u8> buffer(next_chunk);
+    size_t in_size = in_compress_file.GetSize();
+    size_t written = 0;
+
+    while (written != in_size) {
+        size_t to_read = (in_size - written) > next_chunk ? next_chunk : (in_size - written);
+        if (buffer.size() < to_read) {
+            buffer.resize(to_read);
+        }
+        if (in_compress_file.ReadBytes(buffer.data(), to_read) != to_read) {
+            LOG_ERROR(Common_Filesystem, "Failed to read from source file");
+            return false;
+        }
+        if (out_file.WriteBytes(buffer.data(), to_read) != to_read) {
+            LOG_ERROR(Common_Filesystem, "Failed to write to destination file");
+        }
+        written += to_read;
+        if (update_callback) {
+            update_callback(written, in_size);
+        }
+    }
+    LOG_INFO(Common_Filesystem, "File {} decompressed successfully to {}", src_file_name,
+             dst_file_name);
+    return true;
+}
+} // namespace FileUtil
+
+SERIALIZE_EXPORT_IMPL(FileUtil::Z3DSReadIOFile);
+SERIALIZE_EXPORT_IMPL(FileUtil::Z3DSWriteIOFile);

--- a/src/common/zstd_compression.h
+++ b/src/common/zstd_compression.h
@@ -261,7 +261,8 @@ using ProgressCallback = void(std::size_t, std::size_t);
 
 bool CompressZ3DSFile(const std::string& src_file, const std::string& dst_file,
                       const std::array<u8, 4>& underlying_magic, size_t frame_size,
-                      std::function<ProgressCallback>&& update_callback = nullptr);
+                      std::function<ProgressCallback>&& update_callback = nullptr,
+                      std::unordered_map<std::string, std::vector<u8>> metadata = {});
 
 bool DeCompressZ3DSFile(const std::string& src_file, const std::string& dst_file,
                         std::function<ProgressCallback>&& update_callback = nullptr);

--- a/src/common/zstd_compression.h
+++ b/src/common/zstd_compression.h
@@ -55,11 +55,12 @@ namespace FileUtil {
 
 struct Z3DSFileHeader {
     static constexpr std::array<u8, 4> EXPECTED_MAGIC = {'Z', '3', 'D', 'S'};
-    static constexpr u16 EXPECTED_VERSION = 1;
+    static constexpr u8 EXPECTED_VERSION = 1;
 
     std::array<u8, 4> magic = EXPECTED_MAGIC;
     std::array<u8, 4> underlying_magic{};
-    u16 version = EXPECTED_VERSION;
+    u8 version = EXPECTED_VERSION;
+    u8 reserved = 0;
     u16 header_size = 0;
     u32 metadata_size = 0;
     u64 compressed_size = 0;
@@ -70,6 +71,7 @@ struct Z3DSFileHeader {
         ar & magic;
         ar & underlying_magic;
         ar & version;
+        ar & reserved;
         ar & header_size;
         ar & metadata_size;
         ar & compressed_size;
@@ -126,8 +128,9 @@ private:
 
 class Z3DSWriteIOFile : public IOFile {
 public:
-    static constexpr size_t DEFAULT_FRAME_SIZE = 256 * 1024; // 256KiB
-    static constexpr size_t MAX_FRAME_SIZE = 0;              // Let the lib decide, usually 1GiB
+    static constexpr size_t DEFAULT_FRAME_SIZE = 256 * 1024;           // 256KiB
+    static constexpr size_t DEFAULT_CIA_FRAME_SIZE = 32 * 1024 * 1024; // 32MiB
+    static constexpr size_t MAX_FRAME_SIZE = 0; // Let the lib decide, usually 1GiB
 
     Z3DSWriteIOFile();
 

--- a/src/common/zstd_compression.h
+++ b/src/common/zstd_compression.h
@@ -1,3 +1,7 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
 // Copyright 2019 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
@@ -5,9 +9,14 @@
 #pragma once
 
 #include <span>
+#include <unordered_map>
 #include <vector>
 
+#include <boost/serialization/array.hpp>
+#include <boost/serialization/unordered_map.hpp>
+#include "common/archives.h"
 #include "common/common_types.h"
+#include "common/file_util.h"
 
 namespace Common::Compression {
 
@@ -41,3 +50,220 @@ namespace Common::Compression {
 [[nodiscard]] std::vector<u8> DecompressDataZSTD(std::span<const u8> compressed);
 
 } // namespace Common::Compression
+
+namespace FileUtil {
+
+struct Z3DSFileHeader {
+    static constexpr std::array<u8, 4> EXPECTED_MAGIC = {'Z', '3', 'D', 'S'};
+    static constexpr u16 EXPECTED_VERSION = 1;
+
+    std::array<u8, 4> magic = EXPECTED_MAGIC;
+    std::array<u8, 4> underlying_magic{};
+    u16 version = EXPECTED_VERSION;
+    u16 header_size = 0;
+    u32 metadata_size = 0;
+    u64 compressed_size = 0;
+    u64 uncompressed_size = 0;
+
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int) {
+        ar & magic;
+        ar & underlying_magic;
+        ar & version;
+        ar & header_size;
+        ar & metadata_size;
+        ar & compressed_size;
+        ar & uncompressed_size;
+    }
+};
+static_assert(sizeof(Z3DSFileHeader) == 0x20, "Invalid Z3DSFileHeader size");
+
+class Z3DSMetadata {
+public:
+    static constexpr u8 METADATA_VERSION = 1;
+    Z3DSMetadata() {}
+
+    Z3DSMetadata(const std::span<u8>& source_data);
+
+    void Add(const std::string& name, const std::span<u8>& data) {
+        items.insert({name, std::vector<u8>(data.begin(), data.end())});
+    }
+
+    void Add(const std::string& name, const std::string& data) {
+        items.insert({name, std::vector<u8>(data.begin(), data.end())});
+    }
+
+    std::optional<std::vector<u8>> Get(const std::string& name) const {
+        auto it = items.find(name);
+        if (it == items.end()) {
+            return std::nullopt;
+        }
+        return it->second;
+    }
+
+    std::vector<u8> AsBinary();
+
+private:
+    struct Item {
+        enum Type : u8 {
+            TYPE_END = 0,
+            TYPE_BINARY = 1,
+        };
+        Type type{};
+        u8 name_len{};
+        u16 data_len{};
+    };
+    static_assert(sizeof(Item) == 4);
+
+    std::unordered_map<std::string, std::vector<u8>> items;
+
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int) {
+        ar & items;
+    }
+    friend class boost::serialization::access;
+};
+
+class Z3DSWriteIOFile : public IOFile {
+public:
+    static constexpr size_t DEFAULT_FRAME_SIZE = 256 * 1024; // 256KiB
+    static constexpr size_t MAX_FRAME_SIZE = 0;              // Let the lib decide, usually 1GiB
+
+    Z3DSWriteIOFile();
+
+    Z3DSWriteIOFile(std::unique_ptr<IOFile>&& underlying_file,
+                    const std::array<u8, 4>& underlying_magic, size_t frame_size);
+
+    ~Z3DSWriteIOFile();
+
+    bool Close() override;
+
+    u64 GetSize() const override;
+
+    bool Resize(u64 size) override;
+
+    bool Flush() override;
+
+    void Clear() override;
+
+    bool IsCrypto() override;
+
+    bool IsCompressed() override {
+        return true;
+    }
+
+    const std::string& Filename() const override;
+
+    bool IsOpen() const override;
+
+    bool IsGood() const override;
+
+    int GetFd() const override;
+
+    Z3DSMetadata& Metadata() {
+        return metadata;
+    }
+
+    size_t GetNextWriteHint();
+
+private:
+    struct Z3DSWriteIOFileImpl;
+    bool Open() override;
+
+    std::size_t ReadImpl(void* data, std::size_t length, std::size_t data_size) override;
+    std::size_t ReadAtImpl(void* data, std::size_t length, std::size_t data_size,
+                           std::size_t offset) override;
+    std::size_t WriteImpl(const void* data, std::size_t length, std::size_t data_size) override;
+
+    bool SeekImpl(s64 off, int origin) override;
+    u64 TellImpl() const override;
+
+    std::unique_ptr<IOFile> file;
+    std::unique_ptr<Z3DSWriteIOFileImpl> impl;
+    u64 written_uncompressed = 0;
+    bool metadata_written = false;
+    Z3DSMetadata metadata;
+
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int);
+    friend class boost::serialization::access;
+    bool is_serializing = false;
+};
+
+class Z3DSReadIOFile : public IOFile {
+public:
+    static std::optional<u32> GetUnderlyingFileMagic(IOFile* underlying_file);
+
+    Z3DSReadIOFile();
+
+    Z3DSReadIOFile(std::unique_ptr<IOFile>&& underlying_file);
+
+    ~Z3DSReadIOFile();
+
+    bool Close() override;
+
+    u64 GetSize() const override;
+
+    bool Resize(u64 size) override;
+
+    bool Flush() override;
+
+    void Clear() override;
+
+    bool IsCrypto() override;
+
+    bool IsCompressed() override {
+        return true;
+    }
+
+    const std::string& Filename() const override;
+
+    bool IsOpen() const override;
+
+    bool IsGood() const override;
+
+    int GetFd() const override;
+
+    std::array<u8, 4> GetFileMagic();
+
+    const Z3DSMetadata& Metadata();
+
+private:
+    struct Z3DSReadIOFileImpl;
+
+    static constexpr u32 MakeMagic(char a, char b, char c, char d) {
+        return a | b << 8 | c << 16 | d << 24;
+    }
+
+    bool Open() override;
+
+    std::size_t ReadImpl(void* data, std::size_t length, std::size_t data_size) override;
+    std::size_t ReadAtImpl(void* data, std::size_t length, std::size_t data_size,
+                           std::size_t offset) override;
+    std::size_t WriteImpl(const void* data, std::size_t length, std::size_t data_size) override;
+
+    bool SeekImpl(s64 off, int origin) override;
+    u64 TellImpl() const override;
+
+    std::unique_ptr<IOFile> file;
+    std::unique_ptr<Z3DSReadIOFileImpl> impl;
+
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int);
+    friend class boost::serialization::access;
+    bool is_serializing = false;
+};
+
+using ProgressCallback = void(std::size_t, std::size_t);
+
+bool CompressZ3DSFile(const std::string& src_file, const std::string& dst_file,
+                      const std::array<u8, 4>& underlying_magic, size_t frame_size,
+                      std::function<ProgressCallback>&& update_callback = nullptr);
+
+bool DeCompressZ3DSFile(const std::string& src_file, const std::string& dst_file,
+                        std::function<ProgressCallback>&& update_callback = nullptr);
+
+} // namespace FileUtil
+
+BOOST_CLASS_EXPORT_KEY(FileUtil::Z3DSWriteIOFile)
+BOOST_CLASS_EXPORT_KEY(FileUtil::Z3DSReadIOFile)

--- a/src/core/file_sys/cia_container.cpp
+++ b/src/core/file_sys/cia_container.cpp
@@ -59,14 +59,13 @@ Loader::ResultStatus CIAContainer::Load(const FileBackend& backend) {
     return Loader::ResultStatus::Success;
 }
 
-Loader::ResultStatus CIAContainer::Load(const std::string& filepath) {
-    FileUtil::IOFile file(filepath, "rb");
-    if (!file.IsOpen())
+Loader::ResultStatus CIAContainer::Load(FileUtil::IOFile* file) {
+    if (!file->IsOpen())
         return Loader::ResultStatus::Error;
 
     // Load CIA Header
     std::vector<u8> header_data(sizeof(CIAHeader));
-    if (file.ReadBytes(header_data.data(), sizeof(CIAHeader)) != sizeof(CIAHeader))
+    if (file->ReadBytes(header_data.data(), sizeof(CIAHeader)) != sizeof(CIAHeader))
         return Loader::ResultStatus::Error;
 
     Loader::ResultStatus result = LoadHeader(header_data);
@@ -75,8 +74,8 @@ Loader::ResultStatus CIAContainer::Load(const std::string& filepath) {
 
     // Load Ticket
     std::vector<u8> ticket_data(cia_header.tik_size);
-    file.Seek(GetTicketOffset(), SEEK_SET);
-    if (file.ReadBytes(ticket_data.data(), cia_header.tik_size) != cia_header.tik_size)
+    file->Seek(GetTicketOffset(), SEEK_SET);
+    if (file->ReadBytes(ticket_data.data(), cia_header.tik_size) != cia_header.tik_size)
         return Loader::ResultStatus::Error;
 
     result = LoadTicket(ticket_data);
@@ -85,8 +84,8 @@ Loader::ResultStatus CIAContainer::Load(const std::string& filepath) {
 
     // Load Title Metadata
     std::vector<u8> tmd_data(cia_header.tmd_size);
-    file.Seek(GetTitleMetadataOffset(), SEEK_SET);
-    if (file.ReadBytes(tmd_data.data(), cia_header.tmd_size) != cia_header.tmd_size)
+    file->Seek(GetTitleMetadataOffset(), SEEK_SET);
+    if (file->ReadBytes(tmd_data.data(), cia_header.tmd_size) != cia_header.tmd_size)
         return Loader::ResultStatus::Error;
 
     result = LoadTitleMetadata(tmd_data);
@@ -96,8 +95,8 @@ Loader::ResultStatus CIAContainer::Load(const std::string& filepath) {
     // Load CIA Metadata
     if (cia_header.meta_size) {
         std::vector<u8> meta_data(sizeof(Metadata));
-        file.Seek(GetMetadataOffset(), SEEK_SET);
-        if (file.ReadBytes(meta_data.data(), sizeof(Metadata)) != sizeof(Metadata))
+        file->Seek(GetMetadataOffset(), SEEK_SET);
+        if (file->ReadBytes(meta_data.data(), sizeof(Metadata)) != sizeof(Metadata))
             return Loader::ResultStatus::Error;
 
         result = LoadMetadata(meta_data);

--- a/src/core/file_sys/cia_container.h
+++ b/src/core/file_sys/cia_container.h
@@ -9,6 +9,7 @@
 #include <span>
 #include <string>
 #include "common/common_types.h"
+#include "common/file_util.h"
 #include "common/swap.h"
 #include "core/file_sys/ticket.h"
 #include "core/file_sys/title_metadata.h"
@@ -62,7 +63,7 @@ class CIAContainer {
 public:
     // Load whole CIAs outright
     Loader::ResultStatus Load(const FileBackend& backend);
-    Loader::ResultStatus Load(const std::string& filepath);
+    Loader::ResultStatus Load(FileUtil::IOFile* file);
     Loader::ResultStatus Load(std::span<const u8> header_data);
 
     // Load parts of CIAs (for CIAs streamed in)

--- a/src/core/file_sys/cia_container.h
+++ b/src/core/file_sys/cia_container.h
@@ -13,6 +13,7 @@
 #include "common/swap.h"
 #include "core/file_sys/ticket.h"
 #include "core/file_sys/title_metadata.h"
+#include "core/loader/smdh.h"
 
 namespace Loader {
 enum class ResultStatus;
@@ -73,12 +74,14 @@ public:
     Loader::ResultStatus LoadTitleMetadata(std::span<const u8> tmd_data, std::size_t offset = 0);
     Loader::ResultStatus LoadTitleMetadata(const TitleMetadata& tmd);
     Loader::ResultStatus LoadMetadata(std::span<const u8> meta_data, std::size_t offset = 0);
+    Loader::ResultStatus LoadSMDH(std::span<const u8> smdh_data, std::size_t offset = 0);
 
     const CIAHeader* GetHeader();
     Ticket& GetTicket();
     const TitleMetadata& GetTitleMetadata() const;
     std::array<u64, 0x30>& GetDependencies();
     u32 GetCoreVersion() const;
+    const std::unique_ptr<Loader::SMDH>& GetSMDH() const;
 
     u64 GetCertificateOffset() const;
     u64 GetTicketOffset() const;
@@ -108,6 +111,7 @@ private:
     bool has_header = false;
     CIAHeader cia_header;
     Metadata cia_metadata;
+    std::unique_ptr<Loader::SMDH> cia_smdh;
     Ticket cia_ticket;
     TitleMetadata cia_tmd;
 };

--- a/src/core/file_sys/ncch_container.h
+++ b/src/core/file_sys/ncch_container.h
@@ -91,6 +91,10 @@ struct NCCH_Header {
     u8 reserved_4[4];
     u8 exefs_super_block_hash[0x20];
     u8 romfs_super_block_hash[0x20];
+
+    u32 GetContentUnitSize() {
+        return 0x200u * (1u << content_unit_size);
+    }
 };
 
 static_assert(sizeof(NCCH_Header) == 0x200, "NCCH header structure size is wrong");

--- a/src/core/file_sys/ncch_container.h
+++ b/src/core/file_sys/ncch_container.h
@@ -333,16 +333,28 @@ public:
      */
     bool HasExHeader();
 
+    bool IsNCSD() {
+        return is_ncsd;
+    }
+
+    bool IsFileCompressed() {
+        return file->IsCompressed();
+    }
+
     NCCH_Header ncch_header;
     ExeFs_Header exefs_header;
     ExHeader_Header exheader_header;
 
 private:
+    std::unique_ptr<FileUtil::IOFile> Reopen(const std::unique_ptr<FileUtil::IOFile>& orig_file,
+                                             const std::string& new_filename = "");
+
     bool has_header = false;
     bool has_exheader = false;
     bool has_exefs = false;
     bool has_romfs = false;
 
+    bool is_ncsd = false;
     bool is_proto = false;
     bool is_tainted = false; // Are there parts of this container being overridden?
     bool is_loaded = false;

--- a/src/core/file_sys/title_metadata.cpp
+++ b/src/core/file_sys/title_metadata.cpp
@@ -176,6 +176,17 @@ u64 TitleMetadata::GetContentSizeByIndex(std::size_t index) const {
     return tmd_chunks[index].size;
 }
 
+u64 TitleMetadata::GetCombinedContentSize(const CIAHeader* header) const {
+    u64 total_size = 0;
+    for (auto& chunk : tmd_chunks) {
+        if (header && !header->IsContentPresent(static_cast<u16>(chunk.index))) {
+            continue;
+        }
+        total_size += chunk.size;
+    }
+    return total_size;
+}
+
 bool TitleMetadata::GetContentOptional(std::size_t index) const {
     return (static_cast<u16>(tmd_chunks[index].type) & FileSys::TMDContentTypeFlag::Optional) != 0;
 }

--- a/src/core/file_sys/title_metadata.h
+++ b/src/core/file_sys/title_metadata.h
@@ -99,6 +99,7 @@ public:
     u32 GetContentIDByIndex(std::size_t index) const;
     u16 GetContentTypeByIndex(std::size_t index) const;
     u64 GetContentSizeByIndex(std::size_t index) const;
+    u64 GetCombinedContentSize(const CIAHeader* header) const;
     bool GetContentOptional(std::size_t index) const;
     std::array<u8, 16> GetContentCTRByIndex(std::size_t index) const;
     bool HasEncryptedContent(const CIAHeader* header = nullptr) const;

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -105,6 +105,15 @@ struct ImportContentContext {
 };
 static_assert(sizeof(ImportContentContext) == 0x18, "Invalid ImportContentContext size");
 
+struct TitleInfo {
+    u64_le tid;
+    u64_le size;
+    u16_le version;
+    u16_le unused;
+    u32_le type;
+};
+static_assert(sizeof(TitleInfo) == 0x18, "Title info structure size is wrong");
+
 // Title ID valid length
 constexpr std::size_t TITLE_ID_VALID_LENGTH = 16;
 
@@ -366,6 +375,11 @@ InstallStatus InstallCIA(const std::string& path,
  */
 InstallStatus CheckCIAToInstall(const std::string& path, bool& is_compressed,
                                 bool check_encryption);
+
+/**
+ * Get CIA metadata information from file.
+ */
+ResultVal<std::pair<TitleInfo, std::unique_ptr<Loader::SMDH>>> GetCIAInfos(const std::string& path);
 
 /**
  * Get the update title ID for a title

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -360,6 +360,14 @@ InstallStatus InstallCIA(const std::string& path,
                          std::function<ProgressCallback>&& update_callback = nullptr);
 
 /**
+ * Checks if the provided path is a valid CIA file
+ * that can be installed.
+ * @param path file path of the CIA file to check to install
+ */
+InstallStatus CheckCIAToInstall(const std::string& path, bool& is_compressed,
+                                bool check_encryption);
+
+/**
  * Get the update title ID for a title
  * @param titleId the title ID
  * @returns The update title ID

--- a/src/core/loader/3dsx.cpp
+++ b/src/core/loader/3dsx.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <vector>
 #include "common/logging/log.h"
+#include "common/zstd_compression.h"
 #include "core/core.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/resource_limit.h"
@@ -94,16 +95,16 @@ static u32 TranslateAddr(u32 addr, const THREEloadinfo* loadinfo, u32* offsets) 
 
 using Kernel::CodeSet;
 
-static THREEDSX_Error Load3DSXFile(Core::System& system, FileUtil::IOFile& file, u32 base_addr,
+static THREEDSX_Error Load3DSXFile(Core::System& system, FileUtil::IOFile* file, u32 base_addr,
                                    std::shared_ptr<CodeSet>* out_codeset) {
-    if (!file.IsOpen())
+    if (!file->IsOpen())
         return ERROR_FILE;
 
     // Reset read pointer in case this file has been read before.
-    file.Seek(0, SEEK_SET);
+    file->Seek(0, SEEK_SET);
 
     THREEDSX_Header hdr;
-    if (file.ReadBytes(&hdr, sizeof(hdr)) != sizeof(hdr))
+    if (file->ReadBytes(&hdr, sizeof(hdr)) != sizeof(hdr))
         return ERROR_READ;
 
     THREEloadinfo loadinfo;
@@ -129,22 +130,22 @@ static THREEDSX_Error Load3DSXFile(Core::System& system, FileUtil::IOFile& file,
     loadinfo.seg_ptrs[2] = loadinfo.seg_ptrs[1] + loadinfo.seg_sizes[1];
 
     // Skip header for future compatibility
-    file.Seek(hdr.header_size, SEEK_SET);
+    file->Seek(hdr.header_size, SEEK_SET);
 
     // Read the relocation headers
     std::vector<u32> relocs(n_reloc_tables * NUM_SEGMENTS);
     for (unsigned int current_segment = 0; current_segment < NUM_SEGMENTS; ++current_segment) {
         std::size_t size = n_reloc_tables * sizeof(u32);
-        if (file.ReadBytes(&relocs[current_segment * n_reloc_tables], size) != size)
+        if (file->ReadBytes(&relocs[current_segment * n_reloc_tables], size) != size)
             return ERROR_READ;
     }
 
     // Read the segments
-    if (file.ReadBytes(loadinfo.seg_ptrs[0], hdr.code_seg_size) != hdr.code_seg_size)
+    if (file->ReadBytes(loadinfo.seg_ptrs[0], hdr.code_seg_size) != hdr.code_seg_size)
         return ERROR_READ;
-    if (file.ReadBytes(loadinfo.seg_ptrs[1], hdr.rodata_seg_size) != hdr.rodata_seg_size)
+    if (file->ReadBytes(loadinfo.seg_ptrs[1], hdr.rodata_seg_size) != hdr.rodata_seg_size)
         return ERROR_READ;
-    if (file.ReadBytes(loadinfo.seg_ptrs[2], hdr.data_seg_size - hdr.bss_size) !=
+    if (file->ReadBytes(loadinfo.seg_ptrs[2], hdr.data_seg_size - hdr.bss_size) !=
         hdr.data_seg_size - hdr.bss_size)
         return ERROR_READ;
 
@@ -158,7 +159,7 @@ static THREEDSX_Error Load3DSXFile(Core::System& system, FileUtil::IOFile& file,
             u32 n_relocs = relocs[current_segment * n_reloc_tables + current_segment_reloc_table];
             if (current_segment_reloc_table >= 2) {
                 // We are not using this table - ignore it because we don't know what it dose
-                file.Seek(n_relocs * sizeof(THREEDSX_Reloc), SEEK_CUR);
+                file->Seek(n_relocs * sizeof(THREEDSX_Reloc), SEEK_CUR);
                 continue;
             }
             THREEDSX_Reloc reloc_table[RELOCBUFSIZE];
@@ -170,7 +171,7 @@ static THREEDSX_Error Load3DSXFile(Core::System& system, FileUtil::IOFile& file,
                 u32 remaining = std::min(RELOCBUFSIZE, n_relocs);
                 n_relocs -= remaining;
 
-                if (file.ReadBytes(reloc_table, remaining * sizeof(THREEDSX_Reloc)) !=
+                if (file->ReadBytes(reloc_table, remaining * sizeof(THREEDSX_Reloc)) !=
                     remaining * sizeof(THREEDSX_Reloc))
                     return ERROR_READ;
 
@@ -248,13 +249,15 @@ static THREEDSX_Error Load3DSXFile(Core::System& system, FileUtil::IOFile& file,
     return ERROR_NONE;
 }
 
-FileType AppLoader_THREEDSX::IdentifyType(FileUtil::IOFile& file) {
+FileType AppLoader_THREEDSX::IdentifyType(FileUtil::IOFile* file) {
     u32 magic;
-    file.Seek(0, SEEK_SET);
-    if (1 != file.ReadArray<u32>(&magic, 1))
+    file->Seek(0, SEEK_SET);
+    if (1 != file->ReadArray<u32>(&magic, 1))
         return FileType::Error;
 
-    if (MakeMagic('3', 'D', 'S', 'X') == magic)
+    if (MakeMagic('3', 'D', 'S', 'X') == magic ||
+        (MakeMagic('Z', '3', 'D', 'S') == magic &&
+         FileUtil::Z3DSReadIOFile::GetUnderlyingFileMagic(file) == MakeMagic('3', 'D', 'S', 'X')))
         return FileType::THREEDSX;
 
     return FileType::Error;
@@ -264,11 +267,15 @@ ResultStatus AppLoader_THREEDSX::Load(std::shared_ptr<Kernel::Process>& process)
     if (is_loaded)
         return ResultStatus::ErrorAlreadyLoaded;
 
-    if (!file.IsOpen())
+    if (!file->IsOpen())
         return ResultStatus::Error;
 
+    if (FileUtil::Z3DSReadIOFile::GetUnderlyingFileMagic(file.get()) != std::nullopt) {
+        file = std::make_unique<FileUtil::Z3DSReadIOFile>(std::move(file));
+    }
+
     std::shared_ptr<CodeSet> codeset;
-    if (Load3DSXFile(system, file, Memory::PROCESS_IMAGE_VADDR, &codeset) != ERROR_NONE)
+    if (Load3DSXFile(system, file.get(), Memory::PROCESS_IMAGE_VADDR, &codeset) != ERROR_NONE)
         return ResultStatus::Error;
     codeset->name = filename;
 
@@ -292,14 +299,14 @@ ResultStatus AppLoader_THREEDSX::Load(std::shared_ptr<Kernel::Process>& process)
 }
 
 ResultStatus AppLoader_THREEDSX::ReadRomFS(std::shared_ptr<FileSys::RomFSReader>& romfs_file) {
-    if (!file.IsOpen())
+    if (!file->IsOpen())
         return ResultStatus::Error;
 
     // Reset read pointer in case this file has been read before.
-    file.Seek(0, SEEK_SET);
+    file->Seek(0, SEEK_SET);
 
     THREEDSX_Header hdr;
-    if (file.ReadBytes(&hdr, sizeof(THREEDSX_Header)) != sizeof(THREEDSX_Header))
+    if (file->ReadBytes(&hdr, sizeof(THREEDSX_Header)) != sizeof(THREEDSX_Header))
         return ResultStatus::Error;
 
     if (hdr.header_size != sizeof(THREEDSX_Header))
@@ -308,7 +315,7 @@ ResultStatus AppLoader_THREEDSX::ReadRomFS(std::shared_ptr<FileSys::RomFSReader>
     // Check if the 3DSX has a RomFS...
     if (hdr.fs_offset != 0) {
         u32 romfs_offset = hdr.fs_offset;
-        u32 romfs_size = static_cast<u32>(file.GetSize()) - hdr.fs_offset;
+        u32 romfs_size = static_cast<u32>(file->GetSize()) - hdr.fs_offset;
 
         LOG_DEBUG(Loader, "RomFS offset:           {:#010X}", romfs_offset);
         LOG_DEBUG(Loader, "RomFS size:             {:#010X}", romfs_size);
@@ -328,15 +335,26 @@ ResultStatus AppLoader_THREEDSX::ReadRomFS(std::shared_ptr<FileSys::RomFSReader>
     return ResultStatus::ErrorNotUsed;
 }
 
+AppLoader::CompressFileInfo AppLoader_THREEDSX::GetCompressFileInfo() {
+    CompressFileInfo info;
+    info.is_supported = true;
+    info.recommended_compressed_extension = "z3dsx";
+    info.recommended_uncompressed_extension = "3dsx";
+    info.underlying_magic = std::array<u8, 4>({'3', 'D', 'S', 'X'});
+    info.is_compressed =
+        FileUtil::Z3DSReadIOFile::GetUnderlyingFileMagic(file.get()) != std::nullopt;
+    return info;
+}
+
 ResultStatus AppLoader_THREEDSX::ReadIcon(std::vector<u8>& buffer) {
-    if (!file.IsOpen())
+    if (!file->IsOpen())
         return ResultStatus::Error;
 
     // Reset read pointer in case this file has been read before.
-    file.Seek(0, SEEK_SET);
+    file->Seek(0, SEEK_SET);
 
     THREEDSX_Header hdr;
-    if (file.ReadBytes(&hdr, sizeof(THREEDSX_Header)) != sizeof(THREEDSX_Header))
+    if (file->ReadBytes(&hdr, sizeof(THREEDSX_Header)) != sizeof(THREEDSX_Header))
         return ResultStatus::Error;
 
     if (hdr.header_size != sizeof(THREEDSX_Header))
@@ -344,10 +362,10 @@ ResultStatus AppLoader_THREEDSX::ReadIcon(std::vector<u8>& buffer) {
 
     // Check if the 3DSX has a SMDH...
     if (hdr.smdh_offset != 0) {
-        file.Seek(hdr.smdh_offset, SEEK_SET);
+        file->Seek(hdr.smdh_offset, SEEK_SET);
         buffer.resize(hdr.smdh_size);
 
-        if (file.ReadBytes(buffer.data(), hdr.smdh_size) != hdr.smdh_size)
+        if (file->ReadBytes(buffer.data(), hdr.smdh_size) != hdr.smdh_size)
             return ResultStatus::Error;
 
         return ResultStatus::Success;

--- a/src/core/loader/3dsx.h
+++ b/src/core/loader/3dsx.h
@@ -1,3 +1,7 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
 // Copyright 2014 Dolphin Emulator Project / Citra Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
@@ -23,10 +27,10 @@ public:
      * @param file FileUtil::IOFile open file
      * @return FileType found, or FileType::Error if this loader doesn't know it
      */
-    static FileType IdentifyType(FileUtil::IOFile& file);
+    static FileType IdentifyType(FileUtil::IOFile* file);
 
     FileType GetFileType() override {
-        return IdentifyType(file);
+        return IdentifyType(file.get());
     }
 
     ResultStatus Load(std::shared_ptr<Kernel::Process>& process) override;
@@ -34,6 +38,8 @@ public:
     ResultStatus ReadIcon(std::vector<u8>& buffer) override;
 
     ResultStatus ReadRomFS(std::shared_ptr<FileSys::RomFSReader>& romfs_file) override;
+
+    CompressFileInfo GetCompressFileInfo() override;
 
 private:
     std::string filename;

--- a/src/core/loader/artic.cpp
+++ b/src/core/loader/artic.cpp
@@ -80,7 +80,7 @@ Apploader_Artic::~Apploader_Artic() {
     client->Stop();
 }
 
-FileType Apploader_Artic::IdentifyType(FileUtil::IOFile& file) {
+FileType Apploader_Artic::IdentifyType(FileUtil::IOFile* file) {
     return FileType::ARTIC;
 }
 

--- a/src/core/loader/artic.h
+++ b/src/core/loader/artic.h
@@ -33,10 +33,10 @@ public:
      * @param file FileUtil::IOFile open file
      * @return FileType found, or FileType::Error if this loader doesn't know it
      */
-    static FileType IdentifyType(FileUtil::IOFile& file);
+    static FileType IdentifyType(FileUtil::IOFile* file);
 
     FileType GetFileType() override {
-        return IdentifyType(file);
+        return IdentifyType(file.get());
     }
 
     [[nodiscard]] std::span<const u32> GetPreferredRegions() const override {

--- a/src/core/loader/elf.cpp
+++ b/src/core/loader/elf.cpp
@@ -1,3 +1,7 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
 // Copyright 2013 Dolphin Emulator Project / 2014 Citra Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
@@ -352,10 +356,10 @@ SectionID ElfReader::GetSectionByName(const char* name, int firstSection) const 
 
 namespace Loader {
 
-FileType AppLoader_ELF::IdentifyType(FileUtil::IOFile& file) {
+FileType AppLoader_ELF::IdentifyType(FileUtil::IOFile* file) {
     u32 magic;
-    file.Seek(0, SEEK_SET);
-    if (1 != file.ReadArray<u32>(&magic, 1))
+    file->Seek(0, SEEK_SET);
+    if (1 != file->ReadArray<u32>(&magic, 1))
         return FileType::Error;
 
     if (MakeMagic('\x7f', 'E', 'L', 'F') == magic)
@@ -368,15 +372,15 @@ ResultStatus AppLoader_ELF::Load(std::shared_ptr<Kernel::Process>& process) {
     if (is_loaded)
         return ResultStatus::ErrorAlreadyLoaded;
 
-    if (!file.IsOpen())
+    if (!file->IsOpen())
         return ResultStatus::Error;
 
     // Reset read pointer in case this file has been read before.
-    file.Seek(0, SEEK_SET);
+    file->Seek(0, SEEK_SET);
 
-    std::size_t size = file.GetSize();
+    std::size_t size = file->GetSize();
     std::unique_ptr<u8[]> buffer(new u8[size]);
-    if (file.ReadBytes(&buffer[0], size) != size)
+    if (file->ReadBytes(&buffer[0], size) != size)
         return ResultStatus::Error;
 
     ElfReader elf_reader(&buffer[0]);

--- a/src/core/loader/elf.h
+++ b/src/core/loader/elf.h
@@ -1,3 +1,7 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
 // Copyright 2013 Dolphin Emulator Project / 2014 Citra Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
@@ -22,10 +26,10 @@ public:
      * @param file FileUtil::IOFile open file
      * @return FileType found, or FileType::Error if this loader doesn't know it
      */
-    static FileType IdentifyType(FileUtil::IOFile& file);
+    static FileType IdentifyType(FileUtil::IOFile* file);
 
     FileType GetFileType() override {
-        return IdentifyType(file);
+        return IdentifyType(file.get());
     }
 
     ResultStatus Load(std::shared_ptr<Kernel::Process>& process) override;

--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -19,7 +19,7 @@ FileType IdentifyFile(FileUtil::IOFile& file) {
     FileType type;
 
 #define CHECK_TYPE(loader)                                                                         \
-    type = AppLoader_##loader::IdentifyType(file);                                                 \
+    type = AppLoader_##loader::IdentifyType(&file);                                                \
     if (FileType::Error != type)                                                                   \
         return type;
 
@@ -48,16 +48,16 @@ FileType GuessFromExtension(const std::string& extension_) {
     if (extension == ".elf" || extension == ".axf")
         return FileType::ELF;
 
-    if (extension == ".cci")
+    if (extension == ".cci" || extension == ".zcci")
         return FileType::CCI;
 
-    if (extension == ".cxi" || extension == ".app")
+    if (extension == ".cxi" || extension == ".app" || extension == ".zcxi")
         return FileType::CXI;
 
-    if (extension == ".3dsx")
+    if (extension == ".3dsx" || extension == ".z3dsx")
         return FileType::THREEDSX;
 
-    if (extension == ".cia")
+    if (extension == ".cia" || extension == ".zcia")
         return FileType::CIA;
 
     return FileType::Unknown;

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -85,8 +85,16 @@ constexpr u32 MakeMagic(char a, char b, char c, char d) {
 /// Interface for loading an application
 class AppLoader : NonCopyable {
 public:
+    struct CompressFileInfo {
+        bool is_supported{};
+        bool is_compressed{};
+        std::array<u8, 4> underlying_magic{};
+        std::string recommended_compressed_extension;
+        std::string recommended_uncompressed_extension;
+    };
+
     explicit AppLoader(Core::System& system_, FileUtil::IOFile&& file)
-        : system(system_), file(std::move(file)) {}
+        : system(system_), file(std::make_unique<FileUtil::IOFile>(std::move(file))) {}
     virtual ~AppLoader() {}
 
     /**
@@ -279,9 +287,15 @@ public:
         return false;
     }
 
+    virtual CompressFileInfo GetCompressFileInfo() {
+        CompressFileInfo info{};
+        info.is_supported = false;
+        return info;
+    }
+
 protected:
     Core::System& system;
-    FileUtil::IOFile file;
+    std::unique_ptr<FileUtil::IOFile> file;
     bool is_loaded = false;
     std::optional<Kernel::MemoryMode> memory_mode_override = std::nullopt;
 };

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -91,6 +91,7 @@ public:
         std::array<u8, 4> underlying_magic{};
         std::string recommended_compressed_extension;
         std::string recommended_uncompressed_extension;
+        std::unordered_map<std::string, std::vector<u8>> default_metadata;
     };
 
     explicit AppLoader(Core::System& system_, FileUtil::IOFile&& file)

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -12,6 +12,7 @@
 #include "common/settings.h"
 #include "common/string_util.h"
 #include "common/swap.h"
+#include "common/zstd_compression.h"
 #include "core/core.h"
 #include "core/file_sys/ncch_container.h"
 #include "core/file_sys/title_metadata.h"
@@ -34,10 +35,10 @@ namespace Loader {
 using namespace Common::Literals;
 static constexpr u64 UPDATE_TID_HIGH = 0x0004000e00000000;
 
-FileType AppLoader_NCCH::IdentifyType(FileUtil::IOFile& file) {
+FileType AppLoader_NCCH::IdentifyType(FileUtil::IOFile* file) {
     u32 magic;
-    file.Seek(0x100, SEEK_SET);
-    if (1 != file.ReadArray<u32>(&magic, 1))
+    file->Seek(0x100, SEEK_SET);
+    if (1 != file->ReadArray<u32>(&magic, 1))
         return FileType::Error;
 
     if (MakeMagic('N', 'C', 'S', 'D') == magic)
@@ -47,7 +48,7 @@ FileType AppLoader_NCCH::IdentifyType(FileUtil::IOFile& file) {
         return FileType::CXI;
 
     std::unique_ptr<FileUtil::IOFile> file_crypto = HW::UniqueData::OpenUniqueCryptoFile(
-        file.Filename(), "rb", HW::UniqueData::UniqueCryptoFileID::NCCH);
+        file->Filename(), "rb", HW::UniqueData::UniqueCryptoFileID::NCCH);
 
     file_crypto->Seek(0x100, SEEK_SET);
     if (1 != file_crypto->ReadArray<u32>(&magic, 1))
@@ -58,6 +59,16 @@ FileType AppLoader_NCCH::IdentifyType(FileUtil::IOFile& file) {
 
     if (MakeMagic('N', 'C', 'C', 'H') == magic)
         return FileType::CXI;
+
+    std::optional<u32> magic_zstd;
+    if (FileUtil::Z3DSReadIOFile::GetUnderlyingFileMagic(file) != std::nullopt ||
+        FileUtil::Z3DSReadIOFile::GetUnderlyingFileMagic(file_crypto.get()) != std::nullopt) {
+        if (MakeMagic('N', 'C', 'S', 'D') == magic_zstd)
+            return FileType::CCI;
+
+        if (MakeMagic('N', 'C', 'C', 'H') == magic_zstd)
+            return FileType::CXI;
+    }
 
     return FileType::Error;
 }
@@ -394,6 +405,26 @@ ResultStatus AppLoader_NCCH::ReadTitle(std::string& title) {
     title = Common::UTF16ToUTF8(std::u16string{short_title.begin(), title_end});
 
     return ResultStatus::Success;
+}
+
+AppLoader::CompressFileInfo AppLoader_NCCH::GetCompressFileInfo() {
+    CompressFileInfo info{};
+    if (base_ncch.LoadHeader() != ResultStatus::Success) {
+        info.is_supported = false;
+        return info;
+    }
+    info.is_supported = true;
+    info.is_compressed = base_ncch.IsFileCompressed();
+    if (base_ncch.IsNCSD()) {
+        info.underlying_magic = std::array<u8, 4>({'N', 'C', 'S', 'D'});
+        info.recommended_compressed_extension = "zcci";
+        info.recommended_uncompressed_extension = "cci";
+    } else {
+        info.underlying_magic = std::array<u8, 4>({'N', 'C', 'C', 'H'});
+        info.recommended_compressed_extension = "zcxi";
+        info.recommended_uncompressed_extension = "cxi";
+    }
+    return info;
 }
 
 } // namespace Loader

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -424,6 +424,16 @@ AppLoader::CompressFileInfo AppLoader_NCCH::GetCompressFileInfo() {
         info.recommended_compressed_extension = "zcxi";
         info.recommended_uncompressed_extension = "cxi";
     }
+    std::vector<u8> title_info_vec(sizeof(Service::AM::TitleInfo));
+    Service::AM::TitleInfo* title_info =
+        reinterpret_cast<Service::AM::TitleInfo*>(title_info_vec.data());
+    title_info->tid = base_ncch.ncch_header.program_id;
+    title_info->version = base_ncch.ncch_header.version;
+    title_info->size =
+        base_ncch.ncch_header.content_size * base_ncch.ncch_header.GetContentUnitSize();
+    title_info->unused = title_info->type = 0;
+    info.default_metadata.emplace("titleinfo", title_info_vec);
+
     return info;
 }
 

--- a/src/core/loader/ncch.h
+++ b/src/core/loader/ncch.h
@@ -1,4 +1,4 @@
-// Copyright 2014 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -17,17 +17,20 @@ class AppLoader_NCCH final : public AppLoader {
 public:
     AppLoader_NCCH(Core::System& system_, FileUtil::IOFile&& file, const std::string& filepath)
         : AppLoader(system_, std::move(file)), base_ncch(filepath), overlay_ncch(&base_ncch),
-          filepath(filepath) {}
+          filepath(filepath) {
+        filetype = IdentifyType(this->file.get());
+        this->file.reset();
+    }
 
     /**
      * Returns the type of the file
      * @param file FileUtil::IOFile open file
      * @return FileType found, or FileType::Error if this loader doesn't know it
      */
-    static FileType IdentifyType(FileUtil::IOFile& file);
+    static FileType IdentifyType(FileUtil::IOFile* file);
 
     FileType GetFileType() override {
-        return IdentifyType(file);
+        return filetype;
     }
 
     [[nodiscard]] std::span<const u32> GetPreferredRegions() const override {
@@ -71,6 +74,8 @@ public:
 
     ResultStatus ReadTitle(std::string& title) override;
 
+    CompressFileInfo GetCompressFileInfo() override;
+
 private:
     /**
      * Loads .code section into memory for booting
@@ -94,6 +99,7 @@ private:
     std::vector<u32> preferred_regions;
 
     std::string filepath;
+    FileType filetype;
 };
 
 } // namespace Loader

--- a/src/core/loader/smdh.cpp
+++ b/src/core/loader/smdh.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -19,6 +19,10 @@ bool IsValidSMDH(std::span<const u8> smdh_data) {
     u32 magic;
     std::memcpy(&magic, smdh_data.data(), sizeof(u32));
 
+    return Loader::MakeMagic('S', 'M', 'D', 'H') == magic;
+}
+
+bool SMDH::IsValid() const {
     return Loader::MakeMagic('S', 'M', 'D', 'H') == magic;
 }
 

--- a/src/core/loader/smdh.h
+++ b/src/core/loader/smdh.h
@@ -1,4 +1,4 @@
-// Copyright 2016 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -76,6 +76,11 @@ struct SMDH {
     enum Flags {
         Visible = 1 << 0,
     };
+
+    /**
+     * Checks if SMDH is valid.
+     */
+    bool IsValid() const;
 
     /**
      * Gets game icon from SMDH


### PR DESCRIPTION
Adds support for compressed ROM files, with a brand new compressed format using `seekable zstd` as the compression algorithm (`Z3DS` file format). This manages an average compression ratio of 25% for trimmed ROMs (that is, a 1GB file is usually compressed down to 750MB), which is even bigger for non-trimmed ROMs. The ratio highly depends on the game, as some already use compression in their inner files in their romfs partition.

**IMPORTANT: Compression can only be applied to decrypted ROMs, as encrypted ROMs would produce very bad compression ratios (zero or close to zero) due to high entropy.**

# Summary of Changes
- Adds support for `.zcia`, `.zcci`, `.z3dsx` and `.zcxi` files.
- Adds options to compress and decompress files in the QT frontend (`Tools` menu). The Android frontend will be handled in a different PR.
- Adds an option in the `Storage` tab to enable compressing installed CIA contents.

# The Z3DS file format
The `Z3DS` file format is a newly designed format intended to support compressed 3DS ROM files. It was developed with the following key requirements in mind:
- Compression to reduce storage space, with fast decompression prioritised over compression rate.
- Efficient access to the file at any possition (that is, the compression algorithm should allow seeks without having to decompress the whole file).
- The compression algorithm should be easy to integrate by 3rd party applications.
- Support optional generic metadata, so that the original ROM file can be restored, including encryption.

Taking into account the previous requirements, [seekable zstd](https://github.com/facebook/zstd/blob/1dbc2e09084e843f6c0dcc2d0791610015c50979/contrib/seekable_format/README.md) was chosen. This algorithm uses ZSTD as the base, which provides pretty good decompression speeds and compression ratios. The seekable variant allows to break the data into frames so that only a single frame needs to be decompressed when accessing any byte of it, instead of the whole file. ZSTD also supports the `cmake` and `make` build environments, so they can be easily added to 3rd party tools.

## Z3DS Specification
The `Z3DS` file format starts with a 0x20 byte file header:

| Offset (bytes) | Field                        | Type | Expected Value          | Purpose / Notes                                                                                                                     |
|:---------------:|:----------------------------:|:----------------------:|-----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
| `0x00`         | `magic`             | `u8[4]`     | ASCII `"Z3DS"`                | File‑type identifier (magic number). Must match exactly.                                                                            |
| `0x04`         | `underlying_magic`  | `u8[4]`     | `"NCCH"`, `"NCSD"`, etc.    | File‑type identifier (magic number) of the original uncompressed image. Enables easy recognition of the compressed file. |
| `0x08`         | `version`           | `u8`        | `0x01`                         | Format version. To be incremented on incompatible spec changes.                                                                             |
| `0x09`         | `reserved`          | `u8`        | `0x00`                         | Reserved for future use, must be zeroed by writers and ignored by readers.                                                         |
| `0x0A`         | `header_size`       | `u16`       | Calculated                         | Total size of this header in bytes. Allows forward compatibility.                                                              |
| `0x0C`         | `metadata_size`     | `u32`       | Calculated                         | Length of the optional metadata block that follows the header. If no metadata is present this field is zero. Metadata length should always be aligned to 16 bytes.                                                                       |
| `0x10`         | `compressed_size`   | `u64`       | Calculated                         | Length of the compressed ROM data. Data always starts on a 16‑byte boundary due to the metadata length requirements.                             |
| `0x18`         | `uncompressed_size` | `u64`       | Calculated                         | Original size of the ROM before compression.                                     |

Following the header is the metadata, if it exists. Following the metadata is the compressed ROM data. Therefore, metadata is always located in file offset `header_size` (if metadata exists) and the compressed ROM data is always located in file offset `header_size + metadata_size`.

### Z3DS Metadata (v1)

The optional metadata block immediately follows the header.  
It begins with a **version byte**, followed by **zero or more items**, and terminates with a single `TYPE_END` item.  
After the `TYPE_END` entry, the writer **may** add zero‑padding so that the next section (compressed ROM) starts on a 16‑byte boundary, satisfying the global alignment rule.

#### Top‑level structure

| Offset (bytes) | Field    | Type | Expected Value | Description                                                |
|:---------------:|:----------:|:-------------:|:----------------:|------------------------------------------------------------|
| `0x00`         | `version`| `u8`        | **`0x01`**     | Metadata format version.|
| `0x01`       | `items`  |  `-` (repeat)  | `-`              | Repeating **Item** records, ending with an item with type `TYPE_END`.      |
| `...`            | padding  | `u8[]`      | `0x00`         | Optional zeros to reach a 16‑byte file‑alignment boundary. |

#### Item record layout

| Offset (rel.) | Sub‑field   | Type | Expected Value      | Notes                                                                  |
|:--------------:|:-------------:|:-------------:|:---------------------:|------------------------------------------------------------------------|
| `+0x00`          | `type`      | `u8`        | `0x01` = `TYPE_BINARY`, `0x00` = `TYPE_END` | Item payload kind. `TYPE_END` marks **end of list**. Azahar currently only supports the generic `TYPE_BINARY` type, leaving interpretation of the value to the reader. If ever needed, further types may be added. |
| `+0x01`          | `name_len`  | `u8`        | `0 – 255`           | Length of UTF‑8 key string (zero for `TYPE_END`).                    |
| `+0x02`          | `data_len`  | `u16`    | `0 – 65535`         | Length of binary payload (zero for `TYPE_END`).                      |
| `+0x04`          | `name`      | `u8[name_len]` | UTF‑8 bytes      | Key. No NUL terminator.                   |
| `+0x04+name_len`           | `data`      | `u8[data_len]` | Raw bytes        | Value.                                        |

**Termination:**  
- The writer appends **one `TYPE_END` item** (`0x00 00 00 00`).  
- Parsers must stop reading when they encounter the first `TYPE_END`.  
- Any remaining bytes up to `metadata_size` are padding and should be skipped.

**Defined Metadata**
Azahar currently appends the following metadata to compressed files using the built-in converter:
- `compressor`: The name of the compressor, for Azahar it's `Azahar (version)`.
- `date`: Date and time when the compression took place (ISO format)
- `maxframesize`: Maximum seekable zstd frame size used (the zstd library does not store this nor needs it for decompression).
- `titleinfo`: *[AM_TitleInfo](https://www.3dbrew.org/wiki/Application_Manager_Services#TitleInfo)* of the compressed ROM (not present in `z3dsx`).
- `smdh`: *[SMDH](https://www.3dbrew.org/wiki/SMDH)* found in the CIA metadata (only present in `zcia`).

### Compressed ROM
The compressed ROM follows the metadata. Currently only `seekable zstd` is supported. The data can be passed directly to the zstd library without any special processing. The following max frame sizes are used:
- For `CCI`, `CXI` and `3DSX`: 256KB
- For `CIA`: 32MB

Bigger frame sizes are allowed, however accessing a single byte in a frame needs decompression of the entire frame, so be careful when increasing the frame size, as it will require more processing time. Azahar has a romfs access cache, which should reduce the need of decompressing frames multiple times.
