### PR TITLE
desktop: Fix horizontal centering single window mode

### DIFF
--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -121,10 +121,10 @@ FramebufferLayout SingleFrameLayout(u32 width, u32 height, bool swapped, bool up
                       width - Settings::values.screen_bottom_leftright_padding.GetValue(),
                       height - Settings::values.screen_bottom_topbottom_padding.GetValue()};
     } else {
-        top_screen = top_screen.TranslateY((height - top_screen.GetHeight()) / 2);
-        bot_screen = bot_screen.TranslateY((height - bot_screen.GetHeight()) / 2);
-        top_screen = top_screen.TranslateX((width - top_screen.GetWidth()) / 2);
-        bot_screen = bot_screen.TranslateX((width - bot_screen.GetWidth()) / 2);
+        top_screen = top_screen.TranslateX((width - top_screen.GetWidth()) / 2)
+                         .TranslateY((height - top_screen.GetHeight()) / 2);
+        bot_screen = bot_screen.TranslateX((width - bot_screen.GetWidth()) / 2)
+                         .TranslateY((height - bot_screen.GetHeight()) / 2);
     }
 #endif
 

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -123,6 +123,8 @@ FramebufferLayout SingleFrameLayout(u32 width, u32 height, bool swapped, bool up
     } else {
         top_screen = top_screen.TranslateY((height - top_screen.GetHeight()) / 2);
         bot_screen = bot_screen.TranslateY((height - bot_screen.GetHeight()) / 2);
+        top_screen = top_screen.TranslateX((width - top_screen.GetWidth()) / 2);
+        bot_screen = bot_screen.TranslateX((width - bot_screen.GetWidth()) / 2);
     }
 #endif
 


### PR DESCRIPTION
Fixes the bug #1109 where single screen layout / separate windows layout was not correctly centering the screen in full screen or with windows wider than the content. Seems to have been introduced by the aspect ratio code.