### PR TITLE
math_util.cpp: Don't set `GCC novector` pragma when using GCC <14

### DIFF
--- a/src/common/math_util.cpp
+++ b/src/common/math_util.cpp
@@ -19,7 +19,7 @@
 #define DISABLE_VECTORIZE __pragma(loop(no_vector))
 #elif defined(__clang__)
 #define DISABLE_VECTORIZE _Pragma("clang loop vectorize(disable)")
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) && (__GNUC__ >= 14)
 #define DISABLE_VECTORIZE _Pragma("GCC novector")
 #else
 #define DISABLE_VECTORIZE


### PR DESCRIPTION
Closes #1195