### PR TITLE
Installer: cleanup NSIS, remove unused code, correct minimum version

### DIFF
--- a/src/installer/citra.nsi
+++ b/src/installer/citra.nsi
@@ -107,7 +107,7 @@ Function .onInit
   !insertmacro MULTIUSER_INIT
 
   ; Keep in sync with build_info.txt
-  !define MIN_WIN10_VERSION 1703
+  !define MIN_WIN10_VERSION 1607
   ${IfNot} ${AtLeastwin10}
   ${OrIfNot} ${AtLeastWaaS} ${MIN_WIN10_VERSION}
     MessageBox MB_OK "At least Windows 10 version ${MIN_WIN10_VERSION} is required."
@@ -161,9 +161,6 @@ Section "Base"
   !insertmacro UPDATE_DISPLAYNAME
 
   ; Create start menu and desktop shortcuts
-  Delete "$SMPROGRAMS\${PRODUCT_NAME}\$DisplayName.lnk"
-  Delete "$SMPROGRAMS\${PRODUCT_NAME}\Uninstall $DisplayName.lnk"
-  RMDir "$SMPROGRAMS\${PRODUCT_NAME}"
   CreateShortCut "$SMPROGRAMS\$DisplayName.lnk" "$INSTDIR\azahar.exe"
   ${If} $DesktopShortcut == 1
     CreateShortCut "$DESKTOP\$DisplayName.lnk" "$INSTDIR\azahar.exe"
@@ -200,28 +197,19 @@ Section Uninstall
   Delete "$DESKTOP\$DisplayName.lnk"
   Delete "$SMPROGRAMS\$DisplayName.lnk"
 
-  Delete "$SMPROGRAMS\${PRODUCT_NAME}\$DisplayName.lnk"
-  Delete "$SMPROGRAMS\${PRODUCT_NAME}\Uninstall $DisplayName.lnk"
-  RMDir "$SMPROGRAMS\${PRODUCT_NAME}"
-
   ; Be a bit careful to not delete files a user may have put into the install directory.
   Delete "$INSTDIR\*.dll"
   Delete "$INSTDIR\azahar.exe"
   Delete "$INSTDIR\azahar-room.exe"
-  Delete "$INSTDIR\license.txt"
   Delete "$INSTDIR\qt.conf"
-  Delete "$INSTDIR\README.md"
   Delete "$INSTDIR\uninst.exe"
-  RMDir /r "$INSTDIR\dist"
   RMDir /r "$INSTDIR\plugins"
   RMDir /r "$INSTDIR\scripting"
-  ; This should never be distributed via the installer, but just in case it is
-  Delete "$INSTDIR\tests.exe"
-  ; Delete the installation directory if there are no files left
   RMDir "$INSTDIR"
 
   DeleteRegKey SHCTX "${PRODUCT_UNINST_KEY}"
   DeleteRegKey SHCTX "${PRODUCT_DIR_REGKEY}"
+  DeleteRegKey HKCU "Software\Classes\discord-1345366770436800533"
 
   SetAutoClose true
 SectionEnd


### PR DESCRIPTION
Several NSIS cleanups for the Windows installer/unistaller, as promised earlier.
Includes:
- Remove deletion of files no longer distributed (especially due to 1e8cc02) and other old leftovers during uninstall
- Remove deletion of old rc shortcuts during upgrades, as it was never needed (the application always performs a full uninstall, which includes shortcuts)
- Correct minimum Windows version to 10 1607, as it is the minimum for Qt and everything else we need (note that there is a [bug](https://bugreports.qt.io/browse/QTBUG-134075) preventing startup in the current Qt on 1607. [Fixed in 6.9.1](https://code.qt.io/cgit/qt/qtreleasenotes.git/about/qt/6.9.1/release-note.md#:~:text=QTBUG%2D134075%20Windows%20Server%202016%20is%20no%20longer%20working), recommend upgrading soon)
- Delete the Discord RPC registry entry during uninstall