### PR TITLE
Z3DS: Mark compressed files in UI and other minor fixes

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/adapters/GameAdapter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/adapters/GameAdapter.kt
@@ -343,8 +343,9 @@ class GameAdapter(private val activity: AppCompatActivity, private val inflater:
         bottomSheetView.findViewById<TextView>(R.id.about_game_title).text = game.title
         bottomSheetView.findViewById<TextView>(R.id.about_game_company).text = game.company
         bottomSheetView.findViewById<TextView>(R.id.about_game_region).text = game.regions
-        bottomSheetView.findViewById<TextView>(R.id.about_game_id).text = "ID: " + String.format("%016X", game.titleId)
-        bottomSheetView.findViewById<TextView>(R.id.about_game_filename).text = "File: " + game.filename
+        bottomSheetView.findViewById<TextView>(R.id.about_game_id).text = context.getString(R.string.game_context_id) + " " + String.format("%016X", game.titleId)
+        bottomSheetView.findViewById<TextView>(R.id.about_game_filename).text = context.getString(R.string.game_context_file) + " " + game.filename
+        bottomSheetView.findViewById<TextView>(R.id.about_game_filetype).text = context.getString(R.string.game_context_type) + " " + game.fileType
         GameIconUtils.loadGameIcon(activity, game, bottomSheetView.findViewById(R.id.game_icon))
 
         bottomSheetView.findViewById<MaterialButton>(R.id.about_game_play).setOnClickListener {

--- a/src/android/app/src/main/java/org/citra/citra_emu/model/Game.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/model/Game.kt
@@ -1,4 +1,4 @@
-// Copyright Citra Emulator Project / Lime3DS Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -26,7 +26,8 @@ class Game(
     val isSystemTitle: Boolean = false,
     val isVisibleSystemTitle: Boolean = false,
     val icon: IntArray? = null,
-    val filename: String
+    val fileType: String = "",
+    val filename: String,
 ) : Parcelable {
     val keyAddedToLibraryTime get() = "${filename}_AddedToLibraryTime"
     val keyLastPlayedTime get() = "${filename}_LastPlayed"

--- a/src/android/app/src/main/java/org/citra/citra_emu/model/GameInfo.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/model/GameInfo.kt
@@ -13,16 +13,17 @@ class GameInfo(path: String) {
 
     init {
         pointer = initialize(path)
-        if (pointer == 0L) {
-            throw IOException()
-        }
     }
 
     protected external fun finalize()
 
     external fun getTitle(): String
 
+    external fun isValid(): Boolean
+
     external fun isEncrypted(): Boolean
+
+    external fun getTitleID(): Long
 
     external fun getRegions(): String
 
@@ -30,7 +31,11 @@ class GameInfo(path: String) {
 
     external fun getIcon(): IntArray?
 
+    external fun isSystemTitle(): Boolean
+
     external fun getIsVisibleSystemTitle(): Boolean
+
+    external fun getFileType(): String
 
     companion object {
         @JvmStatic

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/GameHelper.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/GameHelper.kt
@@ -70,29 +70,26 @@ object GameHelper {
 
     fun getGame(uri: Uri, isInstalled: Boolean, addedToLibrary: Boolean): Game {
         val filePath = uri.toString()
-        var gameInfo: GameInfo? = try {
-            GameInfo(filePath)
-        } catch (e: IOException) {
-            null
+        var gameInfo: GameInfo? = GameInfo(filePath)
+
+        if (gameInfo?.isValid() == false) {
+            gameInfo = null
         }
 
-        var isEncrypted = false
-        if (gameInfo?.isEncrypted() == true) {
-            gameInfo = null
-            isEncrypted = true
-        }
+        val isEncrypted = gameInfo?.isEncrypted() == true
 
         val newGame = Game(
             (gameInfo?.getTitle() ?: FileUtil.getFilename(uri)).replace("[\\t\\n\\r]+".toRegex(), " "),
             filePath.replace("\n", " "),
             filePath,
-            NativeLibrary.getTitleId(filePath),
+            gameInfo?.getTitleID() ?: 0,
             gameInfo?.getCompany() ?: "",
-            gameInfo?.getRegions() ?: (if (isEncrypted) { CitraApplication.appContext.getString(R.string.unsupported_encrypted) } else { CitraApplication.appContext.getString(R.string.invalid_region) }),
+            if (isEncrypted) { CitraApplication.appContext.getString(R.string.unsupported_encrypted) } else { gameInfo?.getRegions() ?: "" },
             isInstalled,
-            NativeLibrary.getIsSystemTitle(filePath),
+            gameInfo?.isSystemTitle() ?: false,
             gameInfo?.getIsVisibleSystemTitle() ?: false,
             gameInfo?.getIcon(),
+            gameInfo?.getFileType() ?: "",
             if (FileUtil.isNativePath(filePath)) {
                 CitraApplication.documentsTree.getFilename(filePath)
             } else {

--- a/src/android/app/src/main/res/layout/dialog_about_game.xml
+++ b/src/android/app/src/main/res/layout/dialog_about_game.xml
@@ -86,12 +86,21 @@
                 tools:text="Application Filename" />
 
             <TextView
-                android:id="@+id/about_game_playtime"
+                android:id="@+id/about_game_filetype"
                 style="?attr/textAppearanceBodyMedium"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 app:layout_constraintStart_toStartOf="@id/about_game_title"
                 app:layout_constraintTop_toBottomOf="@+id/about_game_filename"
+                tools:text="Game Filetype" />
+
+            <TextView
+                android:id="@+id/about_game_playtime"
+                style="?attr/textAppearanceBodyMedium"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintStart_toStartOf="@id/about_game_title"
+                app:layout_constraintTop_toBottomOf="@+id/about_game_filetype"
                 tools:text="Game Playtime" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -535,7 +535,6 @@
     <string name="save_load_error">Save/Load Error</string>
     <string name="fatal_error">Fatal Error</string>
     <string name="fatal_error_message">A fatal error occurred. Check the log for details.\nContinuing emulation may result in crashes and bugs.</string>
-    <string name="invalid_region">Invalid region</string>
     <string name="unsupported_encrypted">Unsupported encrypted application</string>
 
     <!-- Disk Shader Cache -->
@@ -561,6 +560,9 @@
     <string name="create_shortcut">Create Shortcut</string>
     <string name="shortcut_name_empty">Shortcut name cannot be empty</string>
     <string name="shortcut_image_stretch_toggle">Stretch to fit image</string>
+    <string name="game_context_id">ID:</string>
+    <string name="game_context_file">File:</string>
+    <string name="game_context_type">Type:</string>
 
     <!-- Performance Overlay settings -->
     <string name="performance_overlay_show">Show Performance Overlay</string>

--- a/src/citra_qt/configuration/configure_per_game.cpp
+++ b/src/citra_qt/configuration/configure_per_game.cpp
@@ -173,8 +173,8 @@ void ConfigurePerGame::LoadConfiguration() {
 
     ui->display_filepath->setText(QString::fromStdString(filename));
 
-    ui->display_format->setText(
-        QString::fromStdString(Loader::GetFileTypeString(loader->GetFileType())));
+    ui->display_format->setText(QString::fromStdString(
+        Loader::GetFileTypeString(loader->GetFileType(), loader->IsFileCompressed())));
 
     const auto valueText = ReadableByteSize(FileUtil::GetSize(filename));
     ui->display_size->setText(valueText);

--- a/src/citra_qt/game_list_worker.cpp
+++ b/src/citra_qt/game_list_worker.cpp
@@ -1,3 +1,7 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
 // Copyright 2018 yuzu emulator team
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
@@ -112,8 +116,8 @@ void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsign
                                          res == Loader::ResultStatus::ErrorEncrypted),
                     new GameListItemCompat(compatibility),
                     new GameListItemRegion(smdh),
-                    new GameListItem(
-                        QString::fromStdString(Loader::GetFileTypeString(loader->GetFileType()))),
+                    new GameListItem(QString::fromStdString(Loader::GetFileTypeString(
+                        loader->GetFileType(), loader->IsFileCompressed()))),
                     new GameListItemSize(FileUtil::GetSize(physical_name)),
                     new GameListItemPlayTime(play_time_manager.GetPlayTime(program_id)),
                 },

--- a/src/core/loader/3dsx.cpp
+++ b/src/core/loader/3dsx.cpp
@@ -346,6 +346,10 @@ AppLoader::CompressFileInfo AppLoader_THREEDSX::GetCompressFileInfo() {
     return info;
 }
 
+bool AppLoader_THREEDSX::IsFileCompressed() {
+    return FileUtil::Z3DSReadIOFile::GetUnderlyingFileMagic(file.get()) != std::nullopt;
+}
+
 ResultStatus AppLoader_THREEDSX::ReadIcon(std::vector<u8>& buffer) {
     if (!file->IsOpen())
         return ResultStatus::Error;

--- a/src/core/loader/3dsx.h
+++ b/src/core/loader/3dsx.h
@@ -41,6 +41,8 @@ public:
 
     CompressFileInfo GetCompressFileInfo() override;
 
+    bool IsFileCompressed() override;
+
 private:
     std::string filename;
     std::string filepath;

--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -63,18 +63,18 @@ FileType GuessFromExtension(const std::string& extension_) {
     return FileType::Unknown;
 }
 
-const char* GetFileTypeString(FileType type) {
+const char* GetFileTypeString(FileType type, bool is_compressed) {
     switch (type) {
     case FileType::CCI:
-        return "NCSD";
+        return is_compressed ? "NCSD (Z)" : "NCSD";
     case FileType::CXI:
-        return "NCCH";
+        return is_compressed ? "NCCH (Z)" : "NCCH";
     case FileType::CIA:
-        return "CIA";
+        return is_compressed ? "CIA (Z)" : "CIA";
     case FileType::ELF:
         return "ELF";
     case FileType::THREEDSX:
-        return "3DSX";
+        return is_compressed ? "3DSX (Z)" : "3DSX";
     case FileType::ARTIC:
         return "ARTIC";
     case FileType::Error:

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -60,7 +60,7 @@ FileType GuessFromExtension(const std::string& extension);
 /**
  * Convert a FileType into a string which can be displayed to the user.
  */
-const char* GetFileTypeString(FileType type);
+const char* GetFileTypeString(FileType type, bool is_compressed = false);
 
 /// Return type for functions in Loader namespace
 enum class ResultStatus {
@@ -292,6 +292,10 @@ public:
         CompressFileInfo info{};
         info.is_supported = false;
         return info;
+    }
+
+    virtual bool IsFileCompressed() {
+        return false;
     }
 
 protected:

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -60,9 +60,12 @@ FileType AppLoader_NCCH::IdentifyType(FileUtil::IOFile* file) {
     if (MakeMagic('N', 'C', 'C', 'H') == magic)
         return FileType::CXI;
 
-    std::optional<u32> magic_zstd;
-    if (FileUtil::Z3DSReadIOFile::GetUnderlyingFileMagic(file) != std::nullopt ||
-        FileUtil::Z3DSReadIOFile::GetUnderlyingFileMagic(file_crypto.get()) != std::nullopt) {
+    std::optional<u32> magic_zstd = FileUtil::Z3DSReadIOFile::GetUnderlyingFileMagic(file);
+    if (!magic_zstd.has_value()) {
+        magic_zstd = FileUtil::Z3DSReadIOFile::GetUnderlyingFileMagic(file_crypto.get());
+    }
+
+    if (magic_zstd.has_value()) {
         if (MakeMagic('N', 'C', 'S', 'D') == magic_zstd)
             return FileType::CCI;
 
@@ -435,6 +438,13 @@ AppLoader::CompressFileInfo AppLoader_NCCH::GetCompressFileInfo() {
     info.default_metadata.emplace("titleinfo", title_info_vec);
 
     return info;
+}
+
+bool AppLoader_NCCH::IsFileCompressed() {
+    if (base_ncch.LoadHeader() != ResultStatus::Success) {
+        return false;
+    }
+    return base_ncch.IsFileCompressed();
 }
 
 } // namespace Loader

--- a/src/core/loader/ncch.h
+++ b/src/core/loader/ncch.h
@@ -76,6 +76,8 @@ public:
 
     CompressFileInfo GetCompressFileInfo() override;
 
+    bool IsFileCompressed() override;
+
 private:
     /**
      * Loads .code section into memory for booting


### PR DESCRIPTION
On QT, adds a `(Z)` marker for compressed Z3DS files to the file type column in the application list. On Android, adds a new `Type` line for the application info, that displays the same thing as file type on QT.

Furthermore, a bit of refractoring was done on Android on the `GameInfo` class that:
- Makes the code cleaner without having to use magic numbers for encryption marking (wasn't working properly anyways). This had to happen to be able to store the file type without having to call NativeLibrary (requires creating a new loader and parsing the file again, which is not efficient).
- Stores the title ID, so that there is no need to call NativeLibrary to fetch the title ID (not efficient as explained above).
- Fixes the logic for building the update data Title ID.
- Moves the logic to delect if it's a system title to the `GameInfo` class, to prevent having to call NativeLibrary (again not efficient).

These changes reduce the amount of times a `Loader` needs to be constructed from 3 to 1.