### PR TITLE
(Re) renderer_vulkan: Add second screen opacity support

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -1185,8 +1185,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     "%",
                     FloatSetting.SECOND_SCREEN_OPACITY.key,
                     FloatSetting.SECOND_SCREEN_OPACITY.defaultValue,
-                    // TODO: Remove graphics API check when #895 is merged
-                    isEnabled = IntSetting.SCREEN_LAYOUT.int == 5 && IntSetting.GRAPHICS_API.int == 1
+                    isEnabled = IntSetting.SCREEN_LAYOUT.int == 5
                 )
             )
             add(HeaderSetting(R.string.bg_color, R.string.bg_color_description))

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -170,7 +170,7 @@ bg_red =
 bg_blue =
 bg_green =
 
-# Opacity of second layer when using custom layout option (bottom screen unless swapped). Useful if positioning on top of the first layer. OpenGL only.
+# Opacity of second layer when using custom layout option (bottom screen unless swapped). Useful if positioning on top of the first layer.
 custom_second_layer_opacity =
 
 # Whether and how Stereoscopic 3D should be rendered

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -455,7 +455,7 @@
     <string name="bg_red">Red</string>
     <string name="bg_green">Green</string>
     <string name="bg_blue">Blue</string>
-    <string name="second_screen_opacity">Custom Layout Second Screen Opacity (OpenGL Only)</string>
+    <string name="second_screen_opacity">Custom Layout Second Screen Opacity</string>
     <string name="second_screen_opacity_description">The opacity of the second 3DS screen when using a custom screen layout. Useful if the second screen is to be positioned on top of the first screen.</string>
     <string name="emulation_small_screen_position">Small Screen Position</string>
     <string name="small_screen_position_description">Where should the small screen appear relative to the large one in Large Screen Layout?</string>

--- a/src/citra_qt/configuration/configure_layout.ui
+++ b/src/citra_qt/configuration/configure_layout.ui
@@ -531,7 +531,7 @@
             <item>
              <widget class="QLabel" name="lb_opacity_second_layer">
               <property name="text">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Bottom Screen Opacity % (OpenGL Only)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Bottom Screen Opacity %&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -710,10 +710,7 @@ void RendererOpenGL::DrawScreens(const Layout::FramebufferLayout& layout, bool f
 }
 
 void RendererOpenGL::ApplySecondLayerOpacity(bool isPortrait) {
-    // TODO: Allow for second layer opacity in portrait mode android
-
-    if (!isPortrait &&
-        (Settings::values.layout_option.GetValue() == Settings::LayoutOption::CustomLayout) &&
+    if (Settings::values.layout_option.GetValue() == Settings::LayoutOption::CustomLayout &&
         Settings::values.custom_second_layer_opacity.GetValue() < 100) {
         state.blend.src_rgb_func = GL_CONSTANT_ALPHA;
         state.blend.src_a_func = GL_CONSTANT_ALPHA;
@@ -724,8 +721,7 @@ void RendererOpenGL::ApplySecondLayerOpacity(bool isPortrait) {
 }
 
 void RendererOpenGL::ResetSecondLayerOpacity(bool isPortrait) {
-    if (!isPortrait &&
-        (Settings::values.layout_option.GetValue() == Settings::LayoutOption::CustomLayout) &&
+    if (Settings::values.layout_option.GetValue() == Settings::LayoutOption::CustomLayout &&
         Settings::values.custom_second_layer_opacity.GetValue() < 100) {
         state.blend.src_rgb_func = GL_ONE;
         state.blend.dst_rgb_func = GL_ZERO;

--- a/src/video_core/renderer_vulkan/renderer_vulkan.h
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.h
@@ -98,12 +98,16 @@ private:
     void DrawScreens(Frame* frame, const Layout::FramebufferLayout& layout, bool flipped);
     void DrawBottomScreen(const Layout::FramebufferLayout& layout,
                           const Common::Rectangle<u32>& bottom_screen);
+
     void DrawTopScreen(const Layout::FramebufferLayout& layout,
                        const Common::Rectangle<u32>& top_screen);
     void DrawSingleScreen(u32 screen_id, float x, float y, float w, float h,
                           Layout::DisplayOrientation orientation);
     void DrawSingleScreenStereo(u32 screen_id_l, u32 screen_id_r, float x, float y, float w,
                                 float h, Layout::DisplayOrientation orientation);
+
+    void ApplySecondLayerOpacity(float alpha);
+
     void LoadFBToScreenInfo(const Pica::FramebufferConfig& framebuffer, ScreenInfo& screen_info,
                             bool right_eye);
     void FillScreen(Common::Vec3<u8> color, const TextureInfo& texture);


### PR DESCRIPTION
Re-opened from #895

Closes #24

Review depends on #1254

> Added support for the second screen opacity option to the vulkan renderer as well because previously it only worked on OpenGL
> 
> Closes https://github.com/azahar-emu/azahar/issues/24