### PR TITLE
Capitalize first letter of builtin shaders

### DIFF
--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -160,11 +160,11 @@ void Config::ReadValues() {
 
     ReadSetting("Renderer", Settings::values.render_3d);
     ReadSetting("Renderer", Settings::values.factor_3d);
-    std::string default_shader = "none (builtin)";
+    std::string default_shader = "None (builtin)";
     if (Settings::values.render_3d.GetValue() == Settings::StereoRenderOption::Anaglyph)
-        default_shader = "dubois (builtin)";
+        default_shader = "Dubois (builtin)";
     else if (Settings::values.render_3d.GetValue() == Settings::StereoRenderOption::Interlaced)
-        default_shader = "horizontal (builtin)";
+        default_shader = "Horizontal (builtin)";
     Settings::values.pp_shader_name =
         sdl2_config->GetString("Renderer", "pp_shader_name", default_shader);
     ReadSetting("Renderer", Settings::values.filter_mode);

--- a/src/citra_qt/configuration/configure_enhancements.cpp
+++ b/src/citra_qt/configuration/configure_enhancements.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/citra_qt/configuration/configure_enhancements.cpp
+++ b/src/citra_qt/configuration/configure_enhancements.cpp
@@ -75,7 +75,7 @@ void ConfigureEnhancements::updateShaders(Settings::StereoRenderOption stereo_op
 
     if (stereo_option == Settings::StereoRenderOption::Interlaced ||
         stereo_option == Settings::StereoRenderOption::ReverseInterlaced) {
-        ui->shader_combobox->addItem(QStringLiteral("horizontal (builtin)"));
+        ui->shader_combobox->addItem(QStringLiteral("Horizontal (builtin)"));
         ui->shader_combobox->setCurrentIndex(0);
         ui->shader_combobox->setEnabled(false);
         return;
@@ -83,10 +83,10 @@ void ConfigureEnhancements::updateShaders(Settings::StereoRenderOption stereo_op
 
     std::string current_shader;
     if (stereo_option == Settings::StereoRenderOption::Anaglyph) {
-        ui->shader_combobox->addItem(QStringLiteral("dubois (builtin)"));
+        ui->shader_combobox->addItem(QStringLiteral("Dubois (builtin)"));
         current_shader = Settings::values.anaglyph_shader_name.GetValue();
     } else {
-        ui->shader_combobox->addItem(QStringLiteral("none (builtin)"));
+        ui->shader_combobox->addItem(QStringLiteral("None (builtin)"));
         current_shader = Settings::values.pp_shader_name.GetValue();
     }
 

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -566,8 +566,8 @@ struct Values {
     Setting<s32> cardboard_y_shift{0, "cardboard_y_shift"};
 
     SwitchableSetting<bool> filter_mode{true, "filter_mode"};
-    SwitchableSetting<std::string> pp_shader_name{"none (builtin)", "pp_shader_name"};
-    SwitchableSetting<std::string> anaglyph_shader_name{"dubois (builtin)", "anaglyph_shader_name"};
+    SwitchableSetting<std::string> pp_shader_name{"None (builtin)", "pp_shader_name"};
+    SwitchableSetting<std::string> anaglyph_shader_name{"Dubois (builtin)", "anaglyph_shader_name"};
 
     SwitchableSetting<bool> dump_textures{false, "dump_textures"};
     SwitchableSetting<bool> custom_textures{false, "custom_textures"};

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -367,7 +367,7 @@ void RendererOpenGL::ReloadShader() {
     // Link shaders and get variable locations
     std::string shader_data = fragment_shader_precision_OES;
     if (Settings::values.render_3d.GetValue() == Settings::StereoRenderOption::Anaglyph) {
-        if (Settings::values.anaglyph_shader_name.GetValue() == "dubois (builtin)") {
+        if (Settings::values.anaglyph_shader_name.GetValue() == "Dubois (builtin)") {
             shader_data += HostShaders::OPENGL_PRESENT_ANAGLYPH_FRAG;
         } else {
             std::string shader_text = OpenGL::GetPostProcessingShaderCode(
@@ -384,7 +384,7 @@ void RendererOpenGL::ReloadShader() {
                    Settings::StereoRenderOption::ReverseInterlaced) {
         shader_data += HostShaders::OPENGL_PRESENT_INTERLACED_FRAG;
     } else {
-        if (Settings::values.pp_shader_name.GetValue() == "none (builtin)") {
+        if (Settings::values.pp_shader_name.GetValue() == "None (builtin)") {
             shader_data += HostShaders::OPENGL_PRESENT_FRAG;
         } else {
             std::string shader_text = OpenGL::GetPostProcessingShaderCode(


### PR DESCRIPTION
Capitalize the first letter of the built-in post-processing shaders for consistency of UI.

This has been bugging me