### PR TITLE
qt: Fix Azahar icon being accessed incorrectly in about + window icon

### DIFF
--- a/src/citra_qt/aboutdialog.cpp
+++ b/src/citra_qt/aboutdialog.cpp
@@ -11,7 +11,6 @@ AboutDialog::AboutDialog(QWidget* parent)
     : QDialog(parent, Qt::WindowTitleHint | Qt::WindowCloseButtonHint | Qt::WindowSystemMenuHint),
       ui(std::make_unique<Ui::AboutDialog>()) {
     ui->setupUi(this);
-    ui->labelLogo->setPixmap(QIcon::fromTheme(QStringLiteral("azahar")).pixmap(200));
     ui->labelBuildInfo->setText(ui->labelBuildInfo->text().arg(
         QString::fromUtf8(Common::g_build_fullname), QString::fromUtf8(Common::g_scm_branch),
         QString::fromUtf8(Common::g_scm_desc), QString::fromUtf8(Common::g_build_date).left(10)));

--- a/src/citra_qt/aboutdialog.ui
+++ b/src/citra_qt/aboutdialog.ui
@@ -27,7 +27,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/azahar.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/default/256x256/azahar.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </widget>
        </item>

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -9,6 +9,7 @@
 #include <thread>
 #include <QFileDialog>
 #include <QFutureWatcher>
+#include <QIcon>
 #include <QLabel>
 #include <QMessageBox>
 #include <QPalette>
@@ -330,8 +331,6 @@ GMainWindow::GMainWindow(Core::System& system_)
     ui->setupUi(this);
     statusBar()->hide();
 
-    setWindowIcon(QIcon(QString::fromStdString(":/icons/azahar.png")));
-
     default_theme_paths = QIcon::themeSearchPaths();
     UpdateUITheme();
 
@@ -389,6 +388,10 @@ GMainWindow::GMainWindow(Core::System& system_)
     LOG_INFO(Frontend, "Host RAM: {:.2f} GiB", mem_info.total_physical_memory / f64{1_GiB});
     LOG_INFO(Frontend, "Host Swap: {:.2f} GiB", mem_info.total_swap_memory / f64{1_GiB});
     UpdateWindowTitle();
+
+    QIcon azahar_icon = QIcon(QString::fromStdString(":/icons/default/256x256/azahar.png"));
+    render_window->setWindowIcon(azahar_icon);
+    secondary_window->setWindowIcon(azahar_icon);
 
     show();
 


### PR DESCRIPTION
Currently, the Azahar logo is being incorrectly retrieved for use in the About menu and for the window app icon.

This results in a missing logo in the About menu and a missing window icon in certain Linux environments.

With the changes in this PR, both of these issues have been resolved.