### PR TITLE
Use MacOS-specific refresh rate check to avoid SDL race condition

### DIFF
--- a/src/common/apple_utils.h
+++ b/src/common/apple_utils.h
@@ -4,6 +4,7 @@
 
 namespace AppleUtils {
 
+float GetRefreshRate();
 int IsLowPowerModeEnabled();
 
-}
+} // namespace AppleUtils

--- a/src/common/apple_utils.mm
+++ b/src/common/apple_utils.mm
@@ -2,9 +2,28 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#import <Cocoa/Cocoa.h>
+#import <CoreGraphics/CoreGraphics.h>
 #import <Foundation/Foundation.h>
 
 namespace AppleUtils {
+
+float GetRefreshRate() { // TODO: How does this handle multi-monitor? -OS
+    NSScreen* screen = [NSScreen mainScreen];
+    if (screen) {
+        NSDictionary* screenInfo = [screen deviceDescription];
+        CGDirectDisplayID displayID =
+            (CGDirectDisplayID)[screenInfo[@"NSScreenNumber"] unsignedIntValue];
+        CGDisplayModeRef displayMode = CGDisplayCopyDisplayMode(displayID);
+        if (displayMode) {
+            CGFloat refreshRate = CGDisplayModeGetRefreshRate(displayMode);
+            CFRelease(displayMode);
+            return refreshRate;
+        }
+    }
+
+    return 60; // Something went wrong, so just return a generic value
+}
 
 int IsLowPowerModeEnabled() {
     return (int)[NSProcessInfo processInfo].lowPowerModeEnabled;

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -60,8 +60,12 @@ constexpr static std::array<vk::DescriptorSetLayoutBinding, 1> PRESENT_BINDINGS 
 
 namespace {
 static bool IsLowRefreshRate() {
-#ifdef ENABLE_SDL2
-    if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+#if defined(__APPLE__) || defined(ENABLE_SDL2)
+#ifdef __APPLE__ // Need a special implementation because MacOS kills itself in disgust if the
+                 // input thread calls SDL_PumpEvents at the same time as we're in SDL_Init here.
+    const auto cur_refresh_rate = AppleUtils::GetRefreshRate();
+#elif defined(ENABLE_SDL2)
+    if (SDL_InitSubSystem(SDL_INIT_VIDEO) != 0) {
         LOG_ERROR(Render_Vulkan, "SDL video failed to initialize, unable to check refresh rate");
         return false;
     }
@@ -71,6 +75,7 @@ static bool IsLowRefreshRate() {
     const auto cur_refresh_rate = cur_display_mode.refresh_rate;
 
     SDL_QuitSubSystem(SDL_INIT_VIDEO);
+#endif // __APPLE__
 
     if (cur_refresh_rate < SCREEN_REFRESH_RATE) {
         LOG_WARNING(Render_Vulkan,
@@ -79,7 +84,7 @@ static bool IsLowRefreshRate() {
                     cur_refresh_rate);
         return true;
     }
-#endif
+#endif // defined(__APPLE__) || defined(ENABLE_SDL2)
 
 #ifdef __APPLE__
     // Apple's low power mode sometimes limits applications to 30fps without changing the refresh

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -65,7 +65,7 @@ static bool IsLowRefreshRate() {
                  // input thread calls SDL_PumpEvents at the same time as we're in SDL_Init here.
     const auto cur_refresh_rate = AppleUtils::GetRefreshRate();
 #elif defined(ENABLE_SDL2)
-    if (SDL_InitSubSystem(SDL_INIT_VIDEO) != 0) {
+    if (SDL_Init(SDL_INIT_VIDEO) != 0) {
         LOG_ERROR(Render_Vulkan, "SDL video failed to initialize, unable to check refresh rate");
         return false;
     }


### PR DESCRIPTION
Because MacOS is very sensitive when it comes to what is allowed to be done on non-main threads, if the input thread called `SDL_PumpEvent` while we were between `SDL_Init` and `SDL_QuitSubSystem` in the prior code, the emulator would completely crash.

To avoid this, we now use a MacOS-specific implementation of the refresh rate check which takes SDL out of the equation entirely, and as other OSes aren't as thread-sensitive, this should resolve the issue completely.