### PR TITLE
MacOS: fix(network): fixes ArticBase UDP buffer handling on macOS

### DIFF
--- a/src/network/artic_base/artic_base_client.cpp
+++ b/src/network/artic_base/artic_base_client.cpp
@@ -6,6 +6,7 @@
 #include "common/assert.h"
 #include "common/logging/log.h"
 
+#include "algorithm"
 #include "chrono"
 #include "limits.h"
 #include "memory"
@@ -143,13 +144,38 @@ void Client::UDPStream::Handle() {
     }
 
     // Limit receive buffer so that packets don't get qeued and are dropped instead.
-    int buffer_size_int = static_cast<int>(buffer_size);
-    if (::setsockopt(main_socket, SOL_SOCKET, SO_RCVBUF, reinterpret_cast<char*>(&buffer_size_int),
-                     sizeof(buffer_size_int)) ||
+    // macOS requires larger UDP buffer sizes for reliable operation
+#ifdef __APPLE__
+    const int min_macos_buffer_size = 8192; // 8KB minimum for macOS
+    int effective_buffer_size = std::max(static_cast<int>(buffer_size), min_macos_buffer_size);
+#else
+    int effective_buffer_size = static_cast<int>(buffer_size);
+#endif
+
+    if (::setsockopt(main_socket, SOL_SOCKET, SO_RCVBUF,
+                     reinterpret_cast<char*>(&effective_buffer_size),
+                     sizeof(effective_buffer_size)) < 0 ||
         !thread_run) {
+        LOG_ERROR(Network, "Cannot change receive buffer size: {} (errno: {})", strerror(GET_ERRNO),
+                  GET_ERRNO);
         closesocket(main_socket);
-        LOG_ERROR(Network, "Cannot change receive buffer size");
         return;
+    }
+
+    // Verify the buffer size was actually set
+    socklen_t actual_size_len = sizeof(int);
+    int actual_buffer_size;
+    if (::getsockopt(main_socket, SOL_SOCKET, SO_RCVBUF,
+                     reinterpret_cast<char*>(&actual_buffer_size), &actual_size_len) == 0) {
+#ifdef __APPLE__
+        LOG_INFO(Network, "macOS UDP buffer size set to: {} (requested: {})", actual_buffer_size,
+                 effective_buffer_size);
+#else
+        LOG_DEBUG(Network, "UDP buffer size set to: {} (requested: {})", actual_buffer_size,
+                  effective_buffer_size);
+#endif
+    } else {
+        LOG_WARNING(Network, "Could not verify UDP buffer size setting");
     }
 
     // Send data to server so that it knows client address.

--- a/src/network/artic_base/artic_base_client.cpp
+++ b/src/network/artic_base/artic_base_client.cpp
@@ -167,13 +167,8 @@ void Client::UDPStream::Handle() {
     int actual_buffer_size;
     if (::getsockopt(main_socket, SOL_SOCKET, SO_RCVBUF,
                      reinterpret_cast<char*>(&actual_buffer_size), &actual_size_len) == 0) {
-#ifdef __APPLE__
-        LOG_INFO(Network, "macOS UDP buffer size set to: {} (requested: {})", actual_buffer_size,
+        LOG_INFO(Network, "UDP buffer size set to: {} (requested: {})", actual_buffer_size,
                  effective_buffer_size);
-#else
-        LOG_DEBUG(Network, "UDP buffer size set to: {} (requested: {})", actual_buffer_size,
-                  effective_buffer_size);
-#endif
     } else {
         LOG_WARNING(Network, "Could not verify UDP buffer size setting");
     }


### PR DESCRIPTION
Fixes ArticBase controller input reliability issues on macOS:

- Set minimum 8KB UDP receive buffer size on macOS for reliable operation
- Add platform-specific buffer size handling with conditional compilation
- Enhance error logging with errno details and buffer size verification
- Maintain backward compatibility with existing buffer sizes on other platforms

