### PR TITLE
ci: Dropped iOS build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,28 +251,3 @@ jobs:
         with:
           name: ${{ env.OS }}-${{ env.TARGET }}
           path: src/android/app/artifacts/
-  ios:
-    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-    runs-on: macos-14
-    env:
-      CCACHE_DIR: ${{ github.workspace }}/.ccache
-      CCACHE_COMPILERCHECK: content
-      CCACHE_SLOPPINESS: time_macros
-      OS: ios
-      TARGET: arm64
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Set up cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.CCACHE_DIR }}
-          key: ${{ runner.os }}-ios-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-ios-
-      - name: Install tools
-        run: brew install ccache ninja
-      - name: Build
-        run: ./.ci/ios.sh
-


### PR DESCRIPTION
We are planning to drop remaining code relating to the old iOS builds of Citra.

As an initial step, this PR removes the build job for iOS from our CI/CD pipeline.