### PR TITLE
renderer_vulkan: Do not disable FIFO when Apple Low Power Mode is enabled, to prevent tearing

### DIFF
--- a/src/common/apple_utils.h
+++ b/src/common/apple_utils.h
@@ -5,6 +5,5 @@
 namespace AppleUtils {
 
 float GetRefreshRate();
-int IsLowPowerModeEnabled();
 
 } // namespace AppleUtils

--- a/src/common/apple_utils.mm
+++ b/src/common/apple_utils.mm
@@ -25,8 +25,4 @@ float GetRefreshRate() { // TODO: How does this handle multi-monitor? -OS
     return 60; // Something went wrong, so just return a generic value
 }
 
-int IsLowPowerModeEnabled() {
-    return (int)[NSProcessInfo processInfo].lowPowerModeEnabled;
-}
-
 } // namespace AppleUtils

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -86,16 +86,6 @@ static bool IsLowRefreshRate() {
     }
 #endif // defined(__APPLE__) || defined(ENABLE_SDL2)
 
-#ifdef __APPLE__
-    // Apple's low power mode sometimes limits applications to 30fps without changing the refresh
-    // rate, meaning the above code doesn't catch it.
-    if (AppleUtils::IsLowPowerModeEnabled()) {
-        LOG_WARNING(Render_Vulkan, "Apple's low power mode is enabled, assuming low application "
-                                   "framerate. FIFO will be disabled");
-        return true;
-    }
-#endif
-
     return false;
 }
 } // Anonymous namespace


### PR DESCRIPTION
#1193 disabled FIFO for macOS when Low Power Mode is enabled, and as MoltenVK has no support for mailbox, it would fall back to immediate despite Vsync being enabled. This introduces tearing. As Low Power Mode is default for at least MacBooks, this would render Vsync ineffective for most users out of the box.

This was originally done because of Low Power Mode being suspected of limiting fps to 30. However there is no documentation indicating this on Apple's sites and have with help of @BYT3XX done throughout testing, where we were unable to reproduce a limiting to 30 fps.

Testing on the following hardware and games with Azahar 2122.1 and Low Power Mode set to always enabled:

- MacBook Air M1
MacOS Ventura 13.6.7 (22H625)

- Mac Mini M4
MacOS Tahoe 26.0 Beta 4 (25A5316i)

Animal Crossing: New Leaf
Super Smash Bros 3DS
Yoshi's New Island
Luigi's Mansion 2
Triforce Heroes

All run at around 60 fps, both in windowed, fullscreen, in the background and while running intensive tasks by the side.

Low Power Mode is noted as only limiting 120 fps to 60 on supported models, and not doing any other limiting of framerate. #1187 was likely a bug of an earlier Tahoe beta, or an issue caused by external factors.