### PR TITLE
cmake: Added `SPIRV_HEADERS` to `LIB_VAR_LIST`

### DIFF
--- a/externals/cmake-modules/CitraHandleSystemLibs.cmake
+++ b/externals/cmake-modules/CitraHandleSystemLibs.cmake
@@ -77,6 +77,7 @@ set(LIB_VAR_LIST
     OPENAL
     VMA
     VULKAN_HEADERS
+    SPIRV_HEADERS
     CATCH2
     )
 


### PR DESCRIPTION
Should've been added as part of #1281 