### PR TITLE
android: Reimplement multitouch code correctly

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableButton.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableButton.kt
@@ -70,9 +70,8 @@ class InputOverlayDrawableButton(
      *
      * @return true if value was changed
      */
-    fun updateStatus(event: MotionEvent, hasActiveButtons: Boolean, overlay: InputOverlay): Boolean {
+    fun updateStatus(event: MotionEvent, pointerIndex: Int, hasActiveButtons: Boolean, overlay: InputOverlay): Boolean {
         val buttonSliding = EmulationMenuSettings.buttonSlide
-        val pointerIndex = event.actionIndex
         val xPosition = event.getX(pointerIndex).toInt()
         val yPosition = event.getY(pointerIndex).toInt()
         val pointerId = event.getPointerId(pointerIndex)
@@ -92,7 +91,7 @@ class InputOverlayDrawableButton(
             if (trackId != pointerId) {
                 return false
             }
-            buttonUp(overlay)
+            buttonUp(overlay, false)
             return true
         }
 
@@ -105,11 +104,14 @@ class InputOverlayDrawableButton(
                 if (inside || trackId != pointerId) {
                     return false
                 }
+
                 // prevent the first (directly pressed) button to deactivate when sliding off
                 if (buttonSliding == ButtonSlidingMode.Alternative.int && isMotionFirstButton) {
                     return false
                 }
-                buttonUp(overlay)
+
+                val preserveTrackId = (buttonSliding != ButtonSlidingMode.Disabled.int)
+                buttonUp(overlay, preserveTrackId)
                 return true
             } else {
                 // button was not yet pressed
@@ -132,10 +134,12 @@ class InputOverlayDrawableButton(
         overlay.hapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
     }
 
-    private fun buttonUp(overlay: InputOverlay) {
+    private fun buttonUp(overlay: InputOverlay, preserveTrackId: Boolean) {
         pressedState = false
         isMotionFirstButton = false
-        trackId = -1
+        if (!preserveTrackId) {
+            trackId = -1
+        }
         overlay.hapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY_RELEASE)
     }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableButton.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableButton.kt
@@ -44,7 +44,6 @@ class InputOverlayDrawableButton(
     val opacity: Int
 ) {
     var trackId: Int
-    var isButtonSliding: Boolean
 
     private var isMotionFirstButton = false // mark the first activated button with the current motion
 
@@ -62,7 +61,6 @@ class InputOverlayDrawableButton(
         this.defaultStateBitmap = BitmapDrawable(res, defaultStateBitmap)
         this.pressedStateBitmap = BitmapDrawable(res, pressedStateBitmap)
         trackId = -1
-        isButtonSliding = false
         width = this.defaultStateBitmap.intrinsicWidth
         height = this.defaultStateBitmap.intrinsicHeight
     }
@@ -94,7 +92,7 @@ class InputOverlayDrawableButton(
             if (trackId != pointerId) {
                 return false
             }
-            buttonUp(overlay, false)
+            buttonUp(overlay)
             return true
         }
 
@@ -111,7 +109,7 @@ class InputOverlayDrawableButton(
                 if (buttonSliding == ButtonSlidingMode.Alternative.int && isMotionFirstButton) {
                     return false
                 }
-                buttonUp(overlay, true)
+                buttonUp(overlay)
                 return true
             } else {
                 // button was not yet pressed
@@ -134,11 +132,10 @@ class InputOverlayDrawableButton(
         overlay.hapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
     }
 
-    private fun buttonUp(overlay: InputOverlay, _isButtonSliding: Boolean) {
+    private fun buttonUp(overlay: InputOverlay) {
         pressedState = false
         isMotionFirstButton = false
         trackId = -1
-        isButtonSliding = _isButtonSliding
         overlay.hapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY_RELEASE)
     }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableDpad.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableDpad.kt
@@ -63,9 +63,8 @@ class InputOverlayDrawableDpad(
         trackId = -1
     }
 
-    fun updateStatus(event: MotionEvent, hasActiveButtons: Boolean, dpadSlide: Boolean, overlay: InputOverlay): Boolean {
+    fun updateStatus(event: MotionEvent, pointerIndex: Int, hasActiveButtons: Boolean, dpadSlide: Boolean, overlay: InputOverlay): Boolean {
         var isDown = false
-        val pointerIndex = event.actionIndex
         val xPosition = event.getX(pointerIndex).toInt()
         val yPosition = event.getY(pointerIndex).toInt()
         val pointerId = event.getPointerId(pointerIndex)

--- a/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableJoystick.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableJoystick.kt
@@ -93,8 +93,7 @@ class InputOverlayDrawableJoystick(
         currentStateBitmapDrawable.draw(canvas)
     }
 
-    fun updateStatus(event: MotionEvent, hasActiveButtons: Boolean, overlay: InputOverlay): Boolean {
-        val pointerIndex = event.actionIndex
+    fun updateStatus(event: MotionEvent, pointerIndex: Int, hasActiveButtons: Boolean, overlay: InputOverlay): Boolean {
         val xPosition = event.getX(pointerIndex).toInt()
         val yPosition = event.getY(pointerIndex).toInt()
         val pointerId = event.getPointerId(pointerIndex)


### PR DESCRIPTION
This pull request heavily tweaks the code from Citra which handles touchscreen input.

The existing code was seemingly written with a misunderstanding of how `onTouch` handles multitouch. Rather than triggering multiple events, which is what the prior code seems to be assuming, a single event is fired which has the information for all simultaneous touches, and we have to handle the multitouch logic manually.

As well as fixing some issues with the new button sliding feature, this PR also allows for true multitouch in the on-screen controller overlay, something that has never worked before due to the aforementioned incorrect implementation.