### PR TITLE
cmake: Don't install zstd_seekable and use header from externals

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -243,13 +243,8 @@ else()
     )
     target_link_libraries(zstd_seekable PUBLIC libzstd_static)
 
-    target_link_libraries(libzstd_static INTERFACE zstd_seekable)
-
-    add_library(zstd ALIAS libzstd_static)
-
-    install(TARGETS zstd_seekable
-        EXPORT zstdExports
-    )
+    add_library(zstd INTERFACE)
+    target_link_libraries(zstd INTERFACE libzstd_static zstd_seekable)
 endif()
 
 # ENet

--- a/src/common/zstd_compression.cpp
+++ b/src/common/zstd_compression.cpp
@@ -13,7 +13,7 @@
 #include <mutex>
 #include <sstream>
 #include <zstd.h>
-#include <zstd/contrib/seekable_format/zstd_seekable.h>
+#include <zstd_seekable.h>
 
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/unique_ptr.hpp>


### PR DESCRIPTION
Specifying the full path to `zstd_seekable.h` relies on the system installed header.