### PR TITLE
frontend: Remove in-application .3ds file compatibility warning

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/GamesFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/GamesFragment.kt
@@ -7,16 +7,12 @@ package org.citra.citra_emu.fragments
 import android.annotation.SuppressLint
 import android.net.Uri
 import android.os.Bundle
-import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.MarginLayoutParams
-import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.edit
-import androidx.core.text.HtmlCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
@@ -28,7 +24,6 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.GridLayoutManager
 import com.google.android.material.color.MaterialColors
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.transition.MaterialFadeThrough
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -47,7 +42,6 @@ class GamesFragment : Fragment() {
 
     private val gamesViewModel: GamesViewModel by activityViewModels()
     private val homeViewModel: HomeViewModel by activityViewModels()
-    private var show3DSFileWarning: Boolean = true
     private lateinit var gameAdapter: GameAdapter
 
     private val openImageLauncher = registerForActivityResult(
@@ -162,34 +156,6 @@ class GamesFragment : Fragment() {
         }
 
         setInsets()
-    }
-
-    override fun onResume() {
-        super.onResume()
-
-        if (show3DSFileWarning &&
-            !PreferenceManager.getDefaultSharedPreferences(CitraApplication.appContext)
-                .getBoolean("show_3ds_files_warning", false)) {
-            val message = HtmlCompat.fromHtml(getString(R.string.warning_3ds_files),
-                HtmlCompat.FROM_HTML_MODE_LEGACY)
-
-            context?.let {
-                val alert = MaterialAlertDialogBuilder(it)
-                    .setTitle(getString(R.string.important))
-                    .setMessage(message)
-                    .setPositiveButton(R.string.dont_show_again) { _, _ ->
-                        PreferenceManager.getDefaultSharedPreferences(CitraApplication.appContext)
-                            .edit() {
-                            putBoolean("show_3ds_files_warning", true)
-                        }
-                    }
-                    .show()
-
-                val alertMessage = alert.findViewById<View>(android.R.id.message) as TextView
-                alertMessage.movementMethod = LinkMovementMethod.getInstance()
-            }
-        }
-        show3DSFileWarning = false
     }
 
     override fun onDestroyView() {

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -36,7 +36,6 @@
     <string name="select_citra_user_folder_home_description">Changes the files that Azahar uses to load applications</string>
     <string name="theme_and_color_description">Modify the look of the app</string>
     <string name="install_cia_title">Install CIA</string>
-    <string name="warning_3ds_files"><![CDATA[Encrypted files and .3ds files are no longer supported. Decrypting and/or renaming to .cci may be necessary. <a href="https://azahar-emu.org/blog/game-loading-changes/">Learn more.</a>]]></string>
 
     <!-- GPU driver installation -->
     <string name="select_gpu_driver">Select GPU driver</string>
@@ -376,8 +375,6 @@
     <string name="auto_select">Auto-Select</string>
     <string name="start">Start</string>
     <string name="cancelling">Cancelling…</string>
-    <string name="important">Important</string>
-    <string name="dont_show_again">Don\'t show again</string>
     <string name="visibility">Visibility</string>
     <string name="information">Information</string>
 

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -835,7 +835,6 @@ void QtConfig::ReadUIGameListValues() {
     ReadBasicSetting(UISettings::values.game_list_row_2);
     ReadBasicSetting(UISettings::values.game_list_hide_no_icon);
     ReadBasicSetting(UISettings::values.game_list_single_line_mode);
-    ReadBasicSetting(UISettings::values.show_3ds_files_warning);
 
     ReadBasicSetting(UISettings::values.show_compat_column);
     ReadBasicSetting(UISettings::values.show_region_column);
@@ -1347,7 +1346,6 @@ void QtConfig::SaveUIGameListValues() {
     WriteBasicSetting(UISettings::values.game_list_row_2);
     WriteBasicSetting(UISettings::values.game_list_hide_no_icon);
     WriteBasicSetting(UISettings::values.game_list_single_line_mode);
-    WriteBasicSetting(UISettings::values.show_3ds_files_warning);
 
     WriteBasicSetting(UISettings::values.show_compat_column);
     WriteBasicSetting(UISettings::values.show_region_column);

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -350,41 +350,6 @@ GameList::GameList(PlayTime::PlayTimeManager& play_time_manager_, GMainWindow* p
 
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);
-
-    if (UISettings::values.show_3ds_files_warning.GetValue()) {
-
-        warning_layout = new QHBoxLayout;
-        deprecated_3ds_warning = new QLabel;
-        deprecated_3ds_warning->setText(
-            tr("IMPORTANT: Encrypted files and .3ds files are no longer supported. Decrypting "
-               "and/or renaming to .cci may be necessary. <a "
-               "href='https://azahar-emu.org/blog/game-loading-changes/'>Learn more.</a>"));
-        deprecated_3ds_warning->setOpenExternalLinks(true);
-        deprecated_3ds_warning->setStyleSheet(
-            QString::fromStdString("color: black; font-weight: bold;"));
-
-        warning_hide = new QPushButton(tr("Don't show again"));
-        warning_hide->setStyleSheet(
-            QString::fromStdString("color: blue; text-decoration: underline;"));
-        warning_hide->setFlat(true);
-        warning_hide->setCursor(Qt::PointingHandCursor);
-
-        connect(warning_hide, &QPushButton::clicked, [this]() {
-            warning_widget->setVisible(false);
-            UISettings::values.show_3ds_files_warning.SetValue(false);
-        });
-
-        warning_layout->addWidget(deprecated_3ds_warning);
-        warning_layout->addStretch();
-        warning_layout->addWidget(warning_hide);
-        warning_layout->setContentsMargins(3, 3, 3, 3);
-        warning_widget = new QWidget;
-        warning_widget->setStyleSheet(QString::fromStdString("background-color: khaki;"));
-        warning_widget->setLayout(warning_layout);
-
-        layout->addWidget(warning_widget);
-    }
-
     layout->addWidget(tree_view);
     layout->addWidget(search_field);
     setLayout(layout);

--- a/src/citra_qt/game_list.h
+++ b/src/citra_qt/game_list.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <QMenu>
-#include <QPushButton>
 #include <QString>
 #include <QVector>
 #include <QWidget>
@@ -134,10 +133,6 @@ private:
     void changeEvent(QEvent*) override;
     void RetranslateUI();
 
-    QHBoxLayout* warning_layout = nullptr;
-    QWidget* warning_widget = nullptr;
-    QLabel* deprecated_3ds_warning = nullptr;
-    QPushButton* warning_hide = nullptr;
     GameListSearchField* search_field;
     GMainWindow* main_window = nullptr;
     QVBoxLayout* layout = nullptr;

--- a/src/citra_qt/uisettings.h
+++ b/src/citra_qt/uisettings.h
@@ -95,7 +95,6 @@ struct Values {
     Settings::Setting<GameListText> game_list_row_2{GameListText::FileName, "row2"};
     Settings::Setting<bool> game_list_hide_no_icon{false, "hideNoIcon"};
     Settings::Setting<bool> game_list_single_line_mode{false, "singleLineMode"};
-    Settings::Setting<bool> show_3ds_files_warning{true, "show_3ds_files_warning"};
 
     // Compatibility List
     Settings::Setting<bool> show_compat_column{true, "show_compat_column"};


### PR DESCRIPTION
Removes the in-application .3ds file compatibility warning introduced in #755

This change has been communicated well for a while now and should no longer be displayed inside the application itself, removing all references to .3ds files and cleaning up the UI. In addition, it simply is annoying and I have seen several forks remove it