### PR TITLE
common: Move `play_time.bin` file to `sysdata` directory

### DIFF
--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -879,7 +879,6 @@ void SetUserPath(const std::string& path) {
     g_paths.emplace(UserPath::LoadDir, user_path + LOAD_DIR DIR_SEP);
     g_paths.emplace(UserPath::StatesDir, user_path + STATES_DIR DIR_SEP);
     g_paths.emplace(UserPath::IconsDir, user_path + ICONS_DIR DIR_SEP);
-    g_paths.emplace(UserPath::PlayTimeDir, user_path + LOG_DIR DIR_SEP);
     g_default_paths = g_paths;
 }
 

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -51,7 +51,6 @@ enum class UserPath {
     LoadDir,
     LogDir,
     NANDDir,
-    PlayTimeDir,
     RootDir,
     SDMCDir,
     ShaderDir,


### PR DESCRIPTION
This moves `play_time.bin` from `log` to `sysdata`.

Also, if `play_time.bin` exists in the old location, but not the new one, the old file is moved to the new location.