### PR TITLE
Refactor `FileUtil::Rename` into two distinct `Rename` and `Move` functions

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
@@ -691,6 +691,19 @@ object NativeLibrary {
 
     @Keep
     @JvmStatic
+    fun moveFile(filename: String, sourceDirPath: String, destinationDirPath: String): Boolean =
+        if (FileUtil.isNativePath(sourceDirPath)) {
+            try {
+                CitraApplication.documentsTree.moveFile(filename, sourceDirPath, destinationDirPath)
+            } catch (e: Exception) {
+                false
+            }
+        } else {
+            FileUtil.moveFile(filename, sourceDirPath, destinationDirPath)
+        }
+
+    @Keep
+    @JvmStatic
     fun deleteDocument(path: String): Boolean =
         if (FileUtil.isNativePath(path)) {
             CitraApplication.documentsTree.deleteDocument(path)

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/DocumentsTree.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/DocumentsTree.kt
@@ -191,7 +191,7 @@ class DocumentsTree {
     }
 
     @Synchronized
-    fun renameFile(filepath: String, destinationFilename: String?): Boolean {
+    fun renameFile(filepath: String, destinationFilename: String): Boolean {
         val node = resolvePath(filepath) ?: return false
         try {
             val filename = URLDecoder.decode(destinationFilename, FileUtil.DECODE_METHOD)
@@ -200,6 +200,20 @@ class DocumentsTree {
             return true
         } catch (e: Exception) {
             error("[DocumentsTree]: Cannot rename file, error: " + e.message)
+        }
+    }
+
+    @Synchronized
+    fun moveFile(filename: String, sourceDirPath: String, destDirPath: String): Boolean {
+        val sourceFileNode = resolvePath(sourceDirPath + "/" + filename) ?: return false
+        val sourceDirNode = resolvePath(sourceDirPath) ?: return false
+        val destDirNode = resolvePath(destDirPath) ?: return false
+        try {
+            val newUri = DocumentsContract.moveDocument(context.contentResolver, sourceFileNode.uri!!, sourceDirNode.uri!!, destDirNode.uri!!)
+            sourceFileNode.rename(filename, newUri)
+            return true
+        } catch (e: Exception) {
+            error("[DocumentsTree]: Cannot move file, error: " + e.message)
         }
     }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.kt
@@ -11,6 +11,7 @@ import android.net.Uri
 import android.provider.DocumentsContract
 import android.system.Os
 import android.util.Pair
+import androidx.core.net.toUri
 import androidx.documentfile.provider.DocumentFile
 import org.citra.citra_emu.CitraApplication
 import org.citra.citra_emu.model.CheapDocument
@@ -430,6 +431,20 @@ object FileUtil {
             return true
         } catch (e: Exception) {
             Log.error("[FileUtil]: Cannot rename file, error: " + e.message)
+        }
+        return false
+    }
+
+    @JvmStatic
+    fun moveFile(filename: String, sourceDirUriString: String, destDirUriString: String): Boolean {
+        try {
+            val sourceFileUri = ("$sourceDirUriString%2F$filename").toUri()
+            val sourceDirUri = sourceDirUriString.toUri()
+            val destDirUri = destDirUriString.toUri()
+            DocumentsContract.moveDocument(context.contentResolver, sourceFileUri, sourceDirUri, destDirUri)
+            return true
+        } catch (e: Exception) {
+            Log.error("[FileUtil]: Cannot move file, error: " + e.message)
         }
         return false
     }

--- a/src/common/android_storage.cpp
+++ b/src/common/android_storage.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/common/android_storage.cpp
+++ b/src/common/android_storage.cpp
@@ -172,6 +172,18 @@ bool RenameFile(const std::string& source, const std::string& filename) {
                                         j_destination_path);
 }
 
+bool MoveFile(const std::string& filename, const std::string& source_dir_path,
+              const std::string& destination_dir_path) {
+    if (rename_file == nullptr)
+        return false;
+    auto env = GetEnvForThread();
+    jstring j_filename = env->NewStringUTF(filename.c_str());
+    jstring j_source_dir_path = env->NewStringUTF(source_dir_path.c_str());
+    jstring j_destination_dir_path = env->NewStringUTF(destination_dir_path.c_str());
+    return env->CallStaticBooleanMethod(native_library, move_file, j_filename, j_source_dir_path,
+                                        j_destination_dir_path);
+}
+
 #define FR(FunctionName, ReturnValue, JMethodID, Caller, JMethodName, Signature)                   \
     F(FunctionName, ReturnValue, JMethodID, Caller)
 #define F(FunctionName, ReturnValue, JMethodID, Caller)                                            \

--- a/src/common/android_storage.h
+++ b/src/common/android_storage.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/common/android_storage.h
+++ b/src/common/android_storage.h
@@ -24,7 +24,11 @@
        const std::string& destination_filename),                                                   \
       copy_file, "copyFile", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z")          \
     V(RenameFile, bool, (const std::string& source, const std::string& filename), rename_file,     \
-      "renameFile", "(Ljava/lang/String;Ljava/lang/String;)Z")
+      "renameFile", "(Ljava/lang/String;Ljava/lang/String;)Z")                                     \
+    V(MoveFile, bool,                                                                              \
+      (const std::string& filename, const std::string& source_dir_path,                            \
+       const std::string& destination_dir_path),                                                   \
+      move_file, "moveFile", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z")
 #define ANDROID_SINGLE_PATH_DETERMINE_FUNCTIONS(V)                                                 \
     V(IsDirectory, bool, is_directory, CallStaticBooleanMethod, "isDirectory",                     \
       "(Ljava/lang/String;)Z")                                                                     \

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -304,20 +304,41 @@ bool DeleteDir(const std::string& filename) {
     return false;
 }
 
-bool Rename(const std::string& srcFilename, const std::string& destFilename) {
-    LOG_TRACE(Common_Filesystem, "{} --> {}", srcFilename, destFilename);
+bool Rename(const std::string& srcFilePath, const std::string& destFileName) {
+    LOG_TRACE(Common_Filesystem, "{} --> {}", srcFilePath, destFileName);
 #ifdef _WIN32
-    if (_wrename(Common::UTF8ToUTF16W(srcFilename).c_str(),
-                 Common::UTF8ToUTF16W(destFilename).c_str()) == 0)
+    if (_wrename(Common::UTF8ToUTF16W(srcFilePath).c_str(),
+                 Common::UTF8ToUTF16W(std::string(GetFilename(destFileName))).c_str()) == 0)
         return true;
 #elif ANDROID
-    if (AndroidStorage::RenameFile(srcFilename, std::string(GetFilename(destFilename))))
+    if (AndroidStorage::RenameFile(srcFilePath, std::string(GetFilename(destFileName))))
         return true;
 #else
-    if (rename(srcFilename.c_str(), destFilename.c_str()) == 0)
+    if (rename(srcFilePath.c_str(), std::string(GetFilename(destFileName)).c_str()) == 0)
         return true;
 #endif
-    LOG_ERROR(Common_Filesystem, "failed {} --> {}: {}", srcFilename, destFilename,
+    LOG_ERROR(Common_Filesystem, "failed {} --> {}: {}", srcFilePath, destFileName,
+              GetLastErrorMsg());
+    return false;
+}
+
+bool Move(const std::string& srcFileName, const std::string& srcDirPath,
+          const std::string& destDirPath) {
+    const auto srcFilePath = srcDirPath + DIR_SEP + srcFileName;
+    const auto destFilePath = destDirPath + DIR_SEP + srcFileName;
+    LOG_TRACE(Common_Filesystem, "{} --> {}", srcFilename, destFileName);
+#ifdef _WIN32
+    if (_wrename(Common::UTF8ToUTF16W(srcFilePath).c_str(),
+                 Common::UTF8ToUTF16W(destFilePath).c_str()) == 0)
+        return true;
+#elif ANDROID
+    if (AndroidStorage::MoveFile(srcFileName, srcDirPath, destDirPath))
+        return true;
+#else
+    if (rename(srcFilePath.c_str(), destFilePath.c_str()) == 0)
+        return true;
+#endif
+    LOG_ERROR(Common_Filesystem, "failed {} --> {}: {}", srcFilePath, destFilePath,
               GetLastErrorMsg());
     return false;
 }

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -136,13 +136,18 @@ bool Delete(const std::string& filename);
 // Deletes a directory filename, returns true on success
 bool DeleteDir(const std::string& filename);
 
-// renames file srcFilename to destFilename, returns true on success
-bool Rename(const std::string& srcFilename, const std::string& destFilename);
+// Renames file srcFilepath to destFilename, returns true on success.
+// If a full path is passed to destFileName, everything except the name of the file is ignored.
+bool Rename(const std::string& srcFilePath, const std::string& destFileName);
 
-// copies file srcFilename to destFilename, returns true on success
+// Moves file srcFileName from srcDirPath to destDirPath, returns true on success
+bool Move(const std::string& srcFileName, const std::string& srcDirPath,
+          const std::string& destDirPath);
+
+// Copies file srcFilename to destFilename, returns true on success
 bool Copy(const std::string& srcFilename, const std::string& destFilename);
 
-// creates an empty file filename, returns true on success
+// Creates an empty file filename, returns true on success
 bool CreateEmptyFile(const std::string& filename);
 
 /**


### PR DESCRIPTION
This plays into how the Android API is designed, restricting the `Rename` function to strictly renaming and `Move` to strictly moving.

This makes behaviour for these functions consistent across all platforms, whereas previously the unified `Rename` function had different behaviour on desktop and Android. The new `Rename` function now mirrors the previous behaviour on Android on all platforms.

I have tested the new `Move` function on desktop Linux, as well as on Android using both the method in `DocumentsTree.kt` and `FileUtil.kt`, by using a modified version of #1310 .