### PR TITLE
am: fix save data being deleted on CIA install failure

### DIFF
--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -864,8 +864,10 @@ bool CIAFile::Close() {
     if (!complete) {
         LOG_ERROR(Service_AM, "CIAFile closed prematurely, aborting install...");
         if (!is_additional_content) {
-            FileUtil::DeleteDirRecursively(
-                GetTitlePath(media_type, container.GetTitleMetadata().GetTitleID()));
+            // Only delete the content folder as there may be user save data in the title folder.
+            const std::string title_content_path =
+                GetTitlePath(media_type, container.GetTitleMetadata().GetTitleID()) + "content/";
+            FileUtil::DeleteDirRecursively(title_content_path);
         }
         return true;
     }


### PR DESCRIPTION
Fixes a critical bug that causes an app's save data be deleted whenever a CIA file for that app fails to install.

The faulty code that causes the issue [was added 8 years ago](https://github.com/azahar-emu/azahar/blame/7a5e1de441f51e992816b59c561f7dfd849093a9/src/core/hle/service/am/am.cpp#L362), but the wrong function call for deletion was used, so it never triggered.
However, this function call [was recently fixed](https://github.com/azahar-emu/azahar/blame/bac344d0592e42a9e781ff73e1fa27fe86687c07/src/core/hle/service/am/am.cpp#L774), which made the bug start to show up.