### PR TITLE
Add Dockerfile, Environment variable support for rooms

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -51,8 +51,6 @@ jobs:
             type=ref,event=branch
             # git tag pushes (e.g., v1.2.3)
             type=ref,event=tag
-            # always add a short SHA tag
-            type=sha,format=short
 
       - name: Build and push (amd64 + arm64)
         uses: docker/build-push-action@v6

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout (with submodules)
@@ -46,7 +46,7 @@ jobs:
           images: ${{ env.IMAGE_NAME }}
           tags: |
             # latest on main
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
             # branch tags (e.g., main, feature/foo)
             type=ref,event=branch
             # git tag pushes (e.g., v1.2.3)

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -1,0 +1,67 @@
+name: Build & Push Docker (multi-arch)
+
+on:
+  push:
+    branches: ["*"]
+    tags: ["*"]
+  workflow_dispatch:
+
+# Required for GHCR
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout (with submodules)
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive # clone submodules recursively
+          fetch-depth: 0 # good practice for tags/metadata
+
+      - name: Set up QEMU (for arm64 emulation)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image name (lowercase for GHCR)
+        shell: bash
+        run: echo "IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
+      - name: Extract Docker metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            # latest on main
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            # branch tags (e.g., main, feature/foo)
+            type=ref,event=branch
+            # git tag pushes (e.g., v1.2.3)
+            type=ref,event=tag
+            # always add a short SHA tag
+            type=sha,format=short
+
+      - name: Build and push (amd64 + arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN strip -s bin/Release/azahar-room
 
 RUN mkdir /azahar && chown 2048 /azahar
 
-FROM gcr.io/distroless/cc-debian12
+FROM gcr.io/distroless/static-debian12
 
 ENV AZAHAR_PORT=24872
 ENV AZAHAR_ROOMNAME="Azahar Room"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,76 @@
+FROM debian:trixie-slim AS dependencies
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    ccache \
+    clang-19 \
+    cmake \
+    ninja-build \
+    git \
+    wget \
+    ca-certificates \
+    libssl-dev \
+    libsdl2-dev \
+    && ln -s /usr/bin/clang-19 /usr/bin/clang \
+    && ln -s /usr/bin/clang++-19 /usr/bin/clang++ \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV CCACHE_DIR=/ccache
+ENV CCACHE_COMPILERCHECK=content
+ENV CCACHE_SLOPPINESS=time_macros
+RUN mkdir -p $CCACHE_DIR
+
+FROM dependencies AS builder
+
+WORKDIR /build
+
+COPY . . 
+
+WORKDIR /build/build
+
+RUN cmake .. -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    -DENABLE_QT=OFF \
+    -DENABLE_SDL2=OFF \
+    -DENABLE_ROOM_STANDALONE=ON \
+    -DUSE_DISCORD_PRESENCE=OFF \
+    -DENABLE_FFMPEG_VIDEO_DUMPER=OFF \
+    -DCITRA_USE_PRECOMPILED_HEADERS=OFF \
+    -DCITRA_WARNINGS_AS_ERRORS=OFF
+
+RUN ninja citra_room_standalone
+
+RUN strip -s bin/Release/azahar-room
+
+RUN mkdir /azahar && chown 2048 /azahar
+
+FROM gcr.io/distroless/cc-debian12
+
+ENV AZAHAR_PORT=24872
+ENV AZAHAR_ROOMNAME="Azahar Room"
+ENV AZAHAR_MAXMEMBERS=4
+ENV AZAHAR_ROOMDESC=""
+ENV AZAHAR_PREFAPP=""
+ENV AZAHAR_PREFAPPID="0"
+ENV AZAHAR_PASSWORD=""
+ENV AZAHAR_ISPUBLIC=0
+ENV AZAHAR_USERNAME="azahar"
+ENV AZAHAR_TOKEN=""
+ENV AZAHAR_WEBAPIURL=""
+ENV AZAHAR_BANLISTFILE="bannedlist.cbl"
+ENV AZAHAR_LOGFILE="azahar-room.log"
+
+COPY --from=builder --chmod=755 /build/build/bin/Release/azahar-room /azahar-room
+COPY --from=builder --chmod=755 /azahar /azahar
+
+USER 2048
+WORKDIR /azahar
+
+EXPOSE $AZAHAR_PORT/udp
+
+ENTRYPOINT ["/azahar-room"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+services:
+  azahar:
+    image: ghcr.io/azahar-emu/azahar/azahar:latest
+    ports: 
+      - "24872:24873/udp"
+    environment:
+      - AZAHAR_PORT=24873
+      - AZAHAR_ROOMNAME=Azahar Room
+      - AZAHAR_MAXMEMBERS=10
+      - AZAHAR_ROOMDESC=
+      - AZAHAR_PREFAPP="Pokemon Omega Ruby"
+      - AZAHAR_PREFAPPID=000400000011C400
+      - AZAHAR_PASSWORD=1234
+      - AZAHAR_ISPUBLIC=0
+      - AZAHAR_USERNAME=azahar
+      - AZAHAR_TOKEN=
+      - AZAHAR_WEBAPIURL=
+      # - AZAHAR_BANLISTFILE=bannedlist.cbl
+      # - AZAHAR_LOGFILE=azahar-room.log
+    # volumes:
+    #   - ./bannedlist.cbl:/bannedlist.cbl
+    #   - ./azahar-room.log:/azahar-room.log

--- a/src/citra_room/citra_room.cpp
+++ b/src/citra_room/citra_room.cpp
@@ -404,6 +404,9 @@ void LaunchRoom(int argc, char** argv, bool called_by_option) {
             std::cout << "Failed to create room: \n\n";
             exit(-1);
         }
+
+        std::cout << "Listening on port " << port << "\n\n";
+
         std::cout << "Room is open. Close with Q+Enter...\n\n";
         auto announce_session = std::make_unique<Network::AnnounceMultiplayerSession>();
         if (announce) {

--- a/src/citra_room_standalone/CMakeLists.txt
+++ b/src/citra_room_standalone/CMakeLists.txt
@@ -6,6 +6,12 @@ set_target_properties(citra_room_standalone PROPERTIES OUTPUT_NAME "azahar-room"
 
 target_link_libraries(citra_room_standalone PRIVATE citra_room)
 
+#target_link_libraries(citra_room_standalone PRIVATE -static-libgcc -static-libstdc++)
+
+set(BUILD_SHARED_LIBS OFF)
+set(CMAKE_EXE_LINKER_FLAGS "-static")
+
+
 if(UNIX AND NOT APPLE)
     install(TARGETS citra_room_standalone RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
 endif()


### PR DESCRIPTION
Hello,

this PR has the following changes:

- Dockerfile that builds room_standalone
- docker-compose.yaml as example deployment of the image
- github action that builds the image for amd64 and arm64
- Code changes to the room logic so it can read environment variables

I made a Dockerfile for the standalone room binary, and made some code changes so the room can read its configuration from environment variables in addition to the command line arguments to simplify the deployment as a container. 

To optimize the size of the container image, i added the -static option to the build config of room_standalone.

Also i added a Github action that builds the image for arm64 and amd64, but with the free runners it takes 4 hours. I may make a new one that uses the native arm runners so it does not rely on QEMU for the second build.

