### PR TITLE
renderer_vulkan: Put shader cache directly into the vulkan folder

### DIFF
--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -560,8 +560,7 @@ bool PipelineCache::EnsureDirectories() const {
 }
 
 std::string PipelineCache::GetPipelineCacheDir() const {
-    return FileUtil::GetUserPath(FileUtil::UserPath::ShaderDir) + "vulkan" + DIR_SEP + "pipeline" +
-           DIR_SEP;
+    return FileUtil::GetUserPath(FileUtil::UserPath::ShaderDir) + "vulkan" + DIR_SEP;
 }
 
 void PipelineCache::SwitchPipelineCache(u64 title_id, const std::atomic_bool& stop_loading,


### PR DESCRIPTION
Put the Vulkan shader cache directly into the `vulkan` folder, as how it was before #1118, in order to simply file structure. The extra `pipeline` folder serves no purpose.