### PR TITLE
cmake: Add check for minimum AppleClang version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,15 @@ if (APPLE)
     else()
         # Minimum macOS 13
         set(CMAKE_OSX_DEPLOYMENT_TARGET "13.4")
+
+        # Catch compiler issue on AppleClang versions below 15.0
+        # TODO: Remove this check when we drop macOS 13 Ventura
+        if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND
+            CMAKE_CXX_COMPILER_VERSION VERSION_LESS 15.0)
+            message(FATAL_ERROR "AppleClang 15.0 or later is required due to a compiler bug in earlier versions.\n"
+                                "Current version: ${CMAKE_CXX_COMPILER_VERSION}\n"
+                                "After updating, delete 'CMakeCache.txt' in the build directory.")
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
I have discovered a compiler bug in AppleClang versions before 15.0 which affects our codebase and causes a build failure.

MacOS 13 Ventura, the minimum MacOS version we support, uses AppleClang 14.x, so builds will always fail. Rather than allowing this to happen and confuse users, I have added a check which displays an informative messsage if they have an incompatible compiler version.