### PR TITLE
macos: Set `UIDesignRequiresCompatibility` to true

### DIFF
--- a/dist/apple/Info.plist.in
+++ b/dist/apple/Info.plist.in
@@ -75,6 +75,9 @@
     <true/>
     <key>NSHighResolutionCapable</key>
     <string>True</string>
+    <key>UIDesignRequiresCompatibility</key>
+    <true/> <!-- Remove when Qt Liquid Glass issues are fixed upstream:
+                 https://bugreports.qt.io/browse/QTBUG-138942 -->
     <key>UIFileSharingEnabled</key>
     <true/>
     <key>UILaunchStoryboardName</key>


### PR DESCRIPTION
Evades this upstream Qt issue when building with Xcode 26: https://bugreports.qt.io/browse/QTBUG-138942

Additional context:
- https://wiki.qt.io/Qt_6.9_Known_Issues#macOS
- https://developer.apple.com/documentation/bundleresources/information-property-list/uidesignrequirescompatibility
