### PR TITLE
Fix android termination bug

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationLifecycleUtil.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationLifecycleUtil.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationLifecycleUtil.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationLifecycleUtil.kt
@@ -28,7 +28,7 @@ object EmulationLifecycleUtil {
     fun addPauseResumeHook(hook: Runnable) {
         if (pauseResumeHooks.contains(hook)) {
             Log.warning("Tried to add pause resume hook that already existed. Skipping.")
-        }else{
+        } else {
             pauseResumeHooks.add(hook)
         }
     }

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationLifecycleUtil.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationLifecycleUtil.kt
@@ -19,7 +19,7 @@ object EmulationLifecycleUtil {
 
     fun addShutdownHook(hook: Runnable) {
         if (shutdownHooks.contains(hook)) {
-            Log.warning("Tried to add shutdown hook that already existed. Skipping.")
+            Log.warning("[EmulationLifecycleUtil] Tried to add shutdown hook that already existed. Skipping.")
         } else {
             shutdownHooks.add(hook)
         }
@@ -27,7 +27,7 @@ object EmulationLifecycleUtil {
 
     fun addPauseResumeHook(hook: Runnable) {
         if (pauseResumeHooks.contains(hook)) {
-            Log.warning("Tried to add pause resume hook that already existed. Skipping.")
+            Log.warning("[EmulationLifecycleUtil] Tried to add pause resume hook that already existed. Skipping.")
         } else {
             pauseResumeHooks.add(hook)
         }

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationLifecycleUtil.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationLifecycleUtil.kt
@@ -18,11 +18,19 @@ object EmulationLifecycleUtil {
     }
 
     fun addShutdownHook(hook: Runnable) {
-        shutdownHooks.add(hook)
+        if (shutdownHooks.contains(hook)) {
+            Log.warning("Tried to add shutdown hook that already existed. Skipping.")
+        } else {
+            shutdownHooks.add(hook)
+        }
     }
 
     fun addPauseResumeHook(hook: Runnable) {
-        pauseResumeHooks.add(hook)
+        if (pauseResumeHooks.contains(hook)) {
+            Log.warning("Tried to add pause resume hook that already existed. Skipping.")
+        }else{
+            pauseResumeHooks.add(hook)
+        }
     }
 
     fun clear() {


### PR DESCRIPTION
The EmulationFragment is not destroyed and recreated on rotation, but the EmulationActivity is. This was leading to some hooks getting removed by `EmulationActivity.onDestroy()` but not getting re-added by `EmulationFragment.onCreate()`, causing bug #1343  (and probably other problems). Solved by moving those hook additions to `EmulationFragment.onAttach()` since that is called in both situations. Also added a sanity check to avoid duplicated hooks.
