### PR TITLE
SecondaryDisplay.kt: Remove redundant SurfaceTexture, preventing log spam

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/display/SecondaryDisplay.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/display/SecondaryDisplay.kt
@@ -23,15 +23,12 @@ class SecondaryDisplay(val context: Context) {
     private val vd: VirtualDisplay
 
     init {
-        val st = SurfaceTexture(0)
-        st.setDefaultBufferSize(1920, 1080)
-        val vdSurface = Surface(st)
         vd = displayManager.createVirtualDisplay(
             "HiddenDisplay",
             1920,
             1080,
             320,
-            vdSurface,
+            null,
             DisplayManager.VIRTUAL_DISPLAY_FLAG_PRESENTATION
         )
     }


### PR DESCRIPTION
I recently noticed new messages being spammed in the LogCat output that look similar to this:
```
[SurfaceTexture-0-16580-2](id:40c400000019,api:1,p:1183,c:16580) dequeueBuffer: BufferQueue has been abandoned
```

I determined that this issue first appeared after merging #617, and after looking into it, it seems that it was caused by a Surface being created from a SurfaceTexture, assigned to a virtual display, then being garbage collected or otherwise invalidated, resulting in the above error.

Seeing as the emulator was running fine despite this Surface seemingly not existing, I tested simply passing `null` to the virtual display, [which according to the Android documentation is perfectly fine](https://developer.android.com/reference/android/hardware/display/DisplayManager#createVirtualDisplay(java.lang.String,%20int,%20int,%20int,%20android.view.Surface,%20int)), and everything seems to be working as normal, except the spammy messages in the log are now gone.

I have tested both with and without using a Chromecast, and both seemed fine.

@DavidRGriswold Is there any reason that this change shouldn't be made that I'm missing?