### PR TITLE
Cleaner bugfix for orientation-triggered termination bug

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.kt
@@ -61,7 +61,14 @@ class EmulationActivity : AppCompatActivity() {
     private lateinit var screenAdjustmentUtil: ScreenAdjustmentUtil
     private lateinit var hotkeyUtility: HotkeyUtility
     private lateinit var secondaryDisplay: SecondaryDisplay
-    private lateinit var onShutdown: Runnable
+
+    private val onShutdown = Runnable {
+        if (intent.getBooleanExtra("launched_from_shortcut", false)) {
+            finishAffinity()
+        } else {
+            this.finish()
+        }
+    }
 
     private val emulationFragment: EmulationFragment
         get() {
@@ -102,13 +109,6 @@ class EmulationActivity : AppCompatActivity() {
             windowManager.defaultDisplay.rotation
         )
 
-        onShutdown = Runnable {
-            if (intent.getBooleanExtra("launched_from_shortcut", false)) {
-                finishAffinity()
-            } else {
-                this.finish()
-            }
-        }
         EmulationLifecycleUtil.addShutdownHook(onShutdown)
 
         isEmulationRunning = true

--- a/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.kt
@@ -60,7 +60,8 @@ class EmulationActivity : AppCompatActivity() {
     private lateinit var binding: ActivityEmulationBinding
     private lateinit var screenAdjustmentUtil: ScreenAdjustmentUtil
     private lateinit var hotkeyUtility: HotkeyUtility
-    private lateinit var secondaryDisplay: SecondaryDisplay;
+    private lateinit var secondaryDisplay: SecondaryDisplay
+    private lateinit var shutdownHook: Runnable
 
     private val emulationFragment: EmulationFragment
         get() {
@@ -77,8 +78,8 @@ class EmulationActivity : AppCompatActivity() {
         ThemeUtil.setTheme(this)
         settingsViewModel.settings.loadSettings()
         super.onCreate(savedInstanceState)
-        secondaryDisplay = SecondaryDisplay(this);
-        secondaryDisplay.updateDisplay();
+        secondaryDisplay = SecondaryDisplay(this)
+        secondaryDisplay.updateDisplay()
 
         binding = ActivityEmulationBinding.inflate(layoutInflater)
         screenAdjustmentUtil = ScreenAdjustmentUtil(this, windowManager, settingsViewModel.settings)
@@ -101,13 +102,14 @@ class EmulationActivity : AppCompatActivity() {
             windowManager.defaultDisplay.rotation
         )
 
-        EmulationLifecycleUtil.addShutdownHook(hook = {
+        shutdownHook = Runnable {
             if (intent.getBooleanExtra("launched_from_shortcut", false)) {
                 finishAffinity()
             } else {
                 this.finish()
             }
-        })
+        }
+        EmulationLifecycleUtil.addShutdownHook(shutdownHook)
 
         isEmulationRunning = true
         instance = this
@@ -165,12 +167,12 @@ class EmulationActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
-        EmulationLifecycleUtil.clear()
+        EmulationLifecycleUtil.remove(shutdownHook)
         NativeLibrary.playTimeManagerStop()
         isEmulationRunning = false
         instance = null
         secondaryDisplay.releasePresentation()
-        secondaryDisplay.releaseVD();
+        secondaryDisplay.releaseVD()
 
         super.onDestroy()
     }

--- a/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.kt
@@ -167,7 +167,7 @@ class EmulationActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
-        EmulationLifecycleUtil.remove(shutdownHook)
+        EmulationLifecycleUtil.removeHook(shutdownHook)
         NativeLibrary.playTimeManagerStop()
         isEmulationRunning = false
         instance = null

--- a/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.kt
@@ -61,7 +61,7 @@ class EmulationActivity : AppCompatActivity() {
     private lateinit var screenAdjustmentUtil: ScreenAdjustmentUtil
     private lateinit var hotkeyUtility: HotkeyUtility
     private lateinit var secondaryDisplay: SecondaryDisplay
-    private lateinit var shutdownHook: Runnable
+    private lateinit var onShutdown: Runnable
 
     private val emulationFragment: EmulationFragment
         get() {
@@ -102,14 +102,14 @@ class EmulationActivity : AppCompatActivity() {
             windowManager.defaultDisplay.rotation
         )
 
-        shutdownHook = Runnable {
+        onShutdown = Runnable {
             if (intent.getBooleanExtra("launched_from_shortcut", false)) {
                 finishAffinity()
             } else {
                 this.finish()
             }
         }
-        EmulationLifecycleUtil.addShutdownHook(shutdownHook)
+        EmulationLifecycleUtil.addShutdownHook(onShutdown)
 
         isEmulationRunning = true
         instance = this
@@ -167,7 +167,7 @@ class EmulationActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
-        EmulationLifecycleUtil.removeHook(shutdownHook)
+        EmulationLifecycleUtil.removeHook(onShutdown)
         NativeLibrary.playTimeManagerStop()
         isEmulationRunning = false
         instance = null

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
@@ -511,8 +511,8 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
     }
 
     override fun onDestroy() {
-        EmulationLifecycleUtil.removeHook(onShutdown)
         EmulationLifecycleUtil.removeHook(onPause)
+        EmulationLifecycleUtil.removeHook(onShutdown)
         super.onDestroy()
     }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
@@ -513,8 +513,8 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
     }
 
     override fun onDestroy() {
-        EmulationLifecycleUtil.remove(shutdownHook)
-        EmulationLifecycleUtil.remove(pauseHook)
+        EmulationLifecycleUtil.removeHook(shutdownHook)
+        EmulationLifecycleUtil.removeHook(pauseHook)
         super.onDestroy()
     }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
@@ -101,8 +101,8 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
     private val emulationViewModel: EmulationViewModel by activityViewModels()
     private val settingsViewModel: SettingsViewModel by viewModels()
 
-    private lateinit var onShutdown: Runnable
-    private lateinit var onPause: Runnable
+    private val onPause = Runnable{ togglePause() }
+    private val onShutdown = Runnable{ emulationState.stop() }
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -159,10 +159,8 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
         emulationState = EmulationState(game.path)
         emulationActivity = requireActivity() as EmulationActivity
         screenAdjustmentUtil = ScreenAdjustmentUtil(requireContext(), requireActivity().windowManager, settingsViewModel.settings)
-        onShutdown = Runnable{ emulationState.stop()}
-        onPause = Runnable{ togglePause()}
-        EmulationLifecycleUtil.addShutdownHook(onShutdown)
         EmulationLifecycleUtil.addPauseResumeHook(onPause)
+        EmulationLifecycleUtil.addShutdownHook(onShutdown)
     }
 
     override fun onCreateView(

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
@@ -101,8 +101,8 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
     private val emulationViewModel: EmulationViewModel by activityViewModels()
     private val settingsViewModel: SettingsViewModel by viewModels()
 
-    private lateinit var shutdownHook: Runnable
-    private lateinit var pauseHook: Runnable
+    private lateinit var onShutdown: Runnable
+    private lateinit var onPause: Runnable
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -159,10 +159,10 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
         emulationState = EmulationState(game.path)
         emulationActivity = requireActivity() as EmulationActivity
         screenAdjustmentUtil = ScreenAdjustmentUtil(requireContext(), requireActivity().windowManager, settingsViewModel.settings)
-        shutdownHook = Runnable{ emulationState.stop()}
-        pauseHook = Runnable{ togglePause()}
-        EmulationLifecycleUtil.addShutdownHook(shutdownHook)
-        EmulationLifecycleUtil.addPauseResumeHook(pauseHook)
+        onShutdown = Runnable{ emulationState.stop()}
+        onPause = Runnable{ togglePause()}
+        EmulationLifecycleUtil.addShutdownHook(onShutdown)
+        EmulationLifecycleUtil.addPauseResumeHook(onPause)
     }
 
     override fun onCreateView(
@@ -513,8 +513,8 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
     }
 
     override fun onDestroy() {
-        EmulationLifecycleUtil.removeHook(shutdownHook)
-        EmulationLifecycleUtil.removeHook(pauseHook)
+        EmulationLifecycleUtil.removeHook(onShutdown)
+        EmulationLifecycleUtil.removeHook(onPause)
         super.onDestroy()
     }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationLifecycleUtil.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationLifecycleUtil.kt
@@ -1,4 +1,4 @@
-// Copyright Citra Emulator Project / Azahar Emulator Project
+// Copyright 2023 Citra Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -18,19 +18,11 @@ object EmulationLifecycleUtil {
     }
 
     fun addShutdownHook(hook: Runnable) {
-        if (shutdownHooks.contains(hook)) {
-            Log.warning("[EmulationLifecycleUtil] Tried to add shutdown hook that already existed. Skipping.")
-        } else {
-            shutdownHooks.add(hook)
-        }
+        shutdownHooks.add(hook)
     }
 
     fun addPauseResumeHook(hook: Runnable) {
-        if (pauseResumeHooks.contains(hook)) {
-            Log.warning("[EmulationLifecycleUtil] Tried to add pause resume hook that already existed. Skipping.")
-        } else {
-            pauseResumeHooks.add(hook)
-        }
+        pauseResumeHooks.add(hook)
     }
 
     fun clear() {

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationLifecycleUtil.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationLifecycleUtil.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationLifecycleUtil.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationLifecycleUtil.kt
@@ -18,15 +18,20 @@ object EmulationLifecycleUtil {
     }
 
     fun addShutdownHook(hook: Runnable) {
-        shutdownHooks.add(hook)
+        if (!shutdownHooks.contains(hook)) shutdownHooks.add(hook)
     }
 
     fun addPauseResumeHook(hook: Runnable) {
-        pauseResumeHooks.add(hook)
+        if (!pauseResumeHooks.contains(hook)) pauseResumeHooks.add(hook)
     }
 
     fun clear() {
         pauseResumeHooks.clear()
         shutdownHooks.clear()
+    }
+
+    fun remove(hook: Runnable) {
+        if (pauseResumeHooks.contains(hook)) pauseResumeHooks.remove(hook)
+        if (shutdownHooks.contains(hook)) shutdownHooks.remove(hook)
     }
 }

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationLifecycleUtil.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationLifecycleUtil.kt
@@ -25,11 +25,6 @@ object EmulationLifecycleUtil {
         if (!pauseResumeHooks.contains(hook)) pauseResumeHooks.add(hook)
     }
 
-    fun clear() {
-        pauseResumeHooks.clear()
-        shutdownHooks.clear()
-    }
-
     fun removeHook(hook: Runnable) {
         if (pauseResumeHooks.contains(hook)) pauseResumeHooks.remove(hook)
         if (shutdownHooks.contains(hook)) shutdownHooks.remove(hook)

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationLifecycleUtil.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationLifecycleUtil.kt
@@ -30,7 +30,7 @@ object EmulationLifecycleUtil {
         shutdownHooks.clear()
     }
 
-    fun remove(hook: Runnable) {
+    fun removeHook(hook: Runnable) {
         if (pauseResumeHooks.contains(hook)) pauseResumeHooks.remove(hook)
         if (shutdownHooks.contains(hook)) shutdownHooks.remove(hook)
     }

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationLifecycleUtil.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationLifecycleUtil.kt
@@ -18,13 +18,17 @@ object EmulationLifecycleUtil {
     }
 
     fun addShutdownHook(hook: Runnable) {
-        if (!shutdownHooks.contains(hook)) {
+        if (shutdownHooks.contains(hook)) {
+            Log.warning("[EmulationLifecycleUtil] Tried to add shutdown hook for function that already existed. Skipping.")
+        } else {
             shutdownHooks.add(hook)
         }
     }
 
     fun addPauseResumeHook(hook: Runnable) {
-        if (!pauseResumeHooks.contains(hook)) {
+        if (pauseResumeHooks.contains(hook)) {
+            Log.warning("[EmulationLifecycleUtil] Tried to add pause resume hook for function that already existed. Skipping.")
+        } else {
             pauseResumeHooks.add(hook)
         }
     }

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationLifecycleUtil.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationLifecycleUtil.kt
@@ -18,15 +18,23 @@ object EmulationLifecycleUtil {
     }
 
     fun addShutdownHook(hook: Runnable) {
-        if (!shutdownHooks.contains(hook)) shutdownHooks.add(hook)
+        if (!shutdownHooks.contains(hook)) {
+            shutdownHooks.add(hook)
+        }
     }
 
     fun addPauseResumeHook(hook: Runnable) {
-        if (!pauseResumeHooks.contains(hook)) pauseResumeHooks.add(hook)
+        if (!pauseResumeHooks.contains(hook)) {
+            pauseResumeHooks.add(hook)
+        }
     }
 
     fun removeHook(hook: Runnable) {
-        if (pauseResumeHooks.contains(hook)) pauseResumeHooks.remove(hook)
-        if (shutdownHooks.contains(hook)) shutdownHooks.remove(hook)
+        if (pauseResumeHooks.contains(hook)) {
+            pauseResumeHooks.remove(hook)
+        }
+        if (shutdownHooks.contains(hook)) {
+            shutdownHooks.remove(hook)
+        }
     }
 }


### PR DESCRIPTION
This is a better fix for bug #1354 than the previous PR. In this version, EmulationActivity and EmulationFragment have been modified to only remove the hooks they added themselves, while EmulationLifeCycleUtil has had some additional sanity checks added to avoid duplicates and allow selective hook removal.