### PR TITLE
Layout refactor

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/display/SecondaryDisplay.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/display/SecondaryDisplay.kt
@@ -23,15 +23,12 @@ class SecondaryDisplay(val context: Context) {
     private val vd: VirtualDisplay
 
     init {
-        val st = SurfaceTexture(0)
-        st.setDefaultBufferSize(1920, 1080)
-        val vdSurface = Surface(st)
         vd = displayManager.createVirtualDisplay(
             "HiddenDisplay",
             1920,
             1080,
             320,
-            vdSurface,
+            null,
             DisplayManager.VIRTUAL_DISPLAY_FLAG_PRESENTATION
         )
     }

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
@@ -19,6 +19,7 @@ enum class BooleanSetting(
     INSTANT_DEBUG_LOG("instant_debug_log", Settings.SECTION_DEBUG, false),
     ENABLE_RPC_SERVER("enable_rpc_server", Settings.SECTION_DEBUG, false),
     CUSTOM_LAYOUT("custom_layout",Settings.SECTION_LAYOUT,false),
+    SWAP_EYES_3D("swap_eyes_3d",Settings.SECTION_RENDERER,false),
     OVERLAY_SHOW_FPS("overlay_show_fps", Settings.SECTION_LAYOUT, true),
     OVERLAY_SHOW_FRAMETIME("overlay_show_frame_time", Settings.SECTION_LAYOUT, false),
     OVERLAY_SHOW_SPEED("overlay_show_speed", Settings.SECTION_LAYOUT, false),

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
@@ -20,6 +20,8 @@ enum class BooleanSetting(
     ENABLE_RPC_SERVER("enable_rpc_server", Settings.SECTION_DEBUG, false),
     CUSTOM_LAYOUT("custom_layout",Settings.SECTION_LAYOUT,false),
     SWAP_EYES_3D("swap_eyes_3d",Settings.SECTION_RENDERER,false),
+
+    RENDER_3D_SECONDARY_ONLY("render_3d_secondary_only",Settings.SECTION_RENDERER,false),
     OVERLAY_SHOW_FPS("overlay_show_fps", Settings.SECTION_LAYOUT, true),
     OVERLAY_SHOW_FRAMETIME("overlay_show_frame_time", Settings.SECTION_LAYOUT, false),
     OVERLAY_SHOW_SPEED("overlay_show_speed", Settings.SECTION_LAYOUT, false),

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -939,6 +939,15 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                 )
             )
             add(
+                SwitchSetting(
+                    BooleanSetting.RENDER_3D_SECONDARY_ONLY,
+                    R.string.render_3d_secondary_only,
+                    R.string.render_3d_secondary_only_description,
+                    BooleanSetting.RENDER_3D_SECONDARY_ONLY.key,
+                    BooleanSetting.RENDER_3D_SECONDARY_ONLY.defaultValue
+                )
+            )
+            add(
                 SliderSetting(
                     IntSetting.STEREOSCOPIC_3D_DEPTH,
                     R.string.factor3d,

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -960,6 +960,16 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                 )
             )
 
+            add(
+                SwitchSetting(
+                    BooleanSetting.SWAP_EYES_3D,
+                    R.string.swap_eyes_3d,
+                    R.string.swap_eyes_3d_description,
+                    BooleanSetting.SWAP_EYES_3D.key,
+                    BooleanSetting.SWAP_EYES_3D.defaultValue
+                )
+            )
+
             add(HeaderSetting(R.string.cardboard_vr))
             add(
                 SliderSetting(

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -175,7 +175,7 @@ void Config::ReadValues() {
     ReadSetting("Renderer", Settings::values.delay_game_render_thread_us);
     ReadSetting("Renderer", Settings::values.disable_right_eye_render);
     ReadSetting("Renderer", Settings::values.swap_eyes_3d);
-    ReadSetting("Renderer",Settings::values.render_3d_secondary_only);
+    ReadSetting("Renderer", Settings::values.render_3d_secondary_only);
     // Layout
     // Somewhat inelegant solution to ensure layout value is between 0 and 5 on read
     // since older config files may have other values

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -174,6 +174,7 @@ void Config::ReadValues() {
     ReadSetting("Renderer", Settings::values.bg_blue);
     ReadSetting("Renderer", Settings::values.delay_game_render_thread_us);
     ReadSetting("Renderer", Settings::values.disable_right_eye_render);
+    ReadSetting("Renderer", Settings::values.swap_eyes_3d);
 
     // Layout
     // Somewhat inelegant solution to ensure layout value is between 0 and 5 on read

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -175,7 +175,7 @@ void Config::ReadValues() {
     ReadSetting("Renderer", Settings::values.delay_game_render_thread_us);
     ReadSetting("Renderer", Settings::values.disable_right_eye_render);
     ReadSetting("Renderer", Settings::values.swap_eyes_3d);
-
+    ReadSetting("Renderer",Settings::values.render_3d_secondary_only);
     // Layout
     // Somewhat inelegant solution to ensure layout value is between 0 and 5 on read
     // since older config files may have other values

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -182,6 +182,10 @@ factor_3d =
 # true or false (default)
 swap_eyes_3d =
 
+# Render 3D To Secondary Display
+# true or false (default)
+render_3d_secondary_only =
+
 # The name of the post processing shader to apply.
 # Loaded from shaders if render_3d is off or side by side.
 pp_shader_name =

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -178,6 +178,10 @@ render_3d =
 # 0 - 255: Intensity. 0 (default)
 factor_3d =
 
+# Swap Eyes in 3d
+# true or false (default)
+swap_eyes_3d =
+
 # The name of the post processing shader to apply.
 # Loaded from shaders if render_3d is off or side by side.
 pp_shader_name =

--- a/src/android/app/src/main/jni/emu_window/emu_window.cpp
+++ b/src/android/app/src/main/jni/emu_window/emu_window.cpp
@@ -50,6 +50,7 @@ void EmuWindow_Android::OnFramebufferSizeChanged() {
     const int bigger{window_width > window_height ? window_width : window_height};
     const int smaller{window_width < window_height ? window_width : window_height};
     if (is_portrait_mode && !is_secondary) {
+        LOG_INFO(Frontend,"Calling UpdateCurrentFramebufferLayout from Emuwindow_android");
         UpdateCurrentFramebufferLayout(smaller, bigger, is_portrait_mode);
     } else {
         UpdateCurrentFramebufferLayout(bigger, smaller, is_portrait_mode);

--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -240,7 +240,7 @@
     <string-array name="render3dModes">
         <item>@string/off</item>
         <item>@string/side_by_side</item>
-        <item>@string/reverse_side_by_side</item>
+        <item>@string/side_by_side_full</item>
         <item>@string/anaglyph</item>
         <item>@string/interlaced</item>
         <item>@string/reverse_interlaced</item>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -284,6 +284,8 @@
     <string name="disable_right_eye_render_description">Greatly improves performance in some applications, but can cause flickering in others.</string>
     <string name="swap_eyes_3d">Swap Eyes</string>
     <string name="swap_eyes_3d_description">Swaps which eye is shown where. Combine with Side by Side mode and cross your eyes to see 3D with no equipment!</string>
+    <string name="render_3d_secondary_only">3D on Secondary Display Only</string>
+    <string name="render_3d_secondary_only_description">If enabled, the selected 3d mode will only be applied on the secondary display (if enabled in the Layout menu). Applies to SBS modes only. </string>
     <string name="cardboard_vr">Cardboard VR</string>
     <string name="cardboard_screen_size">Cardboard Screen Size</string>
     <string name="cardboard_screen_size_description">Scales the screen to a percentage of its original size.</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -282,6 +282,8 @@
     <string name="factor3d_description">Specifies the value of the 3D slider. This should be set to higher than 0% when Stereoscopic 3D is enabled.\nNote: Depth values over 100% are not possible on real hardware and may cause graphical issues</string>
     <string name="disable_right_eye_render">Disable Right Eye Render</string>
     <string name="disable_right_eye_render_description">Greatly improves performance in some applications, but can cause flickering in others.</string>
+    <string name="swap_eyes_3d">Swap Eyes</string>
+    <string name="swap_eyes_3d_description">Swaps which eye is shown where. Combine with Side by Side mode and cross your eyes to see 3D with no equipment!</string>
     <string name="cardboard_vr">Cardboard VR</string>
     <string name="cardboard_screen_size">Cardboard Screen Size</string>
     <string name="cardboard_screen_size_description">Scales the screen to a percentage of its original size.</string>
@@ -703,7 +705,7 @@
 
     <!-- Render 3D modes -->
     <string name="side_by_side">Side by Side</string>
-    <string name="reverse_side_by_side">Reverse Side by Side</string>
+    <string name="side_by_side_full">Side by Side Full Width</string>
     <string name="anaglyph">Anaglyph</string>
     <string name="interlaced">Interlaced</string>
     <string name="reverse_interlaced">Reverse Interlaced</string>

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -347,12 +347,12 @@ struct SoftwareRenderWidget : public RenderWidget {
 
         using VideoCore::ScreenId;
 
-        const auto layout{Layout::DefaultFrameLayout(width(), height(), false, false)};
+        const auto layout{Layout::CreateLayout(Settings::LayoutOption::Default,width(), height())};
         QPainter painter(this);
 
         const auto draw_screen = [&](ScreenId screen_id) {
             const auto rect =
-                screen_id == ScreenId::TopLeft ? layout.top_screen : layout.bottom_screen;
+                screen_id == ScreenId::TopLeft ? layout.screens[0].rect : layout.screens[1].rect;
             const QImage screen =
                 LoadFramebuffer(screen_id).scaled(rect.GetWidth(), rect.GetHeight());
             painter.drawImage(rect.left, rect.top, screen);
@@ -479,7 +479,7 @@ void GRenderWindow::OnFramebufferSizeChanged() {
     const qreal pixel_ratio = windowPixelRatio();
     const u32 width = static_cast<u32>(this->width() * pixel_ratio);
     const u32 height = static_cast<u32>(this->height() * pixel_ratio);
-    UpdateCurrentFramebufferLayout(width, height);
+    UpdateCurrentFramebufferLayout(width, height, false);
 }
 
 void GRenderWindow::BackupGeometry() {

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -517,6 +517,7 @@ void QtConfig::ReadLayoutValues() {
 
     ReadGlobalSetting(Settings::values.render_3d);
     ReadGlobalSetting(Settings::values.factor_3d);
+    ReadGlobalSetting(Settings::values.swap_eyes_3d);
     ReadGlobalSetting(Settings::values.filter_mode);
     ReadGlobalSetting(Settings::values.pp_shader_name);
     ReadGlobalSetting(Settings::values.anaglyph_shader_name);
@@ -1082,6 +1083,7 @@ void QtConfig::SaveLayoutValues() {
 
     WriteGlobalSetting(Settings::values.render_3d);
     WriteGlobalSetting(Settings::values.factor_3d);
+    WriteGlobalSetting(Settings::values.swap_eyes_3d);
     WriteGlobalSetting(Settings::values.filter_mode);
     WriteGlobalSetting(Settings::values.pp_shader_name);
     WriteGlobalSetting(Settings::values.anaglyph_shader_name);

--- a/src/citra_qt/configuration/configure_enhancements.cpp
+++ b/src/citra_qt/configuration/configure_enhancements.cpp
@@ -57,6 +57,7 @@ void ConfigureEnhancements::SetConfiguration() {
 
     ui->render_3d_combobox->setCurrentIndex(
         static_cast<int>(Settings::values.render_3d.GetValue()));
+    ui->swap_eyes_3d->setChecked(Settings::values.swap_eyes_3d.GetValue());
     ui->factor_3d->setValue(Settings::values.factor_3d.GetValue());
     ui->mono_rendering_eye->setCurrentIndex(
         static_cast<int>(Settings::values.mono_render_option.GetValue()));
@@ -111,6 +112,7 @@ void ConfigureEnhancements::ApplyConfiguration() {
                                              ui->resolution_factor_combobox);
     Settings::values.render_3d =
         static_cast<Settings::StereoRenderOption>(ui->render_3d_combobox->currentIndex());
+    Settings::values.swap_eyes_3d = ui->swap_eyes_3d->isChecked();
     Settings::values.factor_3d = ui->factor_3d->value();
     Settings::values.mono_render_option =
         static_cast<Settings::MonoRenderOption>(ui->mono_rendering_eye->currentIndex());

--- a/src/citra_qt/configuration/configure_enhancements.ui
+++ b/src/citra_qt/configuration/configure_enhancements.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>440</width>
-    <height>950</height>
+    <height>891</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -236,7 +236,7 @@
           </item>
           <item>
            <property name="text">
-            <string>Reverse Side by Side</string>
+            <string>Side by Side Full Width</string>
            </property>
           </item>
           <item>
@@ -318,14 +318,19 @@
        </layout>
       </item>
       <item>
-        <widget class="QCheckBox" name="disable_right_eye_render">
-          <property name="text">
-            <string>Disable Right Eye Rendering</string>
-          </property>
-          <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Disable Right Eye Rendering&lt;/p&gt;&lt;p&gt;Disables rendering the right eye image when not using stereoscopic mode. Greatly improves performance in some applications, but can cause flickering in others.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-        </widget>
+       <widget class="QCheckBox" name="disable_right_eye_render">
+        <property name="text">
+         <string>Disable Right Eye Rendering</string>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Disable Right Eye Rendering&lt;/p&gt;&lt;p&gt;Disables rendering the right eye image when not using stereoscopic mode. Greatly improves performance in some applications, but can cause flickering in others.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+       <widget class="QCheckBox" name="swap_eyes_3d">
+        <property name="text">
+         <string>Swap Eyes</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/citra_qt/configuration/configure_enhancements.ui
+++ b/src/citra_qt/configuration/configure_enhancements.ui
@@ -326,6 +326,8 @@
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Disable Right Eye Rendering&lt;/p&gt;&lt;p&gt;Disables rendering the right eye image when not using stereoscopic mode. Greatly improves performance in some applications, but can cause flickering in others.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="swap_eyes_3d">
         <property name="text">
          <string>Swap Eyes</string>

--- a/src/citra_sdl/default_ini.h
+++ b/src/citra_sdl/default_ini.h
@@ -163,6 +163,10 @@ render_3d =
 # 0 - 100: Intensity. 0 (default)
 factor_3d =
 
+# Swap Eyes in 3D
+# true or false (default)
+swap_eyes_3d =
+
 # Change Default Eye to Render When in Monoscopic Mode
 # 0 (default): Left, 1: Right
 mono_render_option =

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -109,7 +109,8 @@ void LogSettings() {
     log_setting("Stereoscopy_Render3d", values.render_3d.GetValue());
     log_setting("Stereoscopy_Factor3d", values.factor_3d.GetValue());
     log_setting("Stereoscopy_Swap_Eyes", values.swap_eyes_3d.GetValue());
-    log_setting("Stereoscopy_Render_3d_to_secondary_only",values.render_3d_secondary_only.GetValue());
+    log_setting("Stereoscopy_Render_3d_to_secondary_only",
+                values.render_3d_secondary_only.GetValue());
     log_setting("Stereoscopy_MonoRenderOption", values.mono_render_option.GetValue());
     if (values.render_3d.GetValue() == StereoRenderOption::Anaglyph) {
         log_setting("Renderer_AnaglyphShader", values.anaglyph_shader_name.GetValue());

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -108,6 +108,7 @@ void LogSettings() {
     log_setting("Renderer_DisableRightEyeRender", values.disable_right_eye_render.GetValue());
     log_setting("Stereoscopy_Render3d", values.render_3d.GetValue());
     log_setting("Stereoscopy_Factor3d", values.factor_3d.GetValue());
+    log_setting("Stereoscopy_Swap_Eyes",values.swap_eyes_3d.GetValue());
     log_setting("Stereoscopy_MonoRenderOption", values.mono_render_option.GetValue());
     if (values.render_3d.GetValue() == StereoRenderOption::Anaglyph) {
         log_setting("Renderer_AnaglyphShader", values.anaglyph_shader_name.GetValue());
@@ -218,6 +219,7 @@ void RestoreGlobalState(bool is_powered_on) {
     values.bg_green.SetGlobal(true);
     values.bg_blue.SetGlobal(true);
     values.render_3d.SetGlobal(true);
+    values.swap_eyes_3d.SetGlobal(true);
     values.factor_3d.SetGlobal(true);
     values.filter_mode.SetGlobal(true);
     values.pp_shader_name.SetGlobal(true);

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -109,6 +109,7 @@ void LogSettings() {
     log_setting("Stereoscopy_Render3d", values.render_3d.GetValue());
     log_setting("Stereoscopy_Factor3d", values.factor_3d.GetValue());
     log_setting("Stereoscopy_Swap_Eyes", values.swap_eyes_3d.GetValue());
+    log_setting("Stereoscopy_Render_3d_to_secondary_only",values.render_3d_secondary_only.GetValue());
     log_setting("Stereoscopy_MonoRenderOption", values.mono_render_option.GetValue());
     if (values.render_3d.GetValue() == StereoRenderOption::Anaglyph) {
         log_setting("Renderer_AnaglyphShader", values.anaglyph_shader_name.GetValue());
@@ -220,6 +221,7 @@ void RestoreGlobalState(bool is_powered_on) {
     values.bg_blue.SetGlobal(true);
     values.render_3d.SetGlobal(true);
     values.swap_eyes_3d.SetGlobal(true);
+    values.render_3d_secondary_only.SetGlobal(true);
     values.factor_3d.SetGlobal(true);
     values.filter_mode.SetGlobal(true);
     values.pp_shader_name.SetGlobal(true);

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -108,7 +108,7 @@ void LogSettings() {
     log_setting("Renderer_DisableRightEyeRender", values.disable_right_eye_render.GetValue());
     log_setting("Stereoscopy_Render3d", values.render_3d.GetValue());
     log_setting("Stereoscopy_Factor3d", values.factor_3d.GetValue());
-    log_setting("Stereoscopy_Swap_Eyes",values.swap_eyes_3d.GetValue());
+    log_setting("Stereoscopy_Swap_Eyes", values.swap_eyes_3d.GetValue());
     log_setting("Stereoscopy_MonoRenderOption", values.mono_render_option.GetValue());
     if (values.render_3d.GetValue() == StereoRenderOption::Anaglyph) {
         log_setting("Renderer_AnaglyphShader", values.anaglyph_shader_name.GetValue());

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -562,7 +562,7 @@ struct Values {
     SwitchableSetting<StereoRenderOption> render_3d{StereoRenderOption::Off, "render_3d"};
     SwitchableSetting<u32> factor_3d{0, "factor_3d"};
     SwitchableSetting<bool> swap_eyes_3d{false, "swap_eyes_3d"};
-    SwitchableSetting<bool> render_3d_secondary_only{false,"render_3d_secondary_only"};
+    SwitchableSetting<bool> render_3d_secondary_only{false, "render_3d_secondary_only"};
     SwitchableSetting<MonoRenderOption> mono_render_option{MonoRenderOption::LeftEye,
                                                            "mono_render_option"};
 

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -72,11 +72,11 @@ enum class SmallScreenPosition : u32 {
 enum class StereoRenderOption : u32 {
     Off = 0,
     SideBySide = 1,
-    ReverseSideBySide = 2,
-    Anaglyph = 3,
-    Interlaced = 4,
-    ReverseInterlaced = 5,
-    CardboardVR = 6
+    SideBySideFull = 2,
+    Anaglyph = 4,
+    Interlaced = 5,
+    ReverseInterlaced = 6,
+    CardboardVR = 7
 };
 
 // Which eye to render when 3d is off. 800px wide mode could be added here in the future, when
@@ -561,6 +561,7 @@ struct Values {
 
     SwitchableSetting<StereoRenderOption> render_3d{StereoRenderOption::Off, "render_3d"};
     SwitchableSetting<u32> factor_3d{0, "factor_3d"};
+    SwitchableSetting<bool> swap_eyes_3d{false, "swap_eyes"};
     SwitchableSetting<MonoRenderOption> mono_render_option{MonoRenderOption::LeftEye,
                                                            "mono_render_option"};
 

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -561,7 +561,7 @@ struct Values {
 
     SwitchableSetting<StereoRenderOption> render_3d{StereoRenderOption::Off, "render_3d"};
     SwitchableSetting<u32> factor_3d{0, "factor_3d"};
-    SwitchableSetting<bool> swap_eyes_3d{false, "swap_eyes"};
+    SwitchableSetting<bool> swap_eyes_3d{false, "swap_eyes_3d"};
     SwitchableSetting<MonoRenderOption> mono_render_option{MonoRenderOption::LeftEye,
                                                            "mono_render_option"};
 

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -562,6 +562,7 @@ struct Values {
     SwitchableSetting<StereoRenderOption> render_3d{StereoRenderOption::Off, "render_3d"};
     SwitchableSetting<u32> factor_3d{0, "factor_3d"};
     SwitchableSetting<bool> swap_eyes_3d{false, "swap_eyes_3d"};
+    SwitchableSetting<bool> render_3d_secondary_only{false,"render_3d_secondary_only"};
     SwitchableSetting<MonoRenderOption> mono_render_option{MonoRenderOption::LeftEye,
                                                            "mono_render_option"};
 

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -201,9 +201,10 @@ void EmuWindow::UpdateCurrentFramebufferLayout(u32 width, u32 height, bool is_po
     const Settings::LayoutOption layout_option = Settings::values.layout_option.GetValue();
     const Settings::StereoRenderOption stereo_option = Settings::values.render_3d.GetValue();
     bool render_full_stereo = (stereo_option == Settings::StereoRenderOption::SideBySideFull);
-
+    bool is_bottom = is_secondary;
+    if (Settings::values.swap_screen.GetValue()) is_bottom = !is_bottom;
 #ifndef ANDROID
-    if (layout_option == Settings::LayoutOption::SeparateWindows && is_secondary) {
+    if (layout_option == Settings::LayoutOption::SeparateWindows && is_bottom) {
         render_full_stereo = false;
     }
 #endif

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -180,10 +180,8 @@ void EmuWindow::UpdateCurrentFramebufferLayout(u32 width, u32 height, bool is_po
 
     const Settings::PortraitLayoutOption portrait_layout_option =
         Settings::values.portrait_layout_option.GetValue();
-    const auto min_size = is_portrait_mode
-                              ? Layout::GetMinimumSizeFromPortraitLayout()
-                              : Layout::GetMinimumSizeFromLayout(
-                                    layout_option, Settings::values.upright_screen.GetValue());
+    const auto min_size = is_portrait_mode ? Layout::GetMinimumSizeFromPortraitLayout()
+                                           : Layout::GetMinimumSizeFromLayout(layout_option);
 
     width = std::max(width, min_size.first);
     height = std::max(height, min_size.second);
@@ -191,7 +189,7 @@ void EmuWindow::UpdateCurrentFramebufferLayout(u32 width, u32 height, bool is_po
     if (is_portrait_mode) {
         layout = Layout::CreatePortraitLayout(portrait_layout_option, width, height, swapped,
                                               upright, stereo_option, swap_eyes);
-    } else if (is_mobile && is_secondary) { //TODO: Let Pablo look at this and help make it better?
+    } else if (is_mobile && is_secondary) { // TODO: Let Pablo look at this and help make it better?
         layout = Layout::CreateMobileSecondaryLayout(
             Settings::values.secondary_display_layout.GetValue(), width, height, swapped, upright,
             stereo_option, swap_eyes);

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -60,7 +60,9 @@ bool EmuWindow::IsWithinTouchscreen(const Layout::FramebufferLayout& layout, uns
 #ifndef ANDROID
     // If separate windows and the touch is in the primary (top) screen, ignore it.
     if (Settings::values.layout_option.GetValue() == Settings::LayoutOption::SeparateWindows &&
-        !is_secondary && !Settings::values.swap_screen.GetValue()) {
+            (!is_secondary && !Settings::values.swap_screen.GetValue()) ||
+            (is_secondary && Settings::values.swap_screen.GetValue())
+        ) {
         return false;
     }
 #endif

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -110,11 +110,12 @@ void EmuWindow::CreateTouchState() {
 }
 
 bool EmuWindow::TouchPressed(unsigned framebuffer_x, unsigned framebuffer_y) {
-    int screenIndex = WhichTouchscreen(framebuffer_layout, framebuffer_x, framebuffer_y);
+    const int screenIndex = WhichTouchscreen(framebuffer_layout, framebuffer_x, framebuffer_y);
     if (screenIndex < 0)
         return false;
-    Settings::StereoRenderOption render_3d_mode = get3DMode();
+    const Settings::StereoRenderOption render_3d_mode = get3DMode();
 
+    // TODO: test cardboard
     if (render_3d_mode == Settings::StereoRenderOption::CardboardVR)
         framebuffer_x -=
             (framebuffer_layout.width / 2) - (framebuffer_layout.cardboard.user_x_shift * 2);
@@ -186,11 +187,11 @@ void EmuWindow::UpdateCurrentFramebufferLayout(u32 width, u32 height, bool is_po
     width = std::max(width, min_size.first);
     height = std::max(height, min_size.second);
 
-   if (is_mobile && is_secondary) { // TODO: Let Pablo look at this and help make it better?
+    if (is_mobile && is_secondary) { // TODO: Let Pablo look at this and help make it better?
         layout = Layout::CreateMobileSecondaryLayout(
             Settings::values.secondary_display_layout.GetValue(), width, height, swapped, upright,
             stereo_option, swap_eyes);
-    }  else if (is_portrait_mode) {
+    } else if (is_portrait_mode) {
         layout = Layout::CreatePortraitLayout(portrait_layout_option, width, height, swapped,
                                               upright, stereo_option, swap_eyes);
     } else {

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -186,13 +186,13 @@ void EmuWindow::UpdateCurrentFramebufferLayout(u32 width, u32 height, bool is_po
     width = std::max(width, min_size.first);
     height = std::max(height, min_size.second);
 
-    if (is_portrait_mode) {
-        layout = Layout::CreatePortraitLayout(portrait_layout_option, width, height, swapped,
-                                              upright, stereo_option, swap_eyes);
-    } else if (is_mobile && is_secondary) { // TODO: Let Pablo look at this and help make it better?
+   if (is_mobile && is_secondary) { // TODO: Let Pablo look at this and help make it better?
         layout = Layout::CreateMobileSecondaryLayout(
             Settings::values.secondary_display_layout.GetValue(), width, height, swapped, upright,
             stereo_option, swap_eyes);
+    }  else if (is_portrait_mode) {
+        layout = Layout::CreatePortraitLayout(portrait_layout_option, width, height, swapped,
+                                              upright, stereo_option, swap_eyes);
     } else {
 #ifndef ANDROID
         if (layout_option == Settings::LayoutOption::SeparateWindows) {

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -198,8 +198,16 @@ void EmuWindow::TouchMoved(unsigned framebuffer_x, unsigned framebuffer_y) {
 
 void EmuWindow::UpdateCurrentFramebufferLayout(u32 width, u32 height, bool is_portrait_mode) {
     Layout::FramebufferLayout layout;
-
     const Settings::LayoutOption layout_option = Settings::values.layout_option.GetValue();
+    const Settings::StereoRenderOption stereo_option = Settings::values.render_3d.GetValue();
+    bool render_full_stereo = (stereo_option == Settings::StereoRenderOption::SideBySideFull);
+
+#ifndef ANDROID
+    if (layout_option == Settings::LayoutOption::SeparateWindows && is_secondary) {
+        render_full_stereo = false;
+    }
+#endif
+
     const Settings::PortraitLayoutOption portrait_layout_option =
         Settings::values.portrait_layout_option.GetValue();
     const auto min_size = is_portrait_mode
@@ -209,7 +217,7 @@ void EmuWindow::UpdateCurrentFramebufferLayout(u32 width, u32 height, bool is_po
 
     width = std::max(width, min_size.first);
     height = std::max(height, min_size.second);
-    if (Settings::values.render_3d.GetValue() == Settings::StereoRenderOption::SideBySideFull) {
+    if (render_full_stereo) {
         if (Settings::values.upright_screen.GetValue()) {
             height = height / 2;
         } else {
@@ -276,17 +284,13 @@ void EmuWindow::UpdateCurrentFramebufferLayout(u32 width, u32 height, bool is_po
             break;
         }
     }
-bool separate_win = false;
 #ifdef ANDROID
     if (is_secondary) {
         layout = Layout::AndroidSecondaryLayout(width, height);
     }
-#else
-    separate_win =
-        (Settings::values.layout_option.GetValue() == Settings::LayoutOption::SeparateWindows);
 #endif
 
-    if (Settings::values.render_3d.GetValue() == Settings::StereoRenderOption::SideBySideFull && !separate_win) {
+    if (render_full_stereo) {
         if (Settings::values.upright_screen.GetValue()) {
             layout.height = height * 2;
         } else {

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -171,13 +171,12 @@ void EmuWindow::UpdateCurrentFramebufferLayout(u32 width, u32 height, bool is_po
         stereo_option == Settings::StereoRenderOption::Off
             ? Settings::values.mono_render_option.GetValue() == Settings::MonoRenderOption::RightEye
             : Settings::values.swap_eyes_3d.GetValue();
-    bool is_bottom = is_secondary;
-    bool is_mobile = false;
+
 #ifdef ANDROID
-    is_mobile = true;
+    const bool is_mobile = true;
+#else
+    const bool is_mobile = false;
 #endif
-    if (Settings::values.swap_screen.GetValue())
-        is_bottom = !is_bottom;
 
     const Settings::PortraitLayoutOption portrait_layout_option =
         Settings::values.portrait_layout_option.GetValue();
@@ -187,7 +186,7 @@ void EmuWindow::UpdateCurrentFramebufferLayout(u32 width, u32 height, bool is_po
     width = std::max(width, min_size.first);
     height = std::max(height, min_size.second);
 
-    if (is_mobile && is_secondary) { // TODO: Let Pablo look at this and help make it better?
+    if (is_mobile && is_secondary) {
         layout = Layout::CreateMobileSecondaryLayout(
             Settings::values.secondary_display_layout.GetValue(), width, height, swapped, upright,
             stereo_option, swap_eyes);
@@ -198,7 +197,7 @@ void EmuWindow::UpdateCurrentFramebufferLayout(u32 width, u32 height, bool is_po
 #ifndef ANDROID
         if (layout_option == Settings::LayoutOption::SeparateWindows) {
             layout_option = Settings::LayoutOption::SingleScreen;
-            swapped = is_bottom;
+            swapped = (is_secondary != swapped); // swapped here really means "is bottom"
         }
 #endif
         layout = Layout::CreateLayout(layout_option, width, height, swapped, upright, stereo_option,

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -142,9 +142,6 @@ bool EmuWindow::TouchPressed(unsigned framebuffer_x, unsigned framebuffer_y) {
         (Settings::values.layout_option.GetValue() == Settings::LayoutOption::SeparateWindows);
 #endif
 
-    // if (!IsWithinTouchscreen(framebuffer_layout, framebuffer_x, framebuffer_y))
-    //     return false;
-
     if (!separate_win) {
         if (framebuffer_x >= framebuffer_layout.width / 2) {
             if (render_3d_mode == Settings::StereoRenderOption::SideBySide ||
@@ -221,11 +218,7 @@ void EmuWindow::UpdateCurrentFramebufferLayout(u32 width, u32 height, bool is_po
     width = std::max(width, min_size.first);
     height = std::max(height, min_size.second);
     if (render_full_stereo) {
-        if (Settings::values.upright_screen.GetValue()) {
-            height = height / 2;
-        } else {
             width = width / 2;
-        }
     }
     if (is_portrait_mode) {
         switch (portrait_layout_option) {
@@ -294,11 +287,7 @@ void EmuWindow::UpdateCurrentFramebufferLayout(u32 width, u32 height, bool is_po
 #endif
 
     if (render_full_stereo) {
-        if (Settings::values.upright_screen.GetValue()) {
-            layout.height = height * 2;
-        } else {
-            layout.width = width * 2;
-        }
+        layout.width = width * 2;
     }
     UpdateMinimumWindowSize(min_size);
 

--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -258,6 +258,8 @@ public:
         return is_secondary;
     }
 
+    Settings::StereoRenderOption get3DMode() const;
+
 protected:
     EmuWindow();
     EmuWindow(bool is_secondary);

--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -308,14 +308,14 @@ private:
     void CreateTouchState();
 
     /**
-     * Check if the given x/y coordinates are within the touchpad specified by the framebuffer
-     * layout
+     * Check if the given x/y coordinates are within any touchpad specified by the framebuffer
+     * layout and returns the index of the screen. Returns -1 if inside none.
      * @param layout FramebufferLayout object describing the framebuffer size and screen positions
      * @param framebuffer_x Framebuffer x-coordinate to check
      * @param framebuffer_y Framebuffer y-coordinate to check
      * @return True if the coordinates are within the touchpad, otherwise false
      */
-    bool IsWithinTouchscreen(const Layout::FramebufferLayout& layout, unsigned framebuffer_x,
+    int WhichTouchscreen(const Layout::FramebufferLayout& layout, unsigned framebuffer_x,
                              unsigned framebuffer_y);
 
     Layout::FramebufferLayout framebuffer_layout; ///< Current framebuffer layout
@@ -329,7 +329,7 @@ private:
     /**
      * Clip the provided coordinates to be inside the touchscreen area.
      */
-    std::tuple<unsigned, unsigned> ClipToTouchScreen(unsigned new_x, unsigned new_y) const;
+    std::tuple<unsigned, unsigned> ClipToTouchScreen(unsigned new_x, unsigned new_y, int index) const;
 
     void UpdateMinimumWindowSize(std::pair<unsigned, unsigned> min_size);
 };

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -471,9 +471,6 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
                 width = Core::kScreenTopWidth * res_scale;
                 height = Core::kScreenTopHeight * res_scale;
             }
-            if (stereo_full && !separate_window) {
-                width = width / 2;
-            }
             if (Settings::values.upright_screen.GetValue()) {
                 std::swap(width, height);
             }

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -407,6 +407,9 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
                                                  bool is_portrait) {
     u32 width, height, gap;
     gap = (int)(Settings::values.screen_gap.GetValue()) * res_scale;
+     bool stereo_full =
+        Settings::values.render_3d.GetValue() == Settings::StereoRenderOption::SideBySideFull;
+    bool separate_window = false;
     FramebufferLayout layout;
     if (is_portrait) {
         auto layout_option = Settings::values.portrait_layout_option.GetValue();
@@ -456,6 +459,7 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
             break;
 #ifndef ANDROID
         case Settings::LayoutOption::SeparateWindows:
+                separate_window = true;
 #endif
         case Settings::LayoutOption::SingleScreen:
         {
@@ -466,6 +470,9 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
             } else {
                 width = Core::kScreenTopWidth * res_scale;
                 height = Core::kScreenTopHeight * res_scale;
+            }
+            if (stereo_full && !separate_window) {
+                width = width / 2;
             }
             if (Settings::values.upright_screen.GetValue()) {
                 std::swap(width, height);

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -17,11 +17,11 @@ static constexpr float BOT_SCREEN_ASPECT_RATIO =
     static_cast<float>(Core::kScreenBottomHeight) / Core::kScreenBottomWidth;
 
 u32 FramebufferLayout::GetScalingRatio() const {
-    int core_width = screens[0].is_bottom ? Core::kScreenBottomWidth : Core::kScreenTopWidth;
-    int core_height = screens[0].is_bottom ? Core::kScreenBottomHeight : Core::kScreenTopHeight;
+    const int core_width = screens[0].is_bottom ? Core::kScreenBottomWidth : Core::kScreenTopWidth;
+    const int core_height =
+        screens[0].is_bottom ? Core::kScreenBottomHeight : Core::kScreenTopHeight;
     if (orientation == DisplayOrientation::Landscape ||
         orientation == DisplayOrientation::LandscapeFlipped) {
-
         return static_cast<u32>(((screens[0].rect.GetWidth() - 1) / core_width) + 1);
     } else {
         return static_cast<u32>(((screens[0].rect.GetWidth() - 1) / core_height) + 1);
@@ -153,7 +153,7 @@ FramebufferLayout CreatePortraitLayout(Settings::PortraitLayoutOption layout_opt
                                        Settings::StereoRenderOption render_3d, bool swap_eyes) {
     ASSERT(width > 0);
     ASSERT(height > 0);
-    LOG_INFO(Frontend,"Creating new portrait layout");
+    LOG_INFO(Frontend, "Creating new portrait layout");
     if (upright) {
         std::swap(width, height);
     }
@@ -161,9 +161,8 @@ FramebufferLayout CreatePortraitLayout(Settings::PortraitLayoutOption layout_opt
     switch (layout_option) {
     case Settings::PortraitLayoutOption::PortraitTopFullWidth: {
         const float scale_factor = swapped ? 1.25f : 0.8f;
-        res =
-            LargeFrameLayout(width, height, swapped, scale_factor,
-                             Settings::SmallScreenPosition::BelowLarge, swap_eyes);
+        res = LargeFrameLayout(width, height, swapped, scale_factor,
+                               Settings::SmallScreenPosition::BelowLarge, swap_eyes);
         const int shiftY = res.screens[0].rect.top;
         res.screens[0].rect = res.screens[0].rect.TranslateY(-shiftY);
         res.screens[1].rect = res.screens[1].rect.TranslateY(-shiftY);
@@ -176,9 +175,8 @@ FramebufferLayout CreatePortraitLayout(Settings::PortraitLayoutOption layout_opt
     case Settings::PortraitLayoutOption::PortraitOriginal:
     default: {
         const float scale_factor = 1;
-        res =
-            LargeFrameLayout(width, height, swapped, scale_factor,
-                             Settings::SmallScreenPosition::BelowLarge, swap_eyes);
+        res = LargeFrameLayout(width, height, swapped, scale_factor,
+                               Settings::SmallScreenPosition::BelowLarge, swap_eyes);
         const int shiftY = res.screens[0].rect.top;
         res.screens[0].rect = res.screens[0].rect.TranslateY(-shiftY);
         res.screens[1].rect = res.screens[1].rect.TranslateY(-shiftY);
@@ -197,7 +195,6 @@ FramebufferLayout CreatePortraitLayout(Settings::PortraitLayoutOption layout_opt
     } else if (render_3d == Settings::StereoRenderOption::SideBySide) {
         res = ApplyHalfStereo(res, swap_eyes);
     }
- //   LOG_INFO(Frontend,"Layout with {} screens. Screen 0 is {},{},{}.{}",res.screens.size(),res.screens[0].rect.left,res.screens[0].rect.right,res.screens[0].rect.top,res.screens[0].rect.bottom);
     return res;
 }
 
@@ -259,8 +256,8 @@ FramebufferLayout SingleFrameLayout(u32 width, u32 height, bool is_bottom, bool 
                          .TranslateY((height - bot_screen.GetHeight()) / 2);
     }
 #endif
-    Screen top{top_screen, false, swap_eyes, true};
-    Screen bot{bot_screen, true, swap_eyes, true};
+    const Screen top{top_screen, false, swap_eyes, true};
+    const Screen bot{bot_screen, true, swap_eyes, true};
     if (is_bottom) {
         res.screens.push_back(bot);
     } else {
@@ -281,13 +278,13 @@ FramebufferLayout LargeFrameLayout(u32 width, u32 height, bool swapped, float sc
     // To do that, find the total emulation box and maximize that based on window size
     u32 gap = (u32)(Settings::values.screen_gap.GetValue() * scale_factor);
 
-    float large_height =
+    const float large_height =
         swapped ? Core::kScreenBottomHeight * scale_factor : Core::kScreenTopHeight * scale_factor;
-    float small_height =
+    const float small_height =
         static_cast<float>(swapped ? Core::kScreenTopHeight : Core::kScreenBottomHeight);
-    float large_width =
+    const float large_width =
         swapped ? Core::kScreenBottomWidth * scale_factor : Core::kScreenTopWidth * scale_factor;
-    float small_width =
+    const float small_width =
         static_cast<float>(swapped ? Core::kScreenTopWidth : Core::kScreenBottomWidth);
 
     float emulation_width;
@@ -306,7 +303,6 @@ FramebufferLayout LargeFrameLayout(u32 width, u32 height, bool swapped, float sc
 
     Common::Rectangle<u32> screen_window_area{0, 0, width, height};
     Common::Rectangle<u32> total_rect = MaxRectangle(screen_window_area, emulation_aspect_ratio);
-    // TODO: Wtf does this `scale_amount` value represent? -OS
     const float scale_amount = static_cast<float>(total_rect.GetHeight()) / emulation_height;
     gap = static_cast<u32>(static_cast<float>(gap) * scale_amount);
 
@@ -322,6 +318,7 @@ FramebufferLayout LargeFrameLayout(u32 width, u32 height, bool swapped, float sc
     if (window_aspect_ratio < emulation_aspect_ratio) {
         // shift the large screen so it is at the left position of the bounding rectangle
         large_screen = large_screen.TranslateX((width - total_rect.GetWidth()) / 2);
+
     } else {
         // shift the large screen so it is at the top position of the bounding rectangle
         large_screen = large_screen.TranslateY((height - total_rect.GetHeight()) / 2);
@@ -390,23 +387,26 @@ FramebufferLayout LargeFrameLayout(u32 width, u32 height, bool swapped, float sc
         UNREACHABLE();
         break;
     }
-    Screen large = Screen{large_screen, swapped, swap_eyes, true};
-    Screen small = Screen{small_screen, !swapped, swap_eyes, true};
+    const Screen large = Screen{large_screen, swapped, swap_eyes, true};
+    const Screen small = Screen{small_screen, !swapped, swap_eyes, true};
     res.screens.push_back(large);
     res.screens.push_back(small);
     return res;
 }
 
 FramebufferLayout HybridScreenLayout(u32 width, u32 height, bool swapped, bool swap_eyes) {
-    float ratio = swapped ? 2.25f : 1.8f;
-    FramebufferLayout res =
-        LargeFrameLayout(width, height, swapped, ratio, Settings::SmallScreenPosition::BottomRight);
+    const float ratio = swapped ? 2.25f : 1.8f;
+    const Settings::SmallScreenPosition pos = swapped ? Settings::SmallScreenPosition::TopRight
+                                                      : Settings::SmallScreenPosition::BottomRight;
+    FramebufferLayout res = LargeFrameLayout(width, height, swapped, ratio, pos);
 
     // screens[0] is the large screen, screens[1] is the small screen. Add the other small screen.
-    Screen small_screen =
-        Screen{Common::Rectangle<u32>{res.screens[1].rect.left, res.screens[0].rect.top,
-                                      res.screens[1].rect.right, res.screens[1].rect.top},
-               res.screens[0].is_bottom, swap_eyes, true};
+    const Screen small_screen = Screen{
+        Common::Rectangle<u32>{res.screens[1].rect.left,
+                               swapped ? res.screens[1].rect.bottom : res.screens[0].rect.top,
+                               res.screens[1].rect.right,
+                               swapped ? res.screens[0].rect.bottom : res.screens[1].rect.top},
+        res.screens[0].is_bottom, swap_eyes, true};
     res.screens.push_back(small_screen);
     return res;
 }
@@ -599,7 +599,7 @@ FramebufferLayout GetCardboardSettings(const FramebufferLayout& layout) {
 FramebufferLayout reverseLayout(FramebufferLayout layout) {
     std::swap(layout.height, layout.width);
     u32 oldLeft, oldRight, oldTop, oldBottom;
-    for (Screen s : layout.screens) {
+    for (Screen& s : layout.screens) {
         oldLeft = s.rect.left;
         oldRight = s.rect.right;
         oldTop = s.rect.top;
@@ -615,8 +615,8 @@ FramebufferLayout reverseLayout(FramebufferLayout layout) {
 FramebufferLayout ApplyFullStereo(FramebufferLayout layout, bool swap_eyes) {
     // assumptions: the screens have already been set up so they are on the left side
     // if swap_eyes is true, those screens have already been set to right eye
-    int s = layout.screens.size();
-    for (int i = 0; i < s; i++) {
+    int screenCount = layout.screens.size();
+    for (int i = 0; i < screenCount; i++) {
         Screen new_screen = layout.screens[i];
         new_screen.rect.left += layout.width / 2;
         new_screen.rect.right += layout.width / 2;
@@ -627,8 +627,8 @@ FramebufferLayout ApplyFullStereo(FramebufferLayout layout, bool swap_eyes) {
 }
 
 FramebufferLayout ApplyHalfStereo(FramebufferLayout layout, bool swap_eyes) {
-    int s = layout.screens.size();
-    for (int i = 0; i < s; i++) {
+    int screenCount = layout.screens.size();
+    for (int i = 0; i < screenCount; i++) {
         Screen& s = layout.screens[i];
         s.rect.left /= 2;
         s.rect.right /= 2;

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -153,6 +153,7 @@ FramebufferLayout CreatePortraitLayout(Settings::PortraitLayoutOption layout_opt
                                        Settings::StereoRenderOption render_3d, bool swap_eyes) {
     ASSERT(width > 0);
     ASSERT(height > 0);
+    LOG_INFO(Frontend,"Creating new portrait layout");
     if (upright) {
         std::swap(width, height);
     }
@@ -160,12 +161,12 @@ FramebufferLayout CreatePortraitLayout(Settings::PortraitLayoutOption layout_opt
     switch (layout_option) {
     case Settings::PortraitLayoutOption::PortraitTopFullWidth: {
         const float scale_factor = swapped ? 1.25f : 0.8f;
-        FramebufferLayout res =
+        res =
             LargeFrameLayout(width, height, swapped, scale_factor,
                              Settings::SmallScreenPosition::BelowLarge, swap_eyes);
         const int shiftY = res.screens[0].rect.top;
-        res.screens[0].rect = res.screens[0].rect.TranslateY(shiftY);
-        res.screens[1].rect = res.screens[1].rect.TranslateY(shiftY);
+        res.screens[0].rect = res.screens[0].rect.TranslateY(-shiftY);
+        res.screens[1].rect = res.screens[1].rect.TranslateY(-shiftY);
         break;
     }
     case Settings::PortraitLayoutOption::PortraitCustomLayout: {
@@ -175,12 +176,12 @@ FramebufferLayout CreatePortraitLayout(Settings::PortraitLayoutOption layout_opt
     case Settings::PortraitLayoutOption::PortraitOriginal:
     default: {
         const float scale_factor = 1;
-        FramebufferLayout res =
+        res =
             LargeFrameLayout(width, height, swapped, scale_factor,
                              Settings::SmallScreenPosition::BelowLarge, swap_eyes);
         const int shiftY = res.screens[0].rect.top;
-        res.screens[0].rect = res.screens[0].rect.TranslateY(shiftY);
-        res.screens[1].rect = res.screens[1].rect.TranslateY(shiftY);
+        res.screens[0].rect = res.screens[0].rect.TranslateY(-shiftY);
+        res.screens[1].rect = res.screens[1].rect.TranslateY(-shiftY);
         break;
     }
     }
@@ -196,6 +197,7 @@ FramebufferLayout CreatePortraitLayout(Settings::PortraitLayoutOption layout_opt
     } else if (render_3d == Settings::StereoRenderOption::SideBySide) {
         res = ApplyHalfStereo(res, swap_eyes);
     }
+ //   LOG_INFO(Frontend,"Layout with {} screens. Screen 0 is {},{},{}.{}",res.screens.size(),res.screens[0].rect.left,res.screens[0].rect.right,res.screens[0].rect.top,res.screens[0].rect.bottom);
     return res;
 }
 

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -407,9 +407,7 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
                                                  bool is_portrait) {
     u32 width, height, gap;
     gap = (int)(Settings::values.screen_gap.GetValue()) * res_scale;
-     bool stereo_full =
-        Settings::values.render_3d.GetValue() == Settings::StereoRenderOption::SideBySideFull;
-    bool separate_window = false;
+
     FramebufferLayout layout;
     if (is_portrait) {
         auto layout_option = Settings::values.portrait_layout_option.GetValue();
@@ -457,10 +455,6 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
                                                Settings::values.custom_bottom_height.GetValue()),
                                   Settings::values.swap_screen.GetValue(), is_portrait);
             break;
-#ifndef ANDROID
-        case Settings::LayoutOption::SeparateWindows:
-                separate_window = true;
-#endif
         case Settings::LayoutOption::SingleScreen:
         {
             const bool swap_screens = is_secondary || Settings::values.swap_screen.GetValue();

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -79,7 +79,7 @@ FramebufferLayout SingleFrameLayout(u32 width, u32 height, bool swapped, bool up
 
     // TODO: This is kind of gross, make it platform agnostic. -OS
 #ifdef ANDROID
-    const float window_aspect_ratio = static_cast<float>(height) / static_cast<float>(width);
+    const float window_aspect_ratio = static_cast<float>(height) / width;
     const auto aspect_ratio_setting = Settings::values.aspect_ratio.GetValue();
 
     float emulation_aspect_ratio = (swapped) ? BOT_SCREEN_ASPECT_RATIO : TOP_SCREEN_ASPECT_RATIO;
@@ -407,52 +407,57 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
                                                  bool is_portrait) {
     u32 width, height, gap;
     gap = (int)(Settings::values.screen_gap.GetValue()) * res_scale;
+    FramebufferLayout layout;
     if (is_portrait) {
         auto layout_option = Settings::values.portrait_layout_option.GetValue();
         switch (layout_option) {
         case Settings::PortraitLayoutOption::PortraitCustomLayout:
-            return CustomFrameLayout(
-                std::max(Settings::values.custom_portrait_top_x.GetValue() +
-                             Settings::values.custom_portrait_top_width.GetValue(),
-                         Settings::values.custom_portrait_bottom_x.GetValue() +
-                             Settings::values.custom_portrait_bottom_width.GetValue()),
-                std::max(Settings::values.custom_portrait_top_y.GetValue() +
-                             Settings::values.custom_portrait_top_height.GetValue(),
-                         Settings::values.custom_portrait_bottom_y.GetValue() +
-                             Settings::values.custom_portrait_bottom_height.GetValue()),
-                Settings::values.swap_screen.GetValue(), is_portrait);
+            width = std::max(Settings::values.custom_portrait_top_x.GetValue() +
+                                 Settings::values.custom_portrait_top_width.GetValue(),
+                             Settings::values.custom_portrait_bottom_x.GetValue() +
+                                 Settings::values.custom_portrait_bottom_width.GetValue());
+            height = std::max(Settings::values.custom_portrait_top_y.GetValue() +
+                                  Settings::values.custom_portrait_top_height.GetValue(),
+                              Settings::values.custom_portrait_bottom_y.GetValue() +
+                                  Settings::values.custom_portrait_bottom_height.GetValue());
+            layout = CustomFrameLayout(width, height, Settings::values.swap_screen.GetValue(),
+                                       is_portrait);
+
+            break;
         case Settings::PortraitLayoutOption::PortraitTopFullWidth:
             width = Core::kScreenTopWidth * res_scale;
             // clang-format off
             height = (static_cast<int>(Core::kScreenTopHeight + Core::kScreenBottomHeight * 1.25) *
                      res_scale) + gap;
             // clang-format on
-            return PortraitTopFullFrameLayout(width, height,
-                                              Settings::values.swap_screen.GetValue(),
-                                              Settings::values.upright_screen.GetValue());
+            layout= PortraitTopFullFrameLayout(width, height,Settings::values.swap_screen.GetValue(),Settings::values.upright_screen.GetValue());
+            break;
         case Settings::PortraitLayoutOption::PortraitOriginal:
             width = Core::kScreenTopWidth * res_scale;
             height = (Core::kScreenTopHeight + Core::kScreenBottomHeight) * res_scale;
-            return PortraitOriginalLayout(width, height, Settings::values.swap_screen.GetValue());
+            layout = PortraitOriginalLayout(width, height,
+                                              Settings::values.swap_screen.GetValue());
+            break;
         }
     } else {
         auto layout_option = Settings::values.layout_option.GetValue();
         switch (layout_option) {
         case Settings::LayoutOption::CustomLayout:
-            return CustomFrameLayout(std::max(Settings::values.custom_top_x.GetValue() +
-                                                  Settings::values.custom_top_width.GetValue(),
-                                              Settings::values.custom_bottom_x.GetValue() +
-                                                  Settings::values.custom_bottom_width.GetValue()),
-                                     std::max(Settings::values.custom_top_y.GetValue() +
-                                                  Settings::values.custom_top_height.GetValue(),
-                                              Settings::values.custom_bottom_y.GetValue() +
-                                                  Settings::values.custom_bottom_height.GetValue()),
-                                     Settings::values.swap_screen.GetValue(), is_portrait);
-
-        case Settings::LayoutOption::SingleScreen:
+            layout =
+                CustomFrameLayout(std::max(Settings::values.custom_top_x.GetValue() +
+                                               Settings::values.custom_top_width.GetValue(),
+                                           Settings::values.custom_bottom_x.GetValue() +
+                                               Settings::values.custom_bottom_width.GetValue()),
+                                  std::max(Settings::values.custom_top_y.GetValue() +
+                                               Settings::values.custom_top_height.GetValue(),
+                                           Settings::values.custom_bottom_y.GetValue() +
+                                               Settings::values.custom_bottom_height.GetValue()),
+                                  Settings::values.swap_screen.GetValue(), is_portrait);
+            break;
 #ifndef ANDROID
         case Settings::LayoutOption::SeparateWindows:
 #endif
+        case Settings::LayoutOption::SingleScreen:
         {
             const bool swap_screens = is_secondary || Settings::values.swap_screen.GetValue();
             if (swap_screens) {
@@ -465,8 +470,10 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
             if (Settings::values.upright_screen.GetValue()) {
                 std::swap(width, height);
             }
-            return SingleFrameLayout(width, height, swap_screens,
-                                     Settings::values.upright_screen.GetValue());
+
+            layout = SingleFrameLayout(width, height, swap_screens,
+                                       Settings::values.upright_screen.GetValue());
+            break;
         }
 
         case Settings::LayoutOption::LargeScreen: {
@@ -495,10 +502,11 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
             if (Settings::values.upright_screen.GetValue()) {
                 std::swap(width, height);
             }
-            return LargeFrameLayout(width, height, Settings::values.swap_screen.GetValue(),
-                                    Settings::values.upright_screen.GetValue(),
-                                    Settings::values.large_screen_proportion.GetValue(),
-                                    Settings::values.small_screen_position.GetValue());
+            layout = LargeFrameLayout(width, height, Settings::values.swap_screen.GetValue(),
+                                      Settings::values.upright_screen.GetValue(),
+                                      Settings::values.large_screen_proportion.GetValue(),
+                                      Settings::values.small_screen_position.GetValue());
+            break;
         }
         case Settings::LayoutOption::SideScreen:
             width = (Core::kScreenTopWidth + Core::kScreenBottomWidth) * res_scale + gap;
@@ -507,10 +515,10 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
             if (Settings::values.upright_screen.GetValue()) {
                 std::swap(width, height);
             }
-            return LargeFrameLayout(width, height, Settings::values.swap_screen.GetValue(),
-                                    Settings::values.upright_screen.GetValue(), 1,
-                                    Settings::SmallScreenPosition::MiddleRight);
-
+            layout = LargeFrameLayout(width, height, Settings::values.swap_screen.GetValue(),
+                                      Settings::values.upright_screen.GetValue(), 1,
+                                      Settings::SmallScreenPosition::MiddleRight);
+            break;
         case Settings::LayoutOption::HybridScreen:
             height = Core::kScreenTopHeight * res_scale;
 
@@ -526,9 +534,9 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
                 std::swap(width, height);
             }
 
-            return HybridScreenLayout(width, height, Settings::values.swap_screen.GetValue(),
+            layout = HybridScreenLayout(width, height, Settings::values.swap_screen.GetValue(),
                                       Settings::values.upright_screen.GetValue());
-
+            break;
         case Settings::LayoutOption::Default:
         default:
             width = Core::kScreenTopWidth * res_scale;
@@ -537,10 +545,13 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
             if (Settings::values.upright_screen.GetValue()) {
                 std::swap(width, height);
             }
-            return DefaultFrameLayout(width, height, Settings::values.swap_screen.GetValue(),
-                                      Settings::values.upright_screen.GetValue());
+            layout = DefaultFrameLayout(width, height, Settings::values.swap_screen.GetValue(),
+                                        Settings::values.upright_screen.GetValue());
+            break;
         }
     }
+
+    return layout;
     UNREACHABLE();
 }
 

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -455,7 +455,6 @@ FramebufferLayout CustomFrameLayout(u32 width, u32 height, bool is_swapped, bool
 
 FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondary,
                                                  bool is_portrait) {
-    const u32 gap = (int)(Settings::values.screen_gap.GetValue()) * res_scale;
     const std::pair<unsigned, unsigned> min_size =
         is_portrait ? GetMinimumSizeFromPortraitLayout()
                     : GetMinimumSizeFromLayout(Settings::values.layout_option.GetValue());
@@ -693,6 +692,7 @@ std::pair<unsigned, unsigned> GetMinimumSizeFromLayout(Settings::LayoutOption la
         min_height = Core::kScreenTopHeight + Core::kScreenBottomHeight + gap;
         break;
     }
+    return std::make_pair(min_width, min_height);
 }
 
 float FramebufferLayout::GetAspectRatioValue(Settings::AspectRatio aspect_ratio) {

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -431,13 +431,14 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
             height = (static_cast<int>(Core::kScreenTopHeight + Core::kScreenBottomHeight * 1.25) *
                      res_scale) + gap;
             // clang-format on
-            layout= PortraitTopFullFrameLayout(width, height,Settings::values.swap_screen.GetValue(),Settings::values.upright_screen.GetValue());
+            layout =
+                PortraitTopFullFrameLayout(width, height, Settings::values.swap_screen.GetValue(),
+                                           Settings::values.upright_screen.GetValue());
             break;
         case Settings::PortraitLayoutOption::PortraitOriginal:
             width = Core::kScreenTopWidth * res_scale;
             height = (Core::kScreenTopHeight + Core::kScreenBottomHeight) * res_scale;
-            layout = PortraitOriginalLayout(width, height,
-                                              Settings::values.swap_screen.GetValue());
+            layout = PortraitOriginalLayout(width, height, Settings::values.swap_screen.GetValue());
             break;
         }
     } else {
@@ -455,8 +456,7 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
                                                Settings::values.custom_bottom_height.GetValue()),
                                   Settings::values.swap_screen.GetValue(), is_portrait);
             break;
-        case Settings::LayoutOption::SingleScreen:
-        {
+        case Settings::LayoutOption::SingleScreen: {
             const bool swap_screens = is_secondary || Settings::values.swap_screen.GetValue();
             if (swap_screens) {
                 width = Core::kScreenBottomWidth * res_scale;
@@ -533,7 +533,7 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
             }
 
             layout = HybridScreenLayout(width, height, Settings::values.swap_screen.GetValue(),
-                                      Settings::values.upright_screen.GetValue());
+                                        Settings::values.upright_screen.GetValue());
             break;
         case Settings::LayoutOption::Default:
         default:

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -198,12 +198,10 @@ FramebufferLayout CreatePortraitLayout(Settings::PortraitLayoutOption layout_opt
     return res;
 }
 
-FramebufferLayout SingleFrameLayout(u32 width, u32 height, bool is_bottom, bool upright,
-                                    bool render_stereo, bool swap_eyes) {
+FramebufferLayout SingleFrameLayout(u32 width, u32 height, bool is_bottom,
+                                    bool swap_eyes) {
 
     FramebufferLayout res{width, height, {}};
-    if (!render_stereo)
-        res.render_3d_mode = Settings::StereoRenderOption::Off;
 
     Common::Rectangle<u32> screen_window_area{0, 0, width, height};
     Common::Rectangle<u32> top_screen;
@@ -269,19 +267,15 @@ FramebufferLayout SingleFrameLayout(u32 width, u32 height, bool is_bottom, bool 
     return res;
 }
 
-FramebufferLayout LargeFrameLayout(u32 width, u32 height, bool swapped, bool upright,
+FramebufferLayout LargeFrameLayout(u32 width, u32 height, bool swapped,
                                    float scale_factor,
                                    Settings::SmallScreenPosition small_screen_position,
-                                   bool render_stereo, bool swap_eyes) {
+                                 bool swap_eyes) {
 
     const bool vertical = (small_screen_position == Settings::SmallScreenPosition::AboveLarge ||
                            small_screen_position == Settings::SmallScreenPosition::BelowLarge);
     FramebufferLayout res{width, height, {}};
-    if (!render_stereo)
-        res.render_3d_mode = Settings::StereoRenderOption::Off;
 
-    if (upright)
-        res.orientation = DisplayOrientation::Portrait;
     // Split the window into two parts. Give proportional width to the smaller screen
     // To do that, find the total emulation box and maximize that based on window size
     u32 gap = (u32)(Settings::values.screen_gap.GetValue() * scale_factor);
@@ -404,12 +398,12 @@ FramebufferLayout LargeFrameLayout(u32 width, u32 height, bool swapped, bool upr
 
 FramebufferLayout HybridScreenLayout(u32 width, u32 height, bool swapped, bool swap_eyes) {
     FramebufferLayout res =
-        LargeFrameLayout(width, height, swapped, 2.25f, Settings::SmallScreenPosition::TopRight);
+        LargeFrameLayout(width, height, swapped, 2.25f, Settings::SmallScreenPosition::BottomRight);
 
     // screens[0] is the large screen, screens[1] is the small screen. Add the other small screen.
     Screen small_screen =
-        Screen{Common::Rectangle<u32>{res.screens[1].rect.left, res.screens[1].rect.bottom,
-                                      res.screens[1].rect.right, res.screens[0].rect.bottom},
+        Screen{Common::Rectangle<u32>{res.screens[1].rect.left, res.screens[0].rect.top,
+                                      res.screens[1].rect.right, res.screens[1].rect.top},
                res.screens[0].is_bottom, swap_eyes, true};
     res.screens.push_back(small_screen);
     return res;

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -613,7 +613,8 @@ FramebufferLayout reverseLayout(FramebufferLayout layout) {
 FramebufferLayout ApplyFullStereo(FramebufferLayout layout, bool swap_eyes) {
     // assumptions: the screens have already been set up so they are on the left side
     // if swap_eyes is true, those screens have already been set to right eye
-    for (int i = 0; i < layout.screens.size(); i++) {
+    int s = layout.screens.size();
+    for (int i = 0; i < s; i++) {
         Screen new_screen = layout.screens[i];
         new_screen.rect.left += layout.width / 2;
         new_screen.rect.right += layout.width / 2;
@@ -624,7 +625,8 @@ FramebufferLayout ApplyFullStereo(FramebufferLayout layout, bool swap_eyes) {
 }
 
 FramebufferLayout ApplyHalfStereo(FramebufferLayout layout, bool swap_eyes) {
-    for (int i = 0; i < layout.screens.size(); i++) {
+    int s = layout.screens.size();
+    for (int i = 0; i < s; i++) {
         Screen& s = layout.screens[i];
         s.rect.left /= 2;
         s.rect.right /= 2;

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -79,7 +79,7 @@ FramebufferLayout ApplyHalfStereo(FramebufferLayout layout, bool swap_eyes);
  * @return Newly created FramebufferLayout object with default screen regions initialized
  */
 FramebufferLayout CreateLayout(Settings::LayoutOption layout_option, u32 width, u32 height,
-                               bool swapped, bool upright, Settings::StereoRenderOption render_3d,
+                               bool swapped = false, bool upright = false, Settings::StereoRenderOption render_3d = Settings::StereoRenderOption::Off,
                                bool swap_eyes = false);
 
 /**
@@ -120,13 +120,13 @@ FramebufferLayout CreateMobileSecondaryLayout(Settings::SecondaryDisplayLayout l
  * Factory method for constructing a default FramebufferLayout with only one screen
  * @param width Window framebuffer width in pixels
  * @param height Window framebuffer height in pixels
- * @param swapped if true, the bottom screen will be displayed
+ * @param is_bottom if true, the bottom screen will be displayed
  * @param swap_eyes in mono mode, this will make mono do the right eye. In stereo modes, it will
  * swap left eye and right eye
  * @return Newly created FramebufferLayout object with default screen regions initialized
  */
 
-FramebufferLayout SingleFrameLayout(u32 width, u32 height, bool swapped, bool swap_eyes = false);
+FramebufferLayout SingleFrameLayout(u32 width, u32 height, bool is_bottom, bool swap_eyes = false);
 
 /**
  * Factory method for constructing a Frame with top and bottom screens, arranged in a variety of

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -46,6 +46,8 @@ struct FramebufferLayout {
     u32 GetScalingRatio() const;
 
     static float GetAspectRatioValue(Settings::AspectRatio aspect_ratio);
+
+    Settings::StereoRenderOption render_3d_mode = Settings::values.render_3d.GetValue();
 };
 
 /**

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -167,7 +167,7 @@ FramebufferLayout HybridScreenLayout(u32 width, u32 height, bool swapped, bool s
  */
 
 FramebufferLayout CustomFrameLayout(u32 width, u32 height, bool is_swapped,
-                                    bool is_portrait_mode = false, bool swap_eyes);
+                                    bool is_portrait_mode = false, bool swap_eyes = false);
 
 /**
  * Convenience method to get frame layout by resolution scale
@@ -185,8 +185,7 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
  */
 FramebufferLayout GetCardboardSettings(const FramebufferLayout& layout);
 
-std::pair<unsigned, unsigned> GetMinimumSizeFromLayout(Settings::LayoutOption layout,
-                                                       bool upright_screen);
+std::pair<unsigned, unsigned> GetMinimumSizeFromLayout(Settings::LayoutOption layout);
 
 std::pair<unsigned, unsigned> GetMinimumSizeFromPortraitLayout();
 

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -29,6 +29,7 @@ struct Screen {
     bool is_bottom;
     bool right_eye = false;
     bool enabled = true;
+    float opacity = 100.0f;
 };
 
 /// Describes the layout of the window framebuffer (size and top/bottom screen positions)
@@ -78,9 +79,11 @@ FramebufferLayout ApplyHalfStereo(FramebufferLayout layout, bool swap_eyes);
  * swap left eye and right eye
  * @return Newly created FramebufferLayout object with default screen regions initialized
  */
-FramebufferLayout CreateLayout(Settings::LayoutOption layout_option, u32 width, u32 height,
-                               bool swapped = false, bool upright = false, Settings::StereoRenderOption render_3d = Settings::StereoRenderOption::Off,
-                               bool swap_eyes = false);
+FramebufferLayout CreateLayout(
+    Settings::LayoutOption layout_option, u32 width, u32 height, bool swapped = false,
+    bool upright = false,
+    Settings::StereoRenderOption render_3d = Settings::StereoRenderOption::Off,
+    bool swap_eyes = false);
 
 /**
  * Factory method for constructing a portrait layout based on a layout_option

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -62,8 +62,8 @@ FramebufferLayout reverseLayout(FramebufferLayout layout);
 FramebufferLayout ApplyFullStereo(FramebufferLayout layout, bool swap_eyes);
 
 /**
- * Method to duplicate a framebuffer layout to the right side with the other eye, creating
- * half-width stereo behavior
+ * Method to squeeze framebuffer layout to the left side then duplicate it to the right with the
+ * other eye, creating half-width stereo behavior
  */
 FramebufferLayout ApplyHalfStereo(FramebufferLayout layout, bool swap_eyes);
 
@@ -72,12 +72,12 @@ FramebufferLayout ApplyHalfStereo(FramebufferLayout layout, bool swap_eyes);
  * @param layout_option The Layout Option to use
  * @param width Window framebuffer width in pixels
  * @param height Window framebuffer height in pixels
- * @param swapped if true, the bottom screen will be displayed above the top screen
+ * @param swapped if true, the bottom screen and top screen will be swapped
  * @param upright if true, rotate the screens 90 degrees counter-clockwise
  * @param render_3d the StereoRenderOption to apply to this layout
  * @param swap_eyes in mono mode, this will make mono do the right eye. In stereo modes, it will
  * swap left eye and right eye
- * @return Newly created FramebufferLayout object with default screen regions initialized
+ * @return Newly created FramebufferLayout object with all screen regions initialized
  */
 FramebufferLayout CreateLayout(
     Settings::LayoutOption layout_option, u32 width, u32 height, bool swapped = false,
@@ -87,15 +87,15 @@ FramebufferLayout CreateLayout(
 
 /**
  * Factory method for constructing a portrait layout based on a layout_option
- * @param layout_option The Layout Option to use
+ * @param layout_option The Portrait Layout Option to use
  * @param width Window framebuffer width in pixels
  * @param height Window framebuffer height in pixels
- * @param swapped if true, the bottom screen will be displayed above the top screen
+ * @param swapped if true, the bottom screen and top screen will be swapped
  * @param upright if true, rotate the screens 90 degrees counter-clockwise
  * @param render_3d the StereoRenderOption to apply to this layout
  * @param swap_eyes in mono mode, this will make mono do the right eye. In stereo modes, it will
  * swap left eye and right eye
- * @return Newly created FramebufferLayout object with default screen regions initialized
+ * @return Newly created FramebufferLayout object with all screen regions initialized
  */
 FramebufferLayout CreatePortraitLayout(Settings::PortraitLayoutOption layout_option, u32 width,
                                        u32 height, bool swapped, bool upright,
@@ -107,7 +107,7 @@ FramebufferLayout CreatePortraitLayout(Settings::PortraitLayoutOption layout_opt
  * @param layout_option The Layout Option to use
  * @param width Window framebuffer width in pixels
  * @param height Window framebuffer height in pixels
- * @param swapped if true, the bottom screen will be displayed above the top screen
+ * @param swapped if true, swap the screens
  * @param upright if true, rotate the screens 90 degrees counter-clockwise
  * @param render_3d the StereoRenderOption to apply to this layout
  * @param swap_eyes in mono mode, this will make mono do the right eye. In stereo modes, it will
@@ -120,10 +120,10 @@ FramebufferLayout CreateMobileSecondaryLayout(Settings::SecondaryDisplayLayout l
                                               bool swap_eyes = false);
 
 /**
- * Factory method for constructing a default FramebufferLayout with only one screen
+ * Factory method for constructing a FramebufferLayout with only one screen
  * @param width Window framebuffer width in pixels
  * @param height Window framebuffer height in pixels
- * @param is_bottom if true, the bottom screen will be displayed
+ * @param is_bottom if true, the bottom screen will be displayed, otherwise the top
  * @param swap_eyes in mono mode, this will make mono do the right eye. In stereo modes, it will
  * swap left eye and right eye
  * @return Newly created FramebufferLayout object with default screen regions initialized
@@ -132,13 +132,13 @@ FramebufferLayout CreateMobileSecondaryLayout(Settings::SecondaryDisplayLayout l
 FramebufferLayout SingleFrameLayout(u32 width, u32 height, bool is_bottom, bool swap_eyes = false);
 
 /**
- * Factory method for constructing a Frame with top and bottom screens, arranged in a variety of
- * ways
+ * Factory method for constructing a FramebufferLayout with top and bottom screens, arranged in a
+ * variety of ways
  * @param width Window framebuffer width in pixels
  * @param height Window framebuffer height in pixels
- * @param swapped if true, the bottom screen will be displayed above the top screen
+ * @param is_swapped if true, the bottom screen will be displayed above the top screen
  * @param scale_factor The ratio between the large screen with respect to the smaller screen
- * @param vertical_alignment The vertical alignment of the smaller screen relative to the larger
+ * @param small_screen_position The vertical alignment of the smaller screen relative to the larger
  * screen
  * @param swap_eyes in mono mode, this will make mono do the right eye. In stereo modes, it will
  * swap left eye and right eye
@@ -148,8 +148,8 @@ FramebufferLayout LargeFrameLayout(u32 width, u32 height, bool is_swapped, float
                                    Settings::SmallScreenPosition small_screen_position,
                                    bool swap_eyes = false);
 /**
- * Factory method for constructing a frame with 2.5 times bigger top screen on the right,
- * and 1x top and bottom screen on the left
+ * Factory method for constructing a a hybrid layout, with one screen on the left and both on the
+ * right
  * @param width Window framebuffer width in pixels
  * @param height Window framebuffer height in pixels
  * @param is_swapped if true, the bottom screen will be the large display

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -771,9 +771,9 @@ void RendererOpenGL::DrawTopScreen(const Layout::FramebufferLayout& layout,
         DrawSingleScreen(screen_infos[leftside], top_screen_left, top_screen_top, top_screen_width,
                          top_screen_height, orientation);
         glUniform1i(uniform_layer, 1);
-        // DrawSingleScreen(screen_infos[rightside],
-        //                  static_cast<float>(top_screen_left + layout.width),
-        //                  top_screen_top, top_screen_width, top_screen_height, orientation);
+        DrawSingleScreen(screen_infos[rightside],
+                         static_cast<float>(top_screen_left + layout.width / 2), top_screen_top,
+                         top_screen_width, top_screen_height, orientation);
         break;
     }
     case Settings::StereoRenderOption::CardboardVR: {
@@ -840,6 +840,10 @@ void RendererOpenGL::DrawBottomScreen(const Layout::FramebufferLayout& layout,
     case Settings::StereoRenderOption::SideBySideFull: {
         DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
                          bottom_screen_width, bottom_screen_height, orientation);
+         glUniform1i(uniform_layer, 1);
+         DrawSingleScreen(
+             screen_infos[2], bottom_screen_left + layout.width / 2,
+             bottom_screen_top, bottom_screen_width, bottom_screen_height, orientation);
         break;
     }
     case Settings::StereoRenderOption::CardboardVR: {

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -740,6 +740,9 @@ void RendererOpenGL::DrawTopScreen(const Layout::FramebufferLayout& layout,
     if (!layout.top_screen_enabled) {
         return;
     }
+    int leftside, rightside;
+    leftside = Settings::values.swap_eyes_3d.GetValue() ? 0 : 1;
+    rightside = Settings::values.swap_eyes_3d.GetValue() ? 1 : 0;
 
     const float top_screen_left = static_cast<float>(top_screen.left);
     const float top_screen_top = static_cast<float>(top_screen.top);
@@ -756,29 +759,29 @@ void RendererOpenGL::DrawTopScreen(const Layout::FramebufferLayout& layout,
         break;
     }
     case Settings::StereoRenderOption::SideBySide: {
-        DrawSingleScreen(screen_infos[0], top_screen_left / 2, top_screen_top, top_screen_width / 2,
-                         top_screen_height, orientation);
+        DrawSingleScreen(screen_infos[leftside], top_screen_left / 2, top_screen_top,
+                         top_screen_width / 2, top_screen_height, orientation);
         glUniform1i(uniform_layer, 1);
-        DrawSingleScreen(screen_infos[1],
+        DrawSingleScreen(screen_infos[rightside],
                          static_cast<float>((top_screen_left / 2) + (layout.width / 2)),
                          top_screen_top, top_screen_width / 2, top_screen_height, orientation);
         break;
     }
-    case Settings::StereoRenderOption::ReverseSideBySide: {
-        DrawSingleScreen(screen_infos[1], top_screen_left / 2, top_screen_top, top_screen_width / 2,
+    case Settings::StereoRenderOption::SideBySideFull: {
+        DrawSingleScreen(screen_infos[leftside], top_screen_left, top_screen_top, top_screen_width,
                          top_screen_height, orientation);
         glUniform1i(uniform_layer, 1);
-        DrawSingleScreen(screen_infos[0],
-                         static_cast<float>((top_screen_left / 2) + (layout.width / 2)),
-                         top_screen_top, top_screen_width / 2, top_screen_height, orientation);
+        // DrawSingleScreen(screen_infos[rightside],
+        //                  static_cast<float>(top_screen_left + layout.width),
+        //                  top_screen_top, top_screen_width, top_screen_height, orientation);
         break;
     }
     case Settings::StereoRenderOption::CardboardVR: {
-        DrawSingleScreen(screen_infos[0], top_screen_left, top_screen_top, top_screen_width,
+        DrawSingleScreen(screen_infos[leftside], top_screen_left, top_screen_top, top_screen_width,
                          top_screen_height, orientation);
         glUniform1i(uniform_layer, 1);
         DrawSingleScreen(
-            screen_infos[1],
+            screen_infos[rightside],
             static_cast<float>(layout.cardboard.top_screen_right_eye + (layout.width / 2)),
             top_screen_top, top_screen_width, top_screen_height, orientation);
         break;
@@ -786,8 +789,8 @@ void RendererOpenGL::DrawTopScreen(const Layout::FramebufferLayout& layout,
     case Settings::StereoRenderOption::Anaglyph:
     case Settings::StereoRenderOption::Interlaced:
     case Settings::StereoRenderOption::ReverseInterlaced: {
-        DrawSingleScreenStereo(screen_infos[0], screen_infos[1], top_screen_left, top_screen_top,
-                               top_screen_width, top_screen_height, orientation);
+        DrawSingleScreenStereo(screen_infos[leftside], screen_infos[rightside], top_screen_left,
+                               top_screen_top, top_screen_width, top_screen_height, orientation);
         break;
     }
     }
@@ -820,7 +823,7 @@ void RendererOpenGL::DrawBottomScreen(const Layout::FramebufferLayout& layout,
         break;
     }
     case Settings::StereoRenderOption::SideBySide: // Bottom screen is identical on both sides
-    case Settings::StereoRenderOption::ReverseSideBySide: {
+    {
         if (separate_win) {
             DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
                              bottom_screen_width, bottom_screen_height, orientation);
@@ -832,6 +835,11 @@ void RendererOpenGL::DrawBottomScreen(const Layout::FramebufferLayout& layout,
                 screen_infos[2], static_cast<float>((bottom_screen_left / 2) + (layout.width / 2)),
                 bottom_screen_top, bottom_screen_width / 2, bottom_screen_height, orientation);
         }
+        break;
+    }
+    case Settings::StereoRenderOption::SideBySideFull: {
+        DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
+                         bottom_screen_width, bottom_screen_height, orientation);
         break;
     }
     case Settings::StereoRenderOption::CardboardVR: {

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -840,10 +840,9 @@ void RendererOpenGL::DrawBottomScreen(const Layout::FramebufferLayout& layout,
     case Settings::StereoRenderOption::SideBySideFull: {
         DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
                          bottom_screen_width, bottom_screen_height, orientation);
-         glUniform1i(uniform_layer, 1);
-         DrawSingleScreen(
-             screen_infos[2], bottom_screen_left + layout.width / 2,
-             bottom_screen_top, bottom_screen_width, bottom_screen_height, orientation);
+        glUniform1i(uniform_layer, 1);
+        DrawSingleScreen(screen_infos[2], bottom_screen_left + layout.width / 2, bottom_screen_top,
+                         bottom_screen_width, bottom_screen_height, orientation);
         break;
     }
     case Settings::StereoRenderOption::CardboardVR: {

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -326,7 +326,7 @@ void RendererOpenGL::InitOpenGLObjects() {
         glSamplerParameteri(samplers[i].handle, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     }
 
-    ReloadShader();
+    ReloadShader(Settings::values.render_3d.GetValue());
 
     // Generate VBO handle for drawing
     vertex_buffer.Create();
@@ -372,10 +372,10 @@ void RendererOpenGL::InitOpenGLObjects() {
     state.Apply();
 }
 
-void RendererOpenGL::ReloadShader() {
+void RendererOpenGL::ReloadShader(Settings::StereoRenderOption render_3d) {
     // Link shaders and get variable locations
     std::string shader_data = fragment_shader_precision_OES;
-    if (Settings::values.render_3d.GetValue() == Settings::StereoRenderOption::Anaglyph) {
+    if (render_3d == Settings::StereoRenderOption::Anaglyph) {
         if (Settings::values.anaglyph_shader_name.GetValue() == "Dubois (builtin)") {
             shader_data += HostShaders::OPENGL_PRESENT_ANAGLYPH_FRAG;
         } else {
@@ -388,9 +388,8 @@ void RendererOpenGL::ReloadShader() {
                 shader_data += shader_text;
             }
         }
-    } else if (Settings::values.render_3d.GetValue() == Settings::StereoRenderOption::Interlaced ||
-               Settings::values.render_3d.GetValue() ==
-                   Settings::StereoRenderOption::ReverseInterlaced) {
+    } else if (render_3d == Settings::StereoRenderOption::Interlaced ||
+               render_3d == Settings::StereoRenderOption::ReverseInterlaced) {
         shader_data += HostShaders::OPENGL_PRESENT_INTERLACED_FRAG;
     } else {
         if (Settings::values.pp_shader_name.GetValue() == "None (builtin)") {
@@ -411,17 +410,16 @@ void RendererOpenGL::ReloadShader() {
     state.Apply();
     uniform_modelview_matrix = glGetUniformLocation(shader.handle, "modelview_matrix");
     uniform_color_texture = glGetUniformLocation(shader.handle, "color_texture");
-    if (Settings::values.render_3d.GetValue() == Settings::StereoRenderOption::Anaglyph ||
-        Settings::values.render_3d.GetValue() == Settings::StereoRenderOption::Interlaced ||
-        Settings::values.render_3d.GetValue() == Settings::StereoRenderOption::ReverseInterlaced) {
+    if (render_3d == Settings::StereoRenderOption::Anaglyph ||
+        render_3d == Settings::StereoRenderOption::Interlaced ||
+        render_3d == Settings::StereoRenderOption::ReverseInterlaced) {
         uniform_color_texture_r = glGetUniformLocation(shader.handle, "color_texture_r");
     }
-    if (Settings::values.render_3d.GetValue() == Settings::StereoRenderOption::Interlaced ||
-        Settings::values.render_3d.GetValue() == Settings::StereoRenderOption::ReverseInterlaced) {
+    if (render_3d == Settings::StereoRenderOption::Interlaced ||
+        render_3d == Settings::StereoRenderOption::ReverseInterlaced) {
         GLuint uniform_reverse_interlaced =
             glGetUniformLocation(shader.handle, "reverse_interlaced");
-        if (Settings::values.render_3d.GetValue() ==
-            Settings::StereoRenderOption::ReverseInterlaced)
+        if (render_3d == Settings::StereoRenderOption::ReverseInterlaced)
             glUniform1i(uniform_reverse_interlaced, 1);
         else
             glUniform1i(uniform_reverse_interlaced, 0);
@@ -658,7 +656,7 @@ void RendererOpenGL::DrawScreens(const Layout::FramebufferLayout& layout, bool f
         // Update fragment shader before drawing
         shader.Release();
         // Link shaders and get variable locations
-        ReloadShader();
+        ReloadShader(layout.render_3d_mode);
     }
 
     const auto& top_screen = layout.top_screen;
@@ -676,9 +674,9 @@ void RendererOpenGL::DrawScreens(const Layout::FramebufferLayout& layout, bool f
     glUniform1i(uniform_color_texture, 0);
 
     const bool stereo_single_screen =
-        Settings::values.render_3d.GetValue() == Settings::StereoRenderOption::Anaglyph ||
-        Settings::values.render_3d.GetValue() == Settings::StereoRenderOption::Interlaced ||
-        Settings::values.render_3d.GetValue() == Settings::StereoRenderOption::ReverseInterlaced;
+        layout.render_3d_mode == Settings::StereoRenderOption::Anaglyph ||
+        layout.render_3d_mode == Settings::StereoRenderOption::Interlaced ||
+        layout.render_3d_mode == Settings::StereoRenderOption::ReverseInterlaced;
 
     // Bind a second texture for the right eye if in Anaglyph mode
     if (stereo_single_screen) {
@@ -751,7 +749,7 @@ void RendererOpenGL::DrawTopScreen(const Layout::FramebufferLayout& layout,
 
     const auto orientation = layout.is_rotated ? Layout::DisplayOrientation::Landscape
                                                : Layout::DisplayOrientation::Portrait;
-    switch (Settings::values.render_3d.GetValue()) {
+    switch (layout.render_3d_mode) {
     case Settings::StereoRenderOption::Off: {
         const int eye = static_cast<int>(Settings::values.mono_render_option.GetValue());
         DrawSingleScreen(screen_infos[eye], top_screen_left, top_screen_top, top_screen_width,
@@ -810,67 +808,50 @@ void RendererOpenGL::DrawBottomScreen(const Layout::FramebufferLayout& layout,
     const auto orientation = layout.is_rotated ? Layout::DisplayOrientation::Landscape
                                                : Layout::DisplayOrientation::Portrait;
 
-    bool separate_win = false;
-#ifndef ANDROID
-    separate_win =
-        (Settings::values.layout_option.GetValue() == Settings::LayoutOption::SeparateWindows);
-#endif
-
-    if (separate_win) {
+    switch (layout.render_3d_mode) {
+    case Settings::StereoRenderOption::Off: {
         DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
                          bottom_screen_width, bottom_screen_height, orientation);
-    } else {
+        break;
+    }
+    case Settings::StereoRenderOption::SideBySide: // Bottom screen is identical on both sides
+    {
 
-        switch (Settings::values.render_3d.GetValue()) {
-        case Settings::StereoRenderOption::Off: {
-            DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
-                             bottom_screen_width, bottom_screen_height, orientation);
-            break;
-        }
-        case Settings::StereoRenderOption::SideBySide: // Bottom screen is identical on both sides
-        {
-            if (separate_win) {
-                DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
-                                 bottom_screen_width, bottom_screen_height, orientation);
-            } else {
-                DrawSingleScreen(screen_infos[2], bottom_screen_left / 2, bottom_screen_top,
-                                 bottom_screen_width / 2, bottom_screen_height, orientation);
-                glUniform1i(uniform_layer, 1);
-                DrawSingleScreen(screen_infos[2],
-                                 static_cast<float>((bottom_screen_left / 2) + (layout.width / 2)),
-                                 bottom_screen_top, bottom_screen_width / 2, bottom_screen_height,
-                                 orientation);
-            }
-            break;
-        }
-        case Settings::StereoRenderOption::SideBySideFull: {
-            DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
-                             bottom_screen_width, bottom_screen_height, orientation);
-            glUniform1i(uniform_layer, 1);
-            DrawSingleScreen(screen_infos[2], bottom_screen_left + layout.width / 2,
-                             bottom_screen_top, bottom_screen_width, bottom_screen_height,
-                             orientation);
-            break;
-        }
-        case Settings::StereoRenderOption::CardboardVR: {
-            DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
-                             bottom_screen_width, bottom_screen_height, orientation);
-            glUniform1i(uniform_layer, 1);
-            DrawSingleScreen(
-                screen_infos[2],
-                static_cast<float>(layout.cardboard.bottom_screen_right_eye + (layout.width / 2)),
-                bottom_screen_top, bottom_screen_width, bottom_screen_height, orientation);
-            break;
-        }
-        case Settings::StereoRenderOption::Anaglyph:
-        case Settings::StereoRenderOption::Interlaced:
-        case Settings::StereoRenderOption::ReverseInterlaced: {
-            DrawSingleScreenStereo(screen_infos[2], screen_infos[2], bottom_screen_left,
-                                   bottom_screen_top, bottom_screen_width, bottom_screen_height,
-                                   orientation);
-            break;
-        }
-        }
+        DrawSingleScreen(screen_infos[2], bottom_screen_left / 2, bottom_screen_top,
+                         bottom_screen_width / 2, bottom_screen_height, orientation);
+        glUniform1i(uniform_layer, 1);
+        DrawSingleScreen(
+            screen_infos[2], static_cast<float>((bottom_screen_left / 2) + (layout.width / 2)),
+            bottom_screen_top, bottom_screen_width / 2, bottom_screen_height, orientation);
+
+        break;
+    }
+    case Settings::StereoRenderOption::SideBySideFull: {
+        DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
+                         bottom_screen_width, bottom_screen_height, orientation);
+        glUniform1i(uniform_layer, 1);
+        DrawSingleScreen(screen_infos[2], bottom_screen_left + layout.width / 2, bottom_screen_top,
+                         bottom_screen_width, bottom_screen_height, orientation);
+        break;
+    }
+    case Settings::StereoRenderOption::CardboardVR: {
+        DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
+                         bottom_screen_width, bottom_screen_height, orientation);
+        glUniform1i(uniform_layer, 1);
+        DrawSingleScreen(
+            screen_infos[2],
+            static_cast<float>(layout.cardboard.bottom_screen_right_eye + (layout.width / 2)),
+            bottom_screen_top, bottom_screen_width, bottom_screen_height, orientation);
+        break;
+    }
+    case Settings::StereoRenderOption::Anaglyph:
+    case Settings::StereoRenderOption::Interlaced:
+    case Settings::StereoRenderOption::ReverseInterlaced: {
+        DrawSingleScreenStereo(screen_infos[2], screen_infos[2], bottom_screen_left,
+                               bottom_screen_top, bottom_screen_width, bottom_screen_height,
+                               orientation);
+        break;
+    }
     }
 }
 

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -818,56 +818,59 @@ void RendererOpenGL::DrawBottomScreen(const Layout::FramebufferLayout& layout,
 
     if (separate_win) {
         DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
-                                                           bottom_screen_width, bottom_screen_height, orientation);
-    }else {
-
-    switch (Settings::values.render_3d.GetValue()) {
-    case Settings::StereoRenderOption::Off: {
-        DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
                          bottom_screen_width, bottom_screen_height, orientation);
-        break;
-    }
-    case Settings::StereoRenderOption::SideBySide: // Bottom screen is identical on both sides
-    {
-        if (separate_win) {
+    } else {
+
+        switch (Settings::values.render_3d.GetValue()) {
+        case Settings::StereoRenderOption::Off: {
             DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
                              bottom_screen_width, bottom_screen_height, orientation);
-        } else {
-            DrawSingleScreen(screen_infos[2], bottom_screen_left / 2, bottom_screen_top,
-                             bottom_screen_width / 2, bottom_screen_height, orientation);
+            break;
+        }
+        case Settings::StereoRenderOption::SideBySide: // Bottom screen is identical on both sides
+        {
+            if (separate_win) {
+                DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
+                                 bottom_screen_width, bottom_screen_height, orientation);
+            } else {
+                DrawSingleScreen(screen_infos[2], bottom_screen_left / 2, bottom_screen_top,
+                                 bottom_screen_width / 2, bottom_screen_height, orientation);
+                glUniform1i(uniform_layer, 1);
+                DrawSingleScreen(screen_infos[2],
+                                 static_cast<float>((bottom_screen_left / 2) + (layout.width / 2)),
+                                 bottom_screen_top, bottom_screen_width / 2, bottom_screen_height,
+                                 orientation);
+            }
+            break;
+        }
+        case Settings::StereoRenderOption::SideBySideFull: {
+            DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
+                             bottom_screen_width, bottom_screen_height, orientation);
+            glUniform1i(uniform_layer, 1);
+            DrawSingleScreen(screen_infos[2], bottom_screen_left + layout.width / 2,
+                             bottom_screen_top, bottom_screen_width, bottom_screen_height,
+                             orientation);
+            break;
+        }
+        case Settings::StereoRenderOption::CardboardVR: {
+            DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
+                             bottom_screen_width, bottom_screen_height, orientation);
             glUniform1i(uniform_layer, 1);
             DrawSingleScreen(
-                screen_infos[2], static_cast<float>((bottom_screen_left / 2) + (layout.width / 2)),
-                bottom_screen_top, bottom_screen_width / 2, bottom_screen_height, orientation);
+                screen_infos[2],
+                static_cast<float>(layout.cardboard.bottom_screen_right_eye + (layout.width / 2)),
+                bottom_screen_top, bottom_screen_width, bottom_screen_height, orientation);
+            break;
         }
-        break;
-    }
-    case Settings::StereoRenderOption::SideBySideFull: {
-        DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
-                         bottom_screen_width, bottom_screen_height, orientation);
-        glUniform1i(uniform_layer, 1);
-        DrawSingleScreen(screen_infos[2], bottom_screen_left + layout.width / 2, bottom_screen_top,
-                         bottom_screen_width, bottom_screen_height, orientation);
-        break;
-    }
-    case Settings::StereoRenderOption::CardboardVR: {
-        DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
-                         bottom_screen_width, bottom_screen_height, orientation);
-        glUniform1i(uniform_layer, 1);
-        DrawSingleScreen(
-            screen_infos[2],
-            static_cast<float>(layout.cardboard.bottom_screen_right_eye + (layout.width / 2)),
-            bottom_screen_top, bottom_screen_width, bottom_screen_height, orientation);
-        break;
-    }
-    case Settings::StereoRenderOption::Anaglyph:
-    case Settings::StereoRenderOption::Interlaced:
-    case Settings::StereoRenderOption::ReverseInterlaced: {
-        DrawSingleScreenStereo(screen_infos[2], screen_infos[2], bottom_screen_left,
-                               bottom_screen_top, bottom_screen_width, bottom_screen_height,
-                               orientation);
-        break;
-    }
+        case Settings::StereoRenderOption::Anaglyph:
+        case Settings::StereoRenderOption::Interlaced:
+        case Settings::StereoRenderOption::ReverseInterlaced: {
+            DrawSingleScreenStereo(screen_infos[2], screen_infos[2], bottom_screen_left,
+                                   bottom_screen_top, bottom_screen_width, bottom_screen_height,
+                                   orientation);
+            break;
+        }
+        }
     }
 }
 

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -741,8 +741,8 @@ void RendererOpenGL::DrawTopScreen(const Layout::FramebufferLayout& layout,
         return;
     }
     int leftside, rightside;
-    leftside = Settings::values.swap_eyes_3d.GetValue() ? 0 : 1;
-    rightside = Settings::values.swap_eyes_3d.GetValue() ? 1 : 0;
+    leftside = Settings::values.swap_eyes_3d.GetValue() ? 1 : 0;
+    rightside = Settings::values.swap_eyes_3d.GetValue() ? 0 : 1;
 
     const float top_screen_left = static_cast<float>(top_screen.left);
     const float top_screen_top = static_cast<float>(top_screen.top);

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -645,7 +645,7 @@ void RendererOpenGL::DrawSingleScreenStereo(const ScreenInfo& screen_info_l,
 /**
  * Draws the emulated screens to the emulator window.
  */
-void RendererOpenGL::DrawScreens(Layout::FramebufferLayout& layout, bool flipped) {
+void RendererOpenGL::DrawScreens(const Layout::FramebufferLayout& layout, bool flipped) {
     if (settings.bg_color_update_requested.exchange(false)) {
         // Update background color before drawing
         glClearColor(Settings::values.bg_red.GetValue(), Settings::values.bg_green.GetValue(),
@@ -680,7 +680,7 @@ void RendererOpenGL::DrawScreens(Layout::FramebufferLayout& layout, bool flipped
         glUniform1i(uniform_color_texture_r, 1);
     }
 
-    for (Layout::Screen& s : layout.screens) {
+    for (const Layout::Screen& s : layout.screens) {
         glUniform1i(uniform_layer, 0);
         DrawScreen(layout, s);
         // TODO: make opacity a property of individual screens on the layout!
@@ -690,7 +690,7 @@ void RendererOpenGL::DrawScreens(Layout::FramebufferLayout& layout, bool flipped
     ResetSecondLayerOpacity();
 }
 
-void RendererOpenGL::ApplySecondLayerOpacity(Layout::Screen& screen) {
+void RendererOpenGL::ApplySecondLayerOpacity(const Layout::Screen& screen) {
     if (screen.opacity < 100) {
         state.blend.src_rgb_func = GL_CONSTANT_ALPHA;
         state.blend.src_a_func = GL_CONSTANT_ALPHA;

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -816,6 +816,11 @@ void RendererOpenGL::DrawBottomScreen(const Layout::FramebufferLayout& layout,
         (Settings::values.layout_option.GetValue() == Settings::LayoutOption::SeparateWindows);
 #endif
 
+    if (separate_win) {
+        DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,
+                                                           bottom_screen_width, bottom_screen_height, orientation);
+    }else {
+
     switch (Settings::values.render_3d.GetValue()) {
     case Settings::StereoRenderOption::Off: {
         DrawSingleScreen(screen_infos[2], bottom_screen_left, bottom_screen_top,

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -64,8 +64,8 @@ private:
     void ConfigureFramebufferTexture(TextureInfo& texture,
                                      const Pica::FramebufferConfig& framebuffer,
                                      const Pica::ColorFill& color_fill);
-    void DrawScreens(Layout::FramebufferLayout& layout, bool flipped);
-    void ApplySecondLayerOpacity(Layout::Screen& screen);
+    void DrawScreens(const Layout::FramebufferLayout& layout, bool flipped);
+    void ApplySecondLayerOpacity(const Layout::Screen& screen);
     void ResetSecondLayerOpacity();
 
     void DrawScreen(const Layout::FramebufferLayout& layout,

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -56,7 +56,7 @@ public:
 
 private:
     void InitOpenGLObjects();
-    void ReloadShader();
+    void ReloadShader(Settings::StereoRenderOption render_3d);
     void PrepareRendertarget();
     void RenderScreenshot();
     void RenderToMailbox(const Layout::FramebufferLayout& layout,

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -64,13 +64,12 @@ private:
     void ConfigureFramebufferTexture(TextureInfo& texture,
                                      const Pica::FramebufferConfig& framebuffer,
                                      const Pica::ColorFill& color_fill);
-    void DrawScreens(const Layout::FramebufferLayout& layout, bool flipped);
-    void ApplySecondLayerOpacity(bool isPortrait = false);
-    void ResetSecondLayerOpacity(bool isPortrait = false);
-    void DrawBottomScreen(const Layout::FramebufferLayout& layout,
-                          const Common::Rectangle<u32>& bottom_screen);
-    void DrawTopScreen(const Layout::FramebufferLayout& layout,
-                       const Common::Rectangle<u32>& top_screen);
+    void DrawScreens(Layout::FramebufferLayout& layout, bool flipped);
+    void ApplySecondLayerOpacity(Layout::Screen& screen);
+    void ResetSecondLayerOpacity();
+
+    void DrawScreen(const Layout::FramebufferLayout& layout,
+                       const Layout::Screen& screen);
     void DrawSingleScreen(const ScreenInfo& screen_info, float x, float y, float w, float h,
                           Layout::DisplayOrientation orientation);
     void DrawSingleScreenStereo(const ScreenInfo& screen_info_l, const ScreenInfo& screen_info_r,

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -746,8 +746,9 @@ void RendererVulkan::DrawScreen(const Layout::FramebufferLayout& layout,
     case Settings::StereoRenderOption::SideBySide:
     case Settings::StereoRenderOption::SideBySideFull:
     case Settings::StereoRenderOption::CardboardVR: {
-        const int eye = screen.right_eye ? 1 : 0;
-        DrawSingleScreen(eye, screen_left, screen_top, screen_width, screen_height, orientation);
+        // 0 is top left, 1 is top right, 2 is bottom
+        const int screenId = screen.is_bottom ? 2 : (screen.right_eye ? 1 : 0);
+        DrawSingleScreen(screenId, screen_left, screen_top, screen_width, screen_height, orientation);
         break;
     }
 

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -748,7 +748,8 @@ void RendererVulkan::DrawScreen(const Layout::FramebufferLayout& layout,
     case Settings::StereoRenderOption::CardboardVR: {
         // 0 is top left, 1 is top right, 2 is bottom
         const int screenId = screen.is_bottom ? 2 : (screen.right_eye ? 1 : 0);
-        DrawSingleScreen(screenId, screen_left, screen_top, screen_width, screen_height, orientation);
+        DrawSingleScreen(screenId, screen_left, screen_top, screen_width, screen_height,
+                         orientation);
         break;
     }
 

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -735,8 +735,8 @@ void RendererVulkan::DrawTopScreen(const Layout::FramebufferLayout& layout,
         return;
     }
     int leftside, rightside;
-    leftside = Settings::values.swap_eyes_3d.GetValue() ? 0 : 1;
-    rightside = Settings::values.swap_eyes_3d.GetValue() ? 1 : 0;
+    leftside = Settings::values.swap_eyes_3d.GetValue() ? 1 : 0;
+    rightside = Settings::values.swap_eyes_3d.GetValue() ? 0 : 1;
     const float top_screen_left = static_cast<float>(top_screen.left);
     const float top_screen_top = static_cast<float>(top_screen.top);
     const float top_screen_width = static_cast<float>(top_screen.GetWidth());

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -734,7 +734,9 @@ void RendererVulkan::DrawTopScreen(const Layout::FramebufferLayout& layout,
     if (!layout.top_screen_enabled) {
         return;
     }
-
+    int leftside, rightside;
+    leftside = Settings::values.swap_eyes_3d.GetValue() ? 0 : 1;
+    rightside = Settings::values.swap_eyes_3d.GetValue() ? 1 : 0;
     const float top_screen_left = static_cast<float>(top_screen.left);
     const float top_screen_top = static_cast<float>(top_screen.top);
     const float top_screen_width = static_cast<float>(top_screen.GetWidth());
@@ -750,35 +752,36 @@ void RendererVulkan::DrawTopScreen(const Layout::FramebufferLayout& layout,
         break;
     }
     case Settings::StereoRenderOption::SideBySide: {
-        DrawSingleScreen(0, top_screen_left / 2, top_screen_top, top_screen_width / 2,
+        DrawSingleScreen(leftside, top_screen_left / 2, top_screen_top, top_screen_width / 2,
                          top_screen_height, orientation);
         draw_info.layer = 1;
-        DrawSingleScreen(1, static_cast<float>((top_screen_left / 2) + (layout.width / 2)),
+        DrawSingleScreen(rightside, static_cast<float>((top_screen_left / 2) + (layout.width / 2)),
                          top_screen_top, top_screen_width / 2, top_screen_height, orientation);
         break;
     }
-    case Settings::StereoRenderOption::ReverseSideBySide: {
-        DrawSingleScreen(1, top_screen_left / 2, top_screen_top, top_screen_width / 2,
+    case Settings::StereoRenderOption::SideBySideFull: {
+        DrawSingleScreen(leftside, top_screen_left, top_screen_top, top_screen_width,
                          top_screen_height, orientation);
         draw_info.layer = 1;
-        DrawSingleScreen(0, static_cast<float>((top_screen_left / 2) + (layout.width / 2)),
-                         top_screen_top, top_screen_width / 2, top_screen_height, orientation);
+        DrawSingleScreen(rightside, top_screen_left + layout.width / 2, top_screen_top,
+                         top_screen_width, top_screen_height, orientation);
         break;
     }
     case Settings::StereoRenderOption::CardboardVR: {
-        DrawSingleScreen(0, top_screen_left, top_screen_top, top_screen_width, top_screen_height,
-                         orientation);
+        DrawSingleScreen(leftside, top_screen_left, top_screen_top, top_screen_width,
+                         top_screen_height, orientation);
         draw_info.layer = 1;
         DrawSingleScreen(
-            1, static_cast<float>(layout.cardboard.top_screen_right_eye + (layout.width / 2)),
+            rightside,
+            static_cast<float>(layout.cardboard.top_screen_right_eye + (layout.width / 2)),
             top_screen_top, top_screen_width, top_screen_height, orientation);
         break;
     }
     case Settings::StereoRenderOption::Anaglyph:
     case Settings::StereoRenderOption::Interlaced:
     case Settings::StereoRenderOption::ReverseInterlaced: {
-        DrawSingleScreenStereo(0, 1, top_screen_left, top_screen_top, top_screen_width,
-                               top_screen_height, orientation);
+        DrawSingleScreenStereo(leftside, rightside, top_screen_left, top_screen_top,
+                               top_screen_width, top_screen_height, orientation);
         break;
     }
     }
@@ -811,7 +814,7 @@ void RendererVulkan::DrawBottomScreen(const Layout::FramebufferLayout& layout,
         break;
     }
     case Settings::StereoRenderOption::SideBySide: // Bottom screen is identical on both sides
-    case Settings::StereoRenderOption::ReverseSideBySide: {
+    {
         if (separate_win) {
             DrawSingleScreen(2, bottom_screen_left, bottom_screen_top, bottom_screen_width,
                              bottom_screen_height, orientation);
@@ -823,6 +826,14 @@ void RendererVulkan::DrawBottomScreen(const Layout::FramebufferLayout& layout,
                              bottom_screen_top, bottom_screen_width / 2, bottom_screen_height,
                              orientation);
         }
+        break;
+    }
+    case Settings::StereoRenderOption::SideBySideFull: {
+        DrawSingleScreen(2, bottom_screen_left, bottom_screen_top, bottom_screen_width,
+                         bottom_screen_height, orientation);
+        draw_info.layer = 1;
+        DrawSingleScreen(2, bottom_screen_left + layout.width / 2, bottom_screen_top,
+                         bottom_screen_width, bottom_screen_height, orientation);
         break;
     }
     case Settings::StereoRenderOption::CardboardVR: {

--- a/src/video_core/renderer_vulkan/renderer_vulkan.h
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.h
@@ -96,10 +96,8 @@ private:
                         bool flipped);
 
     void DrawScreens(Frame* frame, const Layout::FramebufferLayout& layout, bool flipped);
-    void DrawBottomScreen(const Layout::FramebufferLayout& layout,
-                          const Common::Rectangle<u32>& bottom_screen);
-    void DrawTopScreen(const Layout::FramebufferLayout& layout,
-                       const Common::Rectangle<u32>& top_screen);
+
+    void DrawScreen(const Layout::FramebufferLayout& layout, const Layout::Screen& screen);
     void DrawSingleScreen(u32 screen_id, float x, float y, float w, float h,
                           Layout::DisplayOrientation orientation);
     void DrawSingleScreenStereo(u32 screen_id_l, u32 screen_id_r, float x, float y, float w,

--- a/src/video_core/renderer_vulkan/renderer_vulkan.h
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.h
@@ -80,7 +80,7 @@ public:
     void TryPresent(int timeout_ms, bool is_secondary) override {}
 
 private:
-    void ReloadPipeline();
+    void ReloadPipeline(Settings::StereoRenderOption render_3d);
     void CompileShaders();
     void BuildLayouts();
     void BuildPipelines();


### PR DESCRIPTION
This PR is built off of #1212 , but completely refactors the Layout class inside `framebufferlayout.cpp` to make layouts significantly more portable and general-purpose. The key changes are that layouts can now contain an arbitrary number of screens, each of which has properties declaring which eye (left or right) and which screen (top or bottom) it is, as well as opacity and other features. This simplifies code in both emuwindow and the renderers, and also could potentially allow for much more powerful custom layouts down the line.

At this stage, there are likely still bugs in some layouts and such - things like Android Second Screen specifically have not been fully testing, but full testing will come. For now, I am requesting a review of the core code ideas; if this refactor will not be approved I'd rather not waste time polishing. @OpenSauce04 

Since this is built off of and contains the changes in #1212 rather than directly from current master, a git diff between this code and that code would clearly show the changes that were specific for the refactor. Here is the link for that if it helps: https://github.com/DavidRGriswold/azahar/compare/full-width-side-by-side...DavidRGriswold:azahar:layout_refactor

