### PR TITLE
Android: Add Display Listener methods for smoother secondary display updates

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/display/SecondaryDisplay.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/display/SecondaryDisplay.kt
@@ -20,7 +20,7 @@ import org.citra.citra_emu.features.settings.model.IntSetting
 import org.citra.citra_emu.display.SecondaryDisplayLayout
 import org.citra.citra_emu.NativeLibrary
 
-class SecondaryDisplay(val context: Context) {
+class SecondaryDisplay(val context: Context) : DisplayManager.DisplayListener {
     private var pres: SecondaryDisplayPresentation? = null
     private val displayManager = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
     private val vd: VirtualDisplay
@@ -34,6 +34,7 @@ class SecondaryDisplay(val context: Context) {
             null,
             DisplayManager.VIRTUAL_DISPLAY_FLAG_PRESENTATION
         )
+        displayManager.registerDisplayListener(this, null)
     }
 
     fun updateSurface() {
@@ -74,7 +75,19 @@ class SecondaryDisplay(val context: Context) {
     }
 
     fun releaseVD() {
+        displayManager.unregisterDisplayListener(this)
         vd.release()
+    }
+
+    override fun onDisplayAdded(displayId: Int) {
+        updateDisplay()
+    }
+
+    override fun onDisplayRemoved(displayId: Int) {
+        updateDisplay()
+    }
+    override fun onDisplayChanged(displayId: Int) {
+        updateDisplay()
     }
 }
 class SecondaryDisplayPresentation(


### PR DESCRIPTION
This adds display listener methods to the existing secondary layout code so that the layout automatically updates when an external display is added or removed. Solves #1370 and generally makes the process of adding and removing external displays cleaner.