### PR TITLE
vk_pipeline_cache: Fix directory creation failure if `shaders/vulkan/` is missing

### DIFF
--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -556,12 +556,15 @@ bool PipelineCache::EnsureDirectories() const {
     };
 
     return create_dir(FileUtil::GetUserPath(FileUtil::UserPath::ShaderDir)) &&
-           create_dir(GetPipelineCacheDir());
+           create_dir(GetVulkanDir()) && create_dir(GetPipelineCacheDir());
+}
+
+std::string PipelineCache::GetVulkanDir() const {
+    return FileUtil::GetUserPath(FileUtil::UserPath::ShaderDir) + "vulkan" + DIR_SEP;
 }
 
 std::string PipelineCache::GetPipelineCacheDir() const {
-    return FileUtil::GetUserPath(FileUtil::UserPath::ShaderDir) + "vulkan" + DIR_SEP + "pipeline" +
-           DIR_SEP;
+    return GetVulkanDir() + "pipeline" + DIR_SEP;
 }
 
 void PipelineCache::SwitchPipelineCache(u64 title_id, const std::atomic_bool& stop_loading,

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.h
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.h
@@ -108,6 +108,9 @@ private:
     /// Create pipeline cache directories. Returns true on success.
     bool EnsureDirectories() const;
 
+    /// Returns the Vulkan shader directory
+    std::string GetVulkanDir() const;
+
     /// Returns the pipeline cache storage dir
     std::string GetPipelineCacheDir() const;
 


### PR DESCRIPTION
If `shaders/vulkan/` was missing, the emulator still attempted to create `shaders/vulkan/pipeline/` without the parent directory.

This resulted in the emulator failing to write to the Vulkan pipeline cache, resulting in crashes.

To address this, creation of `shaders/vulkan/` is now ensured before attempting to create `shaders/vulkan/pipeline/`