### PR TITLE
[feat](android): per-game custom config and external launch activity

### DIFF
--- a/src/android/app/src/main/AndroidManifest.xml
+++ b/src/android/app/src/main/AndroidManifest.xml
@@ -79,6 +79,16 @@
         </activity>
 
         <activity
+            android:name="org.citra.citra_emu.features.external.ExternalLaunchActivity"
+            android:exported="true"
+            android:theme="@style/Theme.Citra.Main">
+            <intent-filter>
+                <action android:name="org.citra.citra_emu.LAUNCH_WITH_CUSTOM_CONFIG" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
+        <activity
             android:name="org.citra.citra_emu.features.cheats.ui.CheatsActivity"
             android:exported="false"
             android:theme="@style/Theme.Citra.Main"

--- a/src/android/app/src/main/java/org/citra/citra_emu/adapters/GameAdapter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/adapters/GameAdapter.kt
@@ -56,6 +56,8 @@ import org.citra.citra_emu.model.Game
 import org.citra.citra_emu.utils.FileUtil
 import org.citra.citra_emu.utils.GameIconUtils
 import org.citra.citra_emu.viewmodel.GamesViewModel
+import org.citra.citra_emu.features.settings.ui.SettingsActivity
+import org.citra.citra_emu.features.settings.utils.SettingsFile
 
 class GameAdapter(private val activity: AppCompatActivity, private val inflater: LayoutInflater,  private val openImageLauncher: ActivityResultLauncher<String>?) :
     ListAdapter<Game, GameViewHolder>(AsyncDifferConfig.Builder(DiffCallback()).build()),
@@ -438,6 +440,15 @@ class GameAdapter(private val activity: AppCompatActivity, private val inflater:
         bottomSheetView.findViewById<MaterialButton>(R.id.cheats).setOnClickListener {
             val action = CheatsFragmentDirections.actionGlobalCheatsFragment(holder.game.titleId)
             view.findNavController().navigate(action)
+            bottomSheetDialog.dismiss()
+        }
+
+        bottomSheetView.findViewById<MaterialButton>(R.id.application_settings).setOnClickListener {
+            SettingsActivity.launch(
+                context,
+                SettingsFile.FILE_NAME_CONFIG,
+                String.format("%016X", holder.game.titleId)
+            )
             bottomSheetDialog.dismiss()
         }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/external/ExternalLaunchActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/external/ExternalLaunchActivity.kt
@@ -1,0 +1,156 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+package org.citra.citra_emu.features.external
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import org.citra.citra_emu.CitraApplication
+import org.citra.citra_emu.R
+import org.citra.citra_emu.activities.EmulationActivity
+import org.citra.citra_emu.features.settings.utils.SettingsFile
+import org.citra.citra_emu.model.Game
+import org.citra.citra_emu.utils.DirectoryInitialization
+import org.citra.citra_emu.utils.GameHelper
+import org.citra.citra_emu.utils.Log
+
+class ExternalLaunchActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // Ensure user directory is initialized
+        DirectoryInitialization.start()
+
+        val titleIdStr = intent.getStringExtra(EXTRA_TITLE_ID)
+        val iniText = intent.getStringExtra(EXTRA_CONFIG_INI) ?: ""
+        if (titleIdStr.isNullOrEmpty()) {
+            finishWithResult(success = false)
+            return
+        }
+
+        val titleId = parseTitleId(titleIdStr)
+        if (titleId == null) {
+            finishWithResult(success = false)
+            return
+        }
+
+        // If existing per-game file exists, confirm overwrite
+        val hasExisting = SettingsFile.customExists(String.format("%016X", titleId))
+        if (hasExisting) {
+            MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.application_settings)
+                .setMessage(R.string.overwrite_custom_settings_prompt)
+                .setPositiveButton(android.R.string.ok) { _, _ ->
+                    proceedWithDriverCheckAndLaunch(titleId, iniText)
+                }
+                .setNegativeButton(android.R.string.cancel) { _, _ -> finishWithResult(success = false) }
+                .setOnCancelListener { finishWithResult(success = false) }
+                .show()
+        } else {
+            proceedWithDriverCheckAndLaunch(titleId, iniText)
+        }
+    }
+
+    private fun proceedWithDriverCheckAndLaunch(titleId: Long, iniText: String) {
+        val idHex = String.format("%016X", titleId)
+        val requestedBackend = extractGraphicsApi(iniText)
+
+        if (requestedBackend == GRAPHICS_BACKEND_VULKAN) {
+            MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.custom_launch_backend_warning_title)
+                .setMessage(R.string.custom_launch_backend_warning_message)
+                .setPositiveButton(R.string.custom_launch_backend_option_use_vulkan) { _, _ ->
+                    writeConfigAndLaunch(titleId, iniText, idHex)
+                }
+                .setNegativeButton(R.string.custom_launch_backend_option_use_opengl) { _, _ ->
+                    val adjusted = replaceGraphicsApi(iniText, GRAPHICS_BACKEND_OPENGL)
+                    Log.info("[ExternalLaunch] Falling back to OpenGL for external launch")
+                    writeConfigAndLaunch(titleId, adjusted, idHex)
+                }
+                .setOnCancelListener { finishWithResult(success = false) }
+                .show()
+            return
+        }
+
+        writeConfigAndLaunch(titleId, iniText, idHex)
+    }
+
+    private fun writeConfigAndLaunch(titleId: Long, iniText: String, idHex: String) {
+        SettingsFile.saveCustomFileRaw(idHex, iniText)
+
+        val game = findGameByTitleId(titleId)
+        if (game == null) {
+            MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.custom_launch_missing_game_title)
+                .setMessage(getString(R.string.custom_launch_missing_game_message, idHex))
+                .setPositiveButton(android.R.string.ok) { _, _ -> finishWithResult(success = false) }
+                .setOnCancelListener { finishWithResult(success = false) }
+                .show()
+            return
+        }
+
+        val launch = Intent(this, EmulationActivity::class.java)
+        launch.putExtra("game", game)
+        startActivity(launch)
+        finishWithResult(success = true)
+    }
+
+    private fun findGameByTitleId(titleId: Long): Game? {
+        // Try cached games first
+        val prefs = androidx.preference.PreferenceManager.getDefaultSharedPreferences(CitraApplication.appContext)
+        val serialized = prefs.getStringSet(GameHelper.KEY_GAMES, emptySet()) ?: emptySet()
+        if (serialized.isNotEmpty()) {
+            val games = serialized.mapNotNull {
+                try { kotlinx.serialization.json.Json.decodeFromString(org.citra.citra_emu.model.Game.serializer(), it) } catch (_: Exception) { null }
+            }
+            games.firstOrNull { it.titleId == titleId }?.let { return it }
+        }
+        // Fallback: rescan library
+        return GameHelper.getGames().firstOrNull { it.titleId == titleId }
+    }
+
+    companion object {
+        const val EXTRA_TITLE_ID = "title_id"
+        const val EXTRA_CONFIG_INI = "config_ini"
+        private const val GRAPHICS_BACKEND_OPENGL = 1
+        private const val GRAPHICS_BACKEND_VULKAN = 2
+    }
+
+    private fun parseTitleId(raw: String?): Long? {
+        if (raw.isNullOrBlank()) return null
+        val trimmed = raw.trim()
+        val withoutPrefix = if (trimmed.startsWith("0x", true)) trimmed.substring(2) else trimmed
+
+        // Prefer hexadecimal interpretation – Title IDs are traditionally provided in hex.
+        val hexValue = withoutPrefix.toLongOrNull(16)
+        if (hexValue != null) return hexValue
+
+        return withoutPrefix.toLongOrNull()
+    }
+
+    private fun extractGraphicsApi(config: String): Int? {
+        val regex = Regex(
+            "^\\s*graphics_api\\s*=\\s*(\\d+)\\s*$",
+            setOf(RegexOption.IGNORE_CASE, RegexOption.MULTILINE)
+        )
+        val match = regex.find(config) ?: return null
+        return match.groupValues.getOrNull(1)?.trim()?.toIntOrNull()
+    }
+
+    private fun replaceGraphicsApi(config: String, backend: Int): String {
+        val regex = Regex(
+            "^\\s*graphics_api\\s*=\\s*(\\d+)\\s*$",
+            setOf(RegexOption.IGNORE_CASE, RegexOption.MULTILINE)
+        )
+        return regex.replace(config) { "graphics_api = $backend" }
+    }
+
+    private fun finishWithResult(success: Boolean) {
+        setResult(if (success) RESULT_OK else RESULT_CANCELED)
+        finish()
+    }
+}

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsActivityPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsActivityPresenter.kt
@@ -29,6 +29,9 @@ class SettingsActivityPresenter(private val activityView: SettingsActivityView) 
     fun onCreate(savedInstanceState: Bundle?, menuTag: String, gameId: String) {
         this.menuTag = menuTag
         this.gameId = gameId
+        // Force reload of settings for each entry to avoid leaking values between
+        // global and per-game contexts in the shared Settings instance.
+        settings.isLoaded = false
         if (savedInstanceState != null) {
             shouldSave = savedInstanceState.getBoolean(KEY_SHOULD_SAVE)
         }

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsAdapter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsAdapter.kt
@@ -74,6 +74,7 @@ class SettingsAdapter(
     public val context: Context
 ) : RecyclerView.Adapter<SettingViewHolder?>(), DialogInterface.OnClickListener {
     private var settings: ArrayList<SettingsItem>? = null
+    var isPerGame: Boolean = false
     private var clickedItem: SettingsItem? = null
     private var clickedPosition: Int
     private var dialog: AlertDialog? = null
@@ -531,28 +532,41 @@ class SettingsAdapter(
         MaterialAlertDialogBuilder(context)
             .setMessage(R.string.reset_setting_confirmation)
             .setPositiveButton(android.R.string.ok) { _: DialogInterface, _: Int ->
-                when (setting) {
-                    is AbstractBooleanSetting -> setting.boolean = setting.defaultValue as Boolean
-                    is AbstractFloatSetting -> {
-                        if (setting is ScaledFloatSetting) {
-                            setting.float = setting.defaultValue * setting.scale
-                        } else {
-                            setting.float = setting.defaultValue as Float
-                        }
-                    }
-
-                    is AbstractIntSetting -> setting.int = setting.defaultValue as Int
-                    is AbstractStringSetting -> setting.string = setting.defaultValue as String
-                    is AbstractShortSetting -> setting.short = setting.defaultValue as Short
-                }
-                notifyItemChanged(position)
-                fragmentView.onSettingChanged()
-                fragmentView.loadSettingsList()
+                resetSettingToDefault(setting, position)
             }
             .setNegativeButton(android.R.string.cancel, null)
             .show()
 
         return true
+    }
+
+    fun resetSettingToDefault(setting: AbstractSetting, position: Int) {
+        when (setting) {
+            is AbstractBooleanSetting -> setting.boolean = setting.defaultValue as Boolean
+            is AbstractFloatSetting -> {
+                if (setting is ScaledFloatSetting) {
+                    setting.float = setting.defaultValue * setting.scale
+                } else {
+                    setting.float = setting.defaultValue as Float
+                }
+            }
+            is AbstractIntSetting -> setting.int = setting.defaultValue as Int
+            is AbstractStringSetting -> setting.string = setting.defaultValue as String
+            is AbstractShortSetting -> setting.short = setting.defaultValue as Short
+        }
+        notifyItemChanged(position)
+        fragmentView.onSettingChanged()
+        fragmentView.loadSettingsList()
+    }
+
+    fun isAtCompiledDefault(s: AbstractSetting): Boolean = when (s) {
+        is AbstractBooleanSetting -> s.boolean == s.defaultValue
+        is AbstractIntSetting -> s.int == s.defaultValue
+        is ScaledFloatSetting -> s.float == s.defaultValue * s.scale
+        is AbstractFloatSetting -> s.float == s.defaultValue
+        is AbstractShortSetting -> s.short == s.defaultValue
+        is AbstractStringSetting -> s.string == s.defaultValue
+        else -> false
     }
 
     fun onClickDisabledSetting(isRuntimeDisabled: Boolean) {

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -65,6 +65,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
     fun onViewCreated(settingsAdapter: SettingsAdapter) {
         this.settingsAdapter = settingsAdapter
         preferences = PreferenceManager.getDefaultSharedPreferences(CitraApplication.appContext)
+        settingsAdapter.isPerGame = !TextUtils.isEmpty(gameId)
         loadSettingsList()
     }
 
@@ -74,9 +75,9 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
         }
 
         val section = settings.getSection(setting.section!!)!!
-        if (section.getSetting(setting.key!!) == null) {
-            section.putSetting(setting)
-        }
+        // Update setting and mark as touched so changes persist and save explicitly.
+        section.putSetting(setting)
+        settings.markTouched(setting)
     }
 
     fun loadSettingsList() {

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/viewholder/SingleChoiceViewHolder.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/viewholder/SingleChoiceViewHolder.kt
@@ -36,6 +36,18 @@ class SingleChoiceViewHolder(val binding: ListItemSettingBinding, adapter: Setti
             binding.textSettingDescription.alpha = 0.5f
             binding.textSettingValue.alpha = 0.5f
         }
+
+        // Show "Use default" button in Custom Settings if applicable.
+        val adapterIsPerGame = adapter.isPerGame
+        val showDefault = adapterIsPerGame && setting.setting != null && !adapter.isAtCompiledDefault(setting.setting!!)
+        binding.buttonUseDefault.visibility = if (showDefault) View.VISIBLE else View.GONE
+        if (showDefault) {
+            binding.buttonUseDefault.setOnClickListener {
+                if (setting.setting != null) {
+                    adapter.resetSettingToDefault(setting.setting!!, bindingAdapterPosition)
+                }
+            }
+        }
     }
 
     private fun getTextSetting(): String {

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/viewholder/SliderViewHolder.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/viewholder/SliderViewHolder.kt
@@ -44,6 +44,18 @@ class SliderViewHolder(val binding: ListItemSettingBinding, adapter: SettingsAda
             binding.textSettingDescription.alpha = 0.5f
             binding.textSettingValue.alpha = 0.5f
         }
+
+        // Show "Use default" button in Custom Settings if applicable.
+        val adapterIsPerGame = adapter.isPerGame
+        val showDefault = adapterIsPerGame && setting.setting != null && !adapter.isAtCompiledDefault(setting.setting!!)
+        binding.buttonUseDefault.visibility = if (showDefault) View.VISIBLE else View.GONE
+        if (showDefault) {
+            binding.buttonUseDefault.setOnClickListener {
+                if (setting.setting != null) {
+                    adapter.resetSettingToDefault(setting.setting!!, bindingAdapterPosition)
+                }
+            }
+        }
     }
 
     override fun onClick(clicked: View) {

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/viewholder/StringInputViewHolder.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/viewholder/StringInputViewHolder.kt
@@ -35,6 +35,18 @@ class StringInputViewHolder(val binding: ListItemSettingBinding, adapter: Settin
             binding.textSettingDescription.alpha = 0.5f
             binding.textSettingValue.alpha = 0.5f
         }
+
+        // Show "Use default" button in Custom Settings if applicable.
+        val adapterIsPerGame = adapter.isPerGame
+        val showDefault = adapterIsPerGame && setting.setting != null && !adapter.isAtCompiledDefault(setting.setting!!)
+        binding.buttonUseDefault.visibility = if (showDefault) View.VISIBLE else View.GONE
+        if (showDefault) {
+            binding.buttonUseDefault.setOnClickListener {
+                if (setting.setting != null) {
+                    adapter.resetSettingToDefault(setting.setting!!, bindingAdapterPosition)
+                }
+            }
+        }
     }
 
     override fun onClick(clicked: View) {

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/viewholder/SwitchSettingViewHolder.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/viewholder/SwitchSettingViewHolder.kt
@@ -38,6 +38,18 @@ class SwitchSettingViewHolder(val binding: ListItemSettingSwitchBinding, adapter
         val textAlpha = if (setting.isActive) 1f else 0.5f
         binding.textSettingName.alpha = textAlpha
         binding.textSettingDescription.alpha = textAlpha
+
+        // Show "Use default" button in Custom Settings if applicable.
+        val adapterIsPerGame = adapter.isPerGame
+        val showDefault = adapterIsPerGame && setting.setting != null && !adapter.isAtCompiledDefault(setting.setting!!)
+        binding.buttonUseDefault.visibility = if (showDefault) View.VISIBLE else View.GONE
+        if (showDefault) {
+            binding.buttonUseDefault.setOnClickListener {
+                if (setting.setting != null) {
+                    adapter.resetSettingToDefault(setting.setting!!, bindingAdapterPosition)
+                }
+            }
+        }
     }
 
     override fun onClick(clicked: View) {

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/utils/SettingsFile.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/utils/SettingsFile.kt
@@ -170,6 +170,19 @@ object SettingsFile {
         }
     }
 
+    fun saveCustomFileRaw(gameId: String, contents: String) {
+        val ini = getOrCreateCustomGameSettingsFile(gameId)
+        val context: Context = CitraApplication.appContext
+        context.contentResolver.openOutputStream(ini.uri, "wt").use { out ->
+            out?.write(contents.toByteArray())
+            out?.flush()
+        }
+    }
+
+    fun customExists(gameId: String): Boolean {
+        return findCustomGameSettingsFile(gameId) != null
+    }
+
     fun saveFile(
         fileName: String,
         setting: AbstractSetting

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
@@ -359,6 +359,27 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
                     true
                 }
 
+                R.id.menu_application_settings -> {
+                    val titleId = NativeLibrary.getRunningTitleId()
+                    if (titleId != 0L) {
+                        val gameId = java.lang.String.format("%016X", titleId)
+                        SettingsActivity.launch(
+                            requireContext(),
+                            SettingsFile.FILE_NAME_CONFIG,
+                            gameId
+                        )
+                    } else {
+                        // Fallback: open global settings if title id unknown
+                        SettingsActivity.launch(
+                            requireContext(),
+                            SettingsFile.FILE_NAME_CONFIG,
+                            ""
+                        )
+                    }
+
+                    true
+                }
+
                 R.id.menu_exit -> {
                     emulationState.pause()
                     MaterialAlertDialogBuilder(requireContext())

--- a/src/android/app/src/main/jni/config.h
+++ b/src/android/app/src/main/jni/config.h
@@ -14,6 +14,8 @@ class Config {
 private:
     std::unique_ptr<INIReader> sdl2_config;
     std::string sdl2_config_loc;
+    std::unique_ptr<INIReader> per_game_config;
+    std::string per_game_config_loc;
 
     bool LoadINI(const std::string& default_contents = "", bool retry = true);
     void ReadValues();
@@ -23,6 +25,8 @@ public:
     ~Config();
 
     void Reload();
+    // Load a per-game config overlay by title id or fallback name. Does not create files.
+    void LoadPerGameConfig(u64 title_id, const std::string& fallback_name = "");
 
 private:
     /**

--- a/src/android/app/src/main/res/layout/dialog_about_game.xml
+++ b/src/android/app/src/main/res/layout/dialog_about_game.xml
@@ -179,6 +179,14 @@
                 android:contentDescription="@string/cheats"
                 android:text="@string/cheats" />
 
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/application_settings"
+                style="@style/Widget.Material3.Button.TonalButton.Icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:contentDescription="@string/application_settings"
+                android:text="@string/application_settings" />
 
         </LinearLayout>
 

--- a/src/android/app/src/main/res/layout/list_item_setting.xml
+++ b/src/android/app/src/main/res/layout/list_item_setting.xml
@@ -62,6 +62,15 @@
                 android:textSize="13sp"
                 tools:text="1x" />
 
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/button_use_default"
+                style="@style/Widget.Material3.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="@string/use_default"
+                android:visibility="gone" />
+
         </LinearLayout>
 
     </LinearLayout>

--- a/src/android/app/src/main/res/layout/list_item_setting_switch.xml
+++ b/src/android/app/src/main/res/layout/list_item_setting_switch.xml
@@ -46,6 +46,15 @@
             android:textAlignment="viewStart"
             tools:text="@string/frame_limit_enable_description" />
 
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/button_use_default"
+            style="@style/Widget.Material3.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/use_default"
+            android:visibility="gone" />
+
     </LinearLayout>
 
 </RelativeLayout>

--- a/src/android/app/src/main/res/menu/menu_in_game.xml
+++ b/src/android/app/src/main/res/menu/menu_in_game.xml
@@ -58,6 +58,11 @@
         android:title="@string/preferences_settings" />
 
     <item
+        android:id="@+id/menu_application_settings"
+        android:icon="@drawable/ic_settings"
+        android:title="@string/application_settings" />
+
+    <item
         android:id="@+id/menu_exit"
         android:icon="@drawable/ic_exit"
         android:title="@string/emulation_close_game" />

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -496,6 +496,14 @@
     <string name="menu_emulation_amiibo_remove">Remove</string>
     <string name="application_settings">Custom Settings</string>
     <string name="use_default">Use default</string>
+    <string name="overwrite_custom_settings_prompt">Custom settings for this game already exist. Overwrite them and proceed?</string>
+    <string name="custom_launch_missing_game_title">Game not found</string>
+    <string name="custom_launch_missing_game_message">This title isn\'t in your Azahar library (ID: %1$s). Add it to the library and try again.</string>
+    <string name="custom_launch_backend_warning_title">Vulkan backend requested</string>
+    <string name="custom_launch_backend_warning_message">This configuration asks Azahar to use the Vulkan renderer. Some devices crash when launching games externally with Vulkan. Keep Vulkan, or switch this launch to OpenGL for safety?</string>
+    <string name="custom_launch_backend_option_use_vulkan">Use Vulkan</string>
+    <string name="custom_launch_backend_option_use_opengl">Use OpenGL</string>
+    <string name="required_driver_missing">Missing required driver: %1$s. Please install it and try again.</string>
     <string name="select_amiibo">Select Amiibo File</string>
     <string name="amiibo_load_error">Error Loading Amiibo</string>
     <string name="amiibo_load_error_message">While loading the specified Amiibo file, an error occurred. Please check that the file is correct.</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -494,6 +494,8 @@
     <string name="menu_emulation_amiibo">Amiibo</string>
     <string name="menu_emulation_amiibo_load">Load</string>
     <string name="menu_emulation_amiibo_remove">Remove</string>
+    <string name="application_settings">Custom Settings</string>
+    <string name="use_default">Use default</string>
     <string name="select_amiibo">Select Amiibo File</string>
     <string name="amiibo_load_error">Error Loading Amiibo</string>
     <string name="amiibo_load_error_message">While loading the specified Amiibo file, an error occurred. Please check that the file is correct.</string>

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -884,6 +884,10 @@ void SetCurrentRomPath(const std::string& path) {
     g_currentRomPath = path;
 }
 
+std::string GetCurrentRomPath() {
+    return g_currentRomPath;
+}
+
 bool StringReplace(std::string& haystack, const std::string& a, const std::string& b, bool swap) {
     const auto& needle = swap ? b : a;
     const auto& replacement = swap ? a : b;

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -200,6 +200,7 @@ bool SetCurrentDir(const std::string& directory);
 void SetUserPath(const std::string& path = "");
 
 void SetCurrentRomPath(const std::string& path);
+[[nodiscard]] std::string GetCurrentRomPath();
 
 // Returns a pointer to a string with a Citra data dir in the user's home
 // directory. To be used in "multi-user" mode (that is, installed).


### PR DESCRIPTION
**Per-game custom settings**
  - Save per‑game INIs to config/custom/.ini
  - Always persist explicit choices (even if equal to global); track touched keys
  - JNI overlays per‑game before ApplySettings
  - Show “Use default” per setting; hide when already default
  - Fix presenter to update model on change

**ExternalLaunchActivity for custom game settings**
  - Tested with EmuReady app but `Intent` can be used by any external launcher
  - Enables launching a game and passing custom settings
  - Asks the user to overwrite the settings if they already have custom settings for the game
  
Note: There is one setting that we overwrite when needed
  - Sets `graphics_api` back to OpenGL when device/driver doesn't support `Vulkan`