### PR TITLE
Screen Layouts Hotkeys

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -807,6 +807,16 @@ void GMainWindow::InitializeHotkeys() {
     };
 
     connect_shortcut(QStringLiteral("Toggle Screen Layout"), &GMainWindow::ToggleScreenLayout);
+
+    connect_shortcut(QStringLiteral("Toggle Previous Layout"), &GMainWindow::TogglePreviousLayout);
+
+    connect_shortcut(QStringLiteral("Use Original Layout"), [&] { GMainWindow::SetLayout(Settings::LayoutOption::Default); });
+    connect_shortcut(QStringLiteral("Use Single Layout"), [&] { GMainWindow::SetLayout(Settings::LayoutOption::SingleScreen); });
+    connect_shortcut(QStringLiteral("Use Large Layout"), [&] { GMainWindow::SetLayout(Settings::LayoutOption::LargeScreen); });
+    connect_shortcut(QStringLiteral("Use Side Layout"), [&] { GMainWindow::SetLayout(Settings::LayoutOption::SideScreen); });
+    connect_shortcut(QStringLiteral("Use Hybrid Layout"), [&] { GMainWindow::SetLayout(Settings::LayoutOption::HybridScreen); });
+    connect_shortcut(QStringLiteral("Use Custom Layout"), [&] { GMainWindow::SetLayout(Settings::LayoutOption::CustomLayout); });
+
     connect_shortcut(QStringLiteral("Exit Fullscreen"), [&] {
         if (emulation_running) {
             ui->action_Fullscreen->setChecked(false);
@@ -878,6 +888,25 @@ void GMainWindow::InitializeHotkeys() {
     const auto fullscreen_hotkey = hotkey_registry.GetKeySequence(main_window, fullscreen);
     add_secondary_window_hotkey(action_secondary_fullscreen, fullscreen_hotkey,
                                 SLOT(ToggleSecondaryFullscreen()));
+}
+
+void GMainWindow::SetLayout(Settings::LayoutOption option) {
+    Settings::LayoutOption old_option = Settings::values.layout_option.GetValue();
+    if (option != old_option)
+        Settings::values.previous_layout_option = old_option;
+    Settings::values.layout_option = option;
+    SyncMenuUISettings();
+    system.ApplySettings();
+    UpdateSecondaryWindowVisibility();
+}
+
+void GMainWindow::TogglePreviousLayout() {
+    Settings::LayoutOption temp = Settings::values.previous_layout_option.GetValue();
+    Settings::values.previous_layout_option = Settings::values.layout_option.GetValue();
+    Settings::values.layout_option = temp;
+    SyncMenuUISettings();
+    system.ApplySettings();
+    UpdateSecondaryWindowVisibility();
 }
 
 void GMainWindow::SetDefaultUIGeometry() {

--- a/src/citra_qt/citra_qt.h
+++ b/src/citra_qt/citra_qt.h
@@ -269,6 +269,8 @@ private slots:
     void AdjustSpeedLimit(bool increase);
     void UpdateSecondaryWindowVisibility();
     void ToggleScreenLayout();
+    void SetLayout(Settings::LayoutOption option);
+    void TogglePreviousLayout();
     void OnSwapScreens();
     void OnRotateScreens();
     void TriggerSwapScreens();

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -54,7 +54,7 @@ const std::array<std::array<int, 5>, Settings::NativeAnalog::NumAnalogs> QtConfi
 // This must be in alphabetical order according to action name as it must have the same order as
 // UISetting::values.shortcuts, which is alphabetically ordered.
 // clang-format off
-const std::array<UISettings::Shortcut, 38> QtConfig::default_hotkeys {{
+const std::array<UISettings::Shortcut, 45> QtConfig::default_hotkeys {{
      {QStringLiteral("Advance Frame"),            QStringLiteral("Main Window"), {QStringLiteral(""),       Qt::ApplicationShortcut}},
      {QStringLiteral("Audio Mute/Unmute"),        QStringLiteral("Main Window"), {QStringLiteral("Ctrl+M"), Qt::WindowShortcut}},
      {QStringLiteral("Audio Volume Down"),        QStringLiteral("Main Window"), {QStringLiteral(""),       Qt::WindowShortcut}},
@@ -90,6 +90,13 @@ const std::array<UISettings::Shortcut, 38> QtConfig::default_hotkeys {{
      {QStringLiteral("Toggle Frame Advancing"),   QStringLiteral("Main Window"), {QStringLiteral("Ctrl+A"), Qt::ApplicationShortcut}},
      {QStringLiteral("Toggle Per-Application Speed"),  QStringLiteral("Main Window"), {QStringLiteral("Ctrl+Z"), Qt::ApplicationShortcut}},
      {QStringLiteral("Toggle Screen Layout"),     QStringLiteral("Main Window"), {QStringLiteral("F10"),    Qt::WindowShortcut}},
+     {QStringLiteral("Use Original Layout"),     QStringLiteral("Main Window"), {QStringLiteral("0"),    Qt::WindowShortcut}},
+     {QStringLiteral("Use Single Layout"),     QStringLiteral("Main Window"), {QStringLiteral("1"),    Qt::WindowShortcut}},
+     {QStringLiteral("Use Large Layout"),     QStringLiteral("Main Window"), {QStringLiteral("2"),    Qt::WindowShortcut}},
+     {QStringLiteral("Use Side Layout"),     QStringLiteral("Main Window"), {QStringLiteral("3"),    Qt::WindowShortcut}},
+     {QStringLiteral("Use Hybrid Layout"),     QStringLiteral("Main Window"), {QStringLiteral("4"),    Qt::WindowShortcut}},
+     {QStringLiteral("Use Custom Layout"),     QStringLiteral("Main Window"), {QStringLiteral("5"),    Qt::WindowShortcut}},
+     {QStringLiteral("Toggle Previous Layout"),     QStringLiteral("Main Window"), {QStringLiteral("F12"),    Qt::WindowShortcut}},
      {QStringLiteral("Toggle Status Bar"),        QStringLiteral("Main Window"), {QStringLiteral("Ctrl+S"), Qt::WindowShortcut}},
      {QStringLiteral("Toggle Texture Dumping"),   QStringLiteral("Main Window"), {QStringLiteral(""),       Qt::ApplicationShortcut}},
      {QStringLiteral("Toggle Turbo Mode"),        QStringLiteral("Main Window"), {QStringLiteral(""),      Qt::ApplicationShortcut}},

--- a/src/citra_qt/configuration/config.h
+++ b/src/citra_qt/configuration/config.h
@@ -26,8 +26,7 @@ public:
 
     static const std::array<int, Settings::NativeButton::NumButtons> default_buttons;
     static const std::array<std::array<int, 5>, Settings::NativeAnalog::NumAnalogs> default_analogs;
-    static const std::array<UISettings::Shortcut, 38> default_hotkeys;
-
+    static const std::array<UISettings::Shortcut, 45> default_hotkeys;
 private:
     void Initialize(const std::string& config_name);
 

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -518,6 +518,7 @@ struct Values {
                                                              "delay_game_render_thread_us"};
 
     SwitchableSetting<LayoutOption> layout_option{LayoutOption::Default, "layout_option"};
+    SwitchableSetting<LayoutOption> previous_layout_option{LayoutOption::CustomLayout, "previous_layout_option"};
     SwitchableSetting<bool> swap_screen{false, "swap_screen"};
     SwitchableSetting<bool> upright_screen{false, "upright_screen"};
     SwitchableSetting<SecondaryDisplayLayout> secondary_display_layout{SecondaryDisplayLayout::None,


### PR DESCRIPTION
resolves issue #723
By adding: 
    - Hotkeys to each screen layout [0..5]
    - Extra  hotkey (F12) to toggle between the current layout and the previous layout.
Currently just for Desktop.