### PR TITLE
ci: Update all macOS runners to macOS 15 Sequoia

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
           name: ${{ env.OS }}-${{ env.TARGET }}
           path: artifacts/
   macos:
-    runs-on: ${{ (matrix.target == 'x86_64' && 'macos-13') || 'macos-14' }}
+    runs-on: ${{ (matrix.target == 'x86_64' && 'macos-15-intel') || 'macos-15' }}
     strategy:
       fail-fast: false
       matrix:
@@ -103,7 +103,7 @@ jobs:
           name: ${{ env.OS }}-${{ env.TARGET }}
           path: artifacts/
   macos-universal:
-    runs-on: macos-14
+    runs-on: macos-15
     needs: macos
     env:
       OS: macos


### PR DESCRIPTION
This is the first of two PRs which will be updating the macOS versions we use in our GitHub Actions build environment.

This first PR will update the x86_64, ARM64, and universal runners to macOS 15 Seqouia, and will be included in the 2123.3 minor release.

This change aims to avoid upcoming scheduled brown-outs and the subsequent removal of the `macos-13` runner, which we were previously relying on for our x86_64 builds. The `macos-15-intel` runner is the replacement as recommended by GitHub.