### PR TITLE
ci: Updated ARM64 and universal macOS runners to macOS 26 Tahoe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
           name: ${{ env.OS }}-${{ env.TARGET }}
           path: artifacts/
   macos:
-    runs-on: ${{ (matrix.target == 'x86_64' && 'macos-15-intel') || 'macos-15' }}
+    runs-on: ${{ (matrix.target == 'x86_64' && 'macos-15-intel') || 'macos-26' }}
     strategy:
       fail-fast: false
       matrix:
@@ -103,7 +103,7 @@ jobs:
           name: ${{ env.OS }}-${{ env.TARGET }}
           path: artifacts/
   macos-universal:
-    runs-on: macos-15
+    runs-on: macos-26
     needs: macos
     env:
       OS: macos


### PR DESCRIPTION
This PR is a follow-up to #1410, and the second in a two-part series of PRs to update our macOS runners.

This PR updates the runners for our ARM64 build and our universal build generator to macOS 26 Tahoe. The x86_64 runner isn't being updated because no Intel runner image for macOS 26 exists, and [according to GitHub](https://github.com/actions/runner-images/issues/13027#issuecomment-3298954106), it's unlikely that such a runner will exist for the forseeable future.

Unlike the first PR, which will be included in 2123.3, this change will be first included in version 2124.