### PR TITLE
fix qt include dir

### DIFF
--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -278,8 +278,8 @@ if (ENABLE_VULKAN)
 endif()
 
 if (NOT WIN32)
-    find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets)
-    target_include_directories(citra_qt PRIVATE ${Qt6Gui_PRIVATE_INCLUDE_DIRS})
+    find_package(Qt6 REQUIRED COMPONENTS Core Gui GuiPrivate Widgets)
+    target_link_libraries(citra_qt PRIVATE Qt6::GuiPrivate)
 endif()
 
 if (APPLE)


### PR DESCRIPTION
Fix this error since Qt 6.10:
```
[727/795] Building CXX object src/citra_qt/CMakeFiles/citra_qt.dir/bootmanager.cpp.o
FAILED: src/citra_qt/CMakeFiles/citra_qt.dir/bootmanager.cpp.o 
/usr/lib/ccache/bin/c++ -DBOOST_ASIO_DISABLE_CONCEPTS -DBOOST_DATE_TIME_NO_LIB -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_IOSTREAMS_DYN_LINK -DBOOST_IOSTREAMS_NO_LIB -DBOOST_NO_CXX98_FUNCTION_BASE -DBOOST_RANDOM_DYN_LINK -DBOOST_RANDOM_NO_LIB -DBOOST_REGEX_DYN_LINK -DBOOST_REGEX_NO_LIB -DBOOST_SERIALIZATION_DYN_LINK -DBOOST_SERIALIZATION_NO_LIB -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DENABLE_OPENGL -DENABLE_QT -DENABLE_QT_TRANSLATION -DENABLE_ROOM -DENABLE_SCRIPTING -DENABLE_SDL2 -DENABLE_SOFTWARE_RENDERER -DENABLE_VULKAN -DENABLE_WEB_SERVICE -DFMT_SHARED -DHAVE_CUBEB -DHAVE_OPENAL -DHAVE_SDL2 -DMICROPROFILE_ENABLED=0 -DNDEBUG -DQT_CONCURRENT_LIB -DQT_CORE_LIB -DQT_DBUS_LIB -DQT_GUI_LIB -DQT_MULTIMEDIA_LIB -DQT_NETWORK_LIB -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT -DQT_NO_PROCESS_COMBINED_ARGUMENT_START -DQT_NO_URL_CAST_FROM_STRING -DQT_USE_QSTRINGBUILDER -DQT_WIDGETS_LIB -DUSE_DISCORD_PRESENCE -D_FILE_OFFSET_BITS=64 -I/build/azahar-git/src/azahar/build/src/citra_qt -I/build/azahar-git/src/azahar/src/citra_qt -I/build/azahar-git/src/azahar/build/src/citra_qt/citra_qt_autogen/include -I/build/azahar-git/src/azahar/src/. -I/usr/include/SDL2 -I/build/azahar-git/src/azahar/externals/./microprofile -I/build/azahar-git/src/azahar/externals/./dds-ktx -I/build/azahar-git/src/azahar/externals/xbyak -I/build/azahar-git/src/azahar/externals/./nihstro/include -I/build/azahar-git/src/azahar/externals/glad/include -I/build/azahar-git/src/azahar/externals/gamemode/include -I/build/azahar-git/src/azahar/externals/./discord-rpc/include -isystem /usr/include/ffmpeg4.4 -isystem /usr/include/qt6/QtWidgets -isystem /usr/include/qt6 -isystem /usr/include/qt6/QtCore -isystem /usr/lib/qt6/mkspecs/linux-g++ -isystem /usr/include/qt6/QtGui -isystem /usr/include/qt6/QtMultimedia -isystem /usr/include/qt6/QtNetwork -isystem /usr/include/qt6/QtConcurrent -isystem /usr/include/qt6/QtDBus -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection         -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -Wp,-D_GLIBCXX_ASSERTIONS -march=znver3 -mtune=znver3 -flto=auto -DNDEBUG -std=gnu++20 -fvisibility=default -Wall -Wno-unused-command-line-argument -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fstack-clash-protection -Wno-attributes -Wno-interference-size -Wno-psabi -w -Wno-invalid-specialization -mno-direct-extern-access -MD -MT src/citra_qt/CMakeFiles/citra_qt.dir/bootmanager.cpp.o -MF src/citra_qt/CMakeFiles/citra_qt.dir/bootmanager.cpp.o.d -o src/citra_qt/CMakeFiles/citra_qt.dir/bootmanager.cpp.o -c /build/azahar-git/src/azahar/src/citra_qt/bootmanager.cpp
/build/azahar-git/src/azahar/src/citra_qt/bootmanager.cpp:42:10: fatal error: qpa/qplatformnativeinterface.h: No such file or directory
   42 | #include <qpa/qplatformnativeinterface.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

From https://doc.qt.io/qt-6/whatsnew610.html#build-system-changes:

> Usage of a private Qt module Foo now requires a call to find_package(Qt6 COMPONENTS FooPrivate) to make the Qt6::FooPrivate target available.