### PR TITLE
Add a new setting to specify which layouts to cycle

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/display/ScreenAdjustmentUtil.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/display/ScreenAdjustmentUtil.kt
@@ -12,6 +12,7 @@ import org.citra.citra_emu.NativeLibrary
 import org.citra.citra_emu.R
 import org.citra.citra_emu.features.settings.model.BooleanSetting
 import org.citra.citra_emu.features.settings.model.IntSetting
+import org.citra.citra_emu.features.settings.model.IntListSetting
 import org.citra.citra_emu.features.settings.model.Settings
 import org.citra.citra_emu.features.settings.utils.SettingsFile
 import org.citra.citra_emu.utils.EmulationMenuSettings
@@ -31,8 +32,16 @@ class ScreenAdjustmentUtil(
         BooleanSetting.SWAP_SCREEN.boolean = isEnabled
         settings.saveSetting(BooleanSetting.SWAP_SCREEN, SettingsFile.FILE_NAME_CONFIG)
     }
+
     fun cycleLayouts() {
-        val landscapeValues = context.resources.getIntArray(R.array.landscapeValues)
+
+        val landscapeLayoutsToCycle = IntListSetting.LAYOUTS_TO_CYCLE.list;
+        val landscapeValues =
+            if (landscapeLayoutsToCycle.isNotEmpty())
+                landscapeLayoutsToCycle.toIntArray()
+            else context.resources.getIntArray(
+                R.array.landscapeValues
+            )
         val portraitValues = context.resources.getIntArray(R.array.portraitValues)
 
         if (NativeLibrary.isPortraitMode) {

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/AbstractListSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/AbstractListSetting.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/AbstractListSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/AbstractListSetting.kt
@@ -1,0 +1,9 @@
+// Copyright 2023 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+package org.citra.citra_emu.features.settings.model
+
+interface AbstractListSetting<E> : AbstractSetting {
+    var list: List<E>
+}

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntListSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntListSetting.kt
@@ -1,0 +1,39 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+package org.citra.citra_emu.features.settings.model
+
+enum class IntListSetting(
+    override val key: String,
+    override val section: String,
+    override val defaultValue: List<Int>
+) : AbstractListSetting<Int> {
+    LAYOUTS_TO_CYCLE("layouts_to_cycle", Settings.SECTION_LAYOUT, listOf(0,1,2,3,4,5));
+
+    override var list: List<Int> = defaultValue
+
+    override val valueAsString: String
+        get() = list.joinToString()
+
+
+    override val isRuntimeEditable: Boolean
+        get() {
+            for (setting in NOT_RUNTIME_EDITABLE) {
+                if (setting == this) {
+                    return false
+                }
+            }
+            return true
+        }
+
+    companion object {
+        private val NOT_RUNTIME_EDITABLE:List<IntListSetting> = listOf();
+
+
+        fun from(key: String): IntListSetting? =
+            values().firstOrNull { it.key == key }
+
+        fun clear() = values().forEach { it.list = it.defaultValue }
+    }
+}

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntListSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntListSetting.kt
@@ -7,11 +7,25 @@ package org.citra.citra_emu.features.settings.model
 enum class IntListSetting(
     override val key: String,
     override val section: String,
-    override val defaultValue: List<Int>
+    override val defaultValue: List<Int>,
+    val canBeEmpty: Boolean = true
 ) : AbstractListSetting<Int> {
-    LAYOUTS_TO_CYCLE("layouts_to_cycle", Settings.SECTION_LAYOUT, listOf(0,1,2,3,4,5));
 
-    override var list: List<Int> = defaultValue
+    LAYOUTS_TO_CYCLE("layouts_to_cycle", Settings.SECTION_LAYOUT, listOf(0, 1, 2, 3, 4, 5), canBeEmpty = false);
+
+    private var backingList: List<Int> = defaultValue
+    private var lastValidList : List<Int> = defaultValue
+
+    override var list: List<Int>
+        get() = backingList
+        set(value) {
+            if (!canBeEmpty && value.isEmpty()) {
+                backingList = lastValidList
+            } else {
+                backingList = value
+                lastValidList = value
+            }
+        }
 
     override val valueAsString: String
         get() = list.joinToString()
@@ -28,8 +42,7 @@ enum class IntListSetting(
         }
 
     companion object {
-        private val NOT_RUNTIME_EDITABLE:List<IntListSetting> = listOf();
-
+        private val NOT_RUNTIME_EDITABLE: List<IntListSetting> = emptyList()
 
         fun from(key: String): IntListSetting? =
             values().firstOrNull { it.key == key }

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/MultiChoiceSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/MultiChoiceSetting.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/MultiChoiceSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/MultiChoiceSetting.kt
@@ -1,0 +1,46 @@
+// Copyright 2023 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+package org.citra.citra_emu.features.settings.model.view
+import org.citra.citra_emu.features.settings.model.AbstractSetting
+import org.citra.citra_emu.features.settings.model.IntListSetting
+class MultiChoiceSetting(
+    setting: AbstractSetting?,
+    titleId: Int,
+    descriptionId: Int,
+    val choicesId: Int,
+    val valuesId: Int,
+    val key: String? = null,
+    val defaultValue: List<Int>? = null,
+    override var isEnabled: Boolean = true
+) : SettingsItem(setting, titleId, descriptionId) {
+    override val type = TYPE_MULTI_CHOICE
+
+    val selectedValues: List<Int>
+        get() {
+            if (setting == null) {
+                return defaultValue!!
+            }
+            try {
+                val setting = setting as IntListSetting
+                return setting.list
+            }catch (_: ClassCastException) {
+            }
+            return defaultValue!!
+        }
+
+    /**
+     * Write a value to the backing list. If that int was previously null,
+     * initializes a new one and returns it, so it can be added to the Hashmap.
+     *
+     * @param selection New value of the int.
+     * @return the existing setting with the new value applied.
+     */
+    fun setSelectedValue(selection: List<Int>): IntListSetting {
+        val intSetting = setting as IntListSetting
+        intSetting.list = selection
+        return intSetting
+    }
+
+}

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/SettingsItem.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/SettingsItem.kt
@@ -47,5 +47,6 @@ abstract class SettingsItem(
         const val TYPE_INPUT_BINDING = 8
         const val TYPE_STRING_INPUT = 9
         const val TYPE_FLOAT_INPUT = 10
+        const val TYPE_MULTI_CHOICE = 11
     }
 }

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsAdapter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsAdapter.kt
@@ -41,12 +41,14 @@ import org.citra.citra_emu.features.settings.model.AbstractIntSetting
 import org.citra.citra_emu.features.settings.model.AbstractSetting
 import org.citra.citra_emu.features.settings.model.AbstractStringSetting
 import org.citra.citra_emu.features.settings.model.FloatSetting
+import org.citra.citra_emu.features.settings.model.IntListSetting
 import org.citra.citra_emu.features.settings.model.ScaledFloatSetting
 import org.citra.citra_emu.features.settings.model.AbstractShortSetting
 import org.citra.citra_emu.features.settings.model.view.DateTimeSetting
 import org.citra.citra_emu.features.settings.model.view.InputBindingSetting
 import org.citra.citra_emu.features.settings.model.view.SettingsItem
 import org.citra.citra_emu.features.settings.model.view.SingleChoiceSetting
+import org.citra.citra_emu.features.settings.model.view.MultiChoiceSetting
 import org.citra.citra_emu.features.settings.model.view.SliderSetting
 import org.citra.citra_emu.features.settings.model.view.StringInputSetting
 import org.citra.citra_emu.features.settings.model.view.StringSingleChoiceSetting
@@ -55,6 +57,7 @@ import org.citra.citra_emu.features.settings.model.view.SwitchSetting
 import org.citra.citra_emu.features.settings.ui.viewholder.DateTimeViewHolder
 import org.citra.citra_emu.features.settings.ui.viewholder.HeaderViewHolder
 import org.citra.citra_emu.features.settings.ui.viewholder.InputBindingSettingViewHolder
+import org.citra.citra_emu.features.settings.ui.viewholder.MultiChoiceViewHolder
 import org.citra.citra_emu.features.settings.ui.viewholder.RunnableViewHolder
 import org.citra.citra_emu.features.settings.ui.viewholder.SettingViewHolder
 import org.citra.citra_emu.features.settings.ui.viewholder.SingleChoiceViewHolder
@@ -72,7 +75,8 @@ import kotlin.math.roundToInt
 class SettingsAdapter(
     private val fragmentView: SettingsFragmentView,
     public val context: Context
-) : RecyclerView.Adapter<SettingViewHolder?>(), DialogInterface.OnClickListener {
+) : RecyclerView.Adapter<SettingViewHolder?>(), DialogInterface.OnClickListener,
+    DialogInterface.OnMultiChoiceClickListener {
     private var settings: ArrayList<SettingsItem>? = null
     private var clickedItem: SettingsItem? = null
     private var clickedPosition: Int
@@ -102,6 +106,10 @@ class SettingsAdapter(
 
             SettingsItem.TYPE_SINGLE_CHOICE, SettingsItem.TYPE_STRING_SINGLE_CHOICE -> {
                 SingleChoiceViewHolder(ListItemSettingBinding.inflate(inflater), this)
+            }
+
+            SettingsItem.TYPE_MULTI_CHOICE -> {
+                MultiChoiceViewHolder(ListItemSettingBinding.inflate(inflater), this)
             }
 
             SettingsItem.TYPE_SLIDER -> {
@@ -181,21 +189,30 @@ class SettingsAdapter(
                     SettingsItem.TYPE_SLIDER -> {
                         (oldItem as SliderSetting).isEnabled == (newItem as SliderSetting).isEnabled
                     }
+
                     SettingsItem.TYPE_SWITCH -> {
                         (oldItem as SwitchSetting).isEnabled == (newItem as SwitchSetting).isEnabled
                     }
+
                     SettingsItem.TYPE_SINGLE_CHOICE -> {
                         (oldItem as SingleChoiceSetting).isEnabled == (newItem as SingleChoiceSetting).isEnabled
                     }
+                    SettingsItem.TYPE_MULTI_CHOICE -> {
+                        (oldItem as MultiChoiceSetting).isEnabled == (newItem as MultiChoiceSetting).isEnabled
+                    }
+
                     SettingsItem.TYPE_DATETIME_SETTING -> {
                         (oldItem as DateTimeSetting).isEnabled == (newItem as DateTimeSetting).isEnabled
                     }
+
                     SettingsItem.TYPE_STRING_SINGLE_CHOICE -> {
                         (oldItem as StringSingleChoiceSetting).isEnabled == (newItem as StringSingleChoiceSetting).isEnabled
                     }
+
                     SettingsItem.TYPE_STRING_INPUT -> {
                         (oldItem as StringInputSetting).isEnabled == (newItem as StringInputSetting).isEnabled
                     }
+
                     else -> {
                         oldItem == newItem
                     }
@@ -214,7 +231,7 @@ class SettingsAdapter(
 
         // If statement is required otherwise the app will crash on activity recreate ex. theme settings
         if (fragmentView.activityView != null)
-            // Reload the settings list to update the UI
+        // Reload the settings list to update the UI
             fragmentView.loadSettingsList()
     }
 
@@ -230,6 +247,21 @@ class SettingsAdapter(
     fun onSingleChoiceClick(item: SingleChoiceSetting, position: Int) {
         clickedPosition = position
         onSingleChoiceClick(item)
+    }
+
+    private fun onMultiChoiceClick(item: MultiChoiceSetting) {
+        clickedItem = item
+
+        val value: BooleanArray = getSelectionForMultiChoiceValue(item);
+        dialog = MaterialAlertDialogBuilder(context)
+            .setTitle(item.nameId)
+            .setMultiChoiceItems(item.choicesId, value, this)
+            .show()
+    }
+
+    fun onMultiChoiceClick(item: MultiChoiceSetting, position: Int) {
+        clickedPosition = position
+        onMultiChoiceClick(item)
     }
 
     private fun onStringSingleChoiceClick(item: StringSingleChoiceSetting) {
@@ -360,14 +392,14 @@ class SettingsAdapter(
                     sliderString = sliderProgress.roundToInt().toString()
                     if (textSliderValue?.text.toString() != sliderString) {
                         textSliderValue?.setText(sliderString)
-                        textSliderValue?.setSelection(textSliderValue?.length() ?: 0 )
+                        textSliderValue?.setSelection(textSliderValue?.length() ?: 0)
                     }
                 } else {
                     val currentText = textSliderValue?.text.toString()
                     val currentTextValue = currentText.toFloat()
                     if (currentTextValue != sliderProgress) {
                         textSliderValue?.setText(sliderString)
-                        textSliderValue?.setSelection(textSliderValue?.length() ?: 0 )
+                        textSliderValue?.setSelection(textSliderValue?.length() ?: 0)
                     }
                 }
             }
@@ -447,6 +479,7 @@ class SettingsAdapter(
                             }
                             it.setSelectedValue(value)
                         }
+
                         is AbstractShortSetting -> {
                             val value = getValueForSingleChoiceSelection(it, which).toShort()
                             if (it.selectedValue.toShort() != value) {
@@ -454,6 +487,7 @@ class SettingsAdapter(
                             }
                             it.setSelectedValue(value)
                         }
+
                         else -> throw IllegalStateException("Unrecognized type used for SingleChoiceSetting!")
                     }
                     fragmentView?.putSetting(setting)
@@ -499,11 +533,12 @@ class SettingsAdapter(
                             val setting = it.setSelectedValue(value)
                             fragmentView?.putSetting(setting)
                         }
+
                         else -> {
                             val setting = it.setSelectedValue(sliderProgress)
                             fragmentView?.putSetting(setting)
                         }
-                   }
+                    }
                     fragmentView.loadSettingsList()
                     closeDialog()
                 }
@@ -519,13 +554,28 @@ class SettingsAdapter(
                     fragmentView?.putSetting(setting)
                     fragmentView.loadSettingsList()
                     closeDialog()
-               }
+                }
             }
         }
         clickedItem = null
         sliderProgress = -1f
         textInputValue = ""
     }
+
+    //onclick for multichoice
+    override fun onClick(dialog: DialogInterface?, which: Int, isChecked: Boolean) {
+        val mcsetting = clickedItem as? MultiChoiceSetting
+        mcsetting?.let {
+            val value = getValueForMultiChoiceSelection(it, which)
+            if (it.selectedValues.contains(value) != isChecked) {
+                val setting = it.setSelectedValue((if (isChecked) it.selectedValues + value else it.selectedValues - value).sorted())
+                fragmentView?.putSetting(setting)
+                fragmentView?.onSettingChanged()
+            }
+            fragmentView.loadSettingsList()
+        }
+    }
+
 
     fun onLongClick(setting: AbstractSetting, position: Int): Boolean {
         MaterialAlertDialogBuilder(context)
@@ -631,6 +681,16 @@ class SettingsAdapter(
         }
     }
 
+    private fun getValueForMultiChoiceSelection(item: MultiChoiceSetting, which: Int): Int {
+        val valuesId = item.valuesId
+        return if (valuesId > 0) {
+            val valuesArray = context.resources.getIntArray(valuesId)
+            valuesArray[which]
+        } else {
+            which
+        }
+    }
+
     private fun getSelectionForSingleChoiceValue(item: SingleChoiceSetting): Int {
         val value = item.selectedValue
         val valuesId = item.valuesId
@@ -646,5 +706,21 @@ class SettingsAdapter(
             return value
         }
         return -1
+    }
+
+    private fun getSelectionForMultiChoiceValue(item: MultiChoiceSetting): BooleanArray {
+        val value = item.selectedValues;
+        val valuesId = item.valuesId;
+        if (valuesId > 0) {
+            val valuesArray = context.resources.getIntArray(valuesId);
+            val res = BooleanArray(valuesArray.size){false}
+            for (index in valuesArray.indices) {
+                if (value.contains(valuesArray[index])) {
+                    res[index] = true;
+                }
+            }
+            return res;
+        }
+        return BooleanArray(1){false};
     }
 }

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsAdapter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsAdapter.kt
@@ -256,6 +256,12 @@ class SettingsAdapter(
         dialog = MaterialAlertDialogBuilder(context)
             .setTitle(item.nameId)
             .setMultiChoiceItems(item.choicesId, value, this)
+            .setOnDismissListener {
+                if (clickedPosition != -1) {
+                    notifyItemChanged(clickedPosition)
+                    clickedPosition = -1
+                }
+            }
             .show()
     }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -14,6 +14,7 @@ import android.os.Build
 import android.text.TextUtils
 import androidx.preference.PreferenceManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import kotlinx.serialization.builtins.IntArraySerializer
 import org.citra.citra_emu.CitraApplication
 import org.citra.citra_emu.R
 import org.citra.citra_emu.display.ScreenLayout
@@ -27,12 +28,14 @@ import org.citra.citra_emu.features.settings.model.AbstractStringSetting
 import org.citra.citra_emu.features.settings.model.BooleanSetting
 import org.citra.citra_emu.features.settings.model.FloatSetting
 import org.citra.citra_emu.features.settings.model.IntSetting
+import org.citra.citra_emu.features.settings.model.IntListSetting
 import org.citra.citra_emu.features.settings.model.ScaledFloatSetting
 import org.citra.citra_emu.features.settings.model.Settings
 import org.citra.citra_emu.features.settings.model.StringSetting
 import org.citra.citra_emu.features.settings.model.view.DateTimeSetting
 import org.citra.citra_emu.features.settings.model.view.HeaderSetting
 import org.citra.citra_emu.features.settings.model.view.InputBindingSetting
+import org.citra.citra_emu.features.settings.model.view.MultiChoiceSetting
 import org.citra.citra_emu.features.settings.model.view.RunnableSetting
 import org.citra.citra_emu.features.settings.model.view.SettingsItem
 import org.citra.citra_emu.features.settings.model.view.SingleChoiceSetting
@@ -1155,6 +1158,17 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     0,
                     BooleanSetting.UPRIGHT_SCREEN.key,
                     BooleanSetting.UPRIGHT_SCREEN.defaultValue
+                )
+            )
+            add(
+                MultiChoiceSetting(
+                    IntListSetting.LAYOUTS_TO_CYCLE,
+                    R.string.layouts_to_cycle,
+                    R.string.layouts_to_cycle_description,
+                    R.array.landscapeLayouts,
+                    R.array.landscapeLayoutValues,
+                    IntListSetting.LAYOUTS_TO_CYCLE.key,
+                    IntListSetting.LAYOUTS_TO_CYCLE.defaultValue
                 )
             )
             add(

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/viewholder/MultiChoiceViewHolder.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/viewholder/MultiChoiceViewHolder.kt
@@ -1,0 +1,80 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+package org.citra.citra_emu.features.settings.ui.viewholder
+
+import android.view.View
+import org.citra.citra_emu.databinding.ListItemSettingBinding
+import org.citra.citra_emu.features.settings.model.view.SettingsItem
+import org.citra.citra_emu.features.settings.model.view.MultiChoiceSetting
+import org.citra.citra_emu.features.settings.ui.SettingsAdapter
+
+class MultiChoiceViewHolder(val binding: ListItemSettingBinding, adapter: SettingsAdapter) :
+    SettingViewHolder(binding.root, adapter) {
+    private lateinit var setting: SettingsItem
+
+    override fun bind(item: SettingsItem) {
+        setting = item
+        binding.textSettingName.setText(item.nameId)
+        if (item.descriptionId != 0) {
+            binding.textSettingDescription.visibility = View.VISIBLE
+            binding.textSettingDescription.setText(item.descriptionId)
+        } else {
+            binding.textSettingDescription.visibility = View.GONE
+        }
+        binding.textSettingValue.visibility = View.VISIBLE
+        binding.textSettingValue.text = getTextSetting()
+
+        if (setting.isActive) {
+            binding.textSettingName.alpha = 1f
+            binding.textSettingDescription.alpha = 1f
+            binding.textSettingValue.alpha = 1f
+        } else {
+            binding.textSettingName.alpha = 0.5f
+            binding.textSettingDescription.alpha = 0.5f
+            binding.textSettingValue.alpha = 0.5f
+        }
+    }
+
+    private fun getTextSetting(): String {
+        when (val item = setting) {
+            is MultiChoiceSetting -> {
+                val resMgr = binding.textSettingDescription.context.resources
+                val values = resMgr.getIntArray(item.valuesId)
+                var resList:List<String> = emptyList();
+                values.forEachIndexed { i: Int, value: Int ->
+                    if ((setting as MultiChoiceSetting).selectedValues.contains(value)) {
+                     resList = resList + resMgr.getStringArray(item.choicesId)[i];
+                    }
+                }
+                return resList.joinToString();
+            }
+
+            else -> return ""
+        }
+    }
+
+    override fun onClick(clicked: View) {
+        if (!setting.isEditable || !setting.isEnabled) {
+            adapter.onClickDisabledSetting(!setting.isEditable)
+            return
+        }
+
+        if (setting is MultiChoiceSetting) {
+            adapter.onMultiChoiceClick(
+                (setting as MultiChoiceSetting),
+                bindingAdapterPosition
+            )
+        }
+    }
+
+    override fun onLongClick(clicked: View): Boolean {
+        if (setting.isActive) {
+            return adapter.onLongClick(setting.setting!!, bindingAdapterPosition)
+        } else {
+            adapter.onClickDisabledSetting(!setting.isEditable)
+        }
+        return false
+    }
+}

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/utils/SettingsFile.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/utils/SettingsFile.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/utils/SettingsFile.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/utils/SettingsFile.kt
@@ -12,6 +12,7 @@ import org.citra.citra_emu.R
 import org.citra.citra_emu.features.settings.model.AbstractSetting
 import org.citra.citra_emu.features.settings.model.BooleanSetting
 import org.citra.citra_emu.features.settings.model.FloatSetting
+import org.citra.citra_emu.features.settings.model.IntListSetting
 import org.citra.citra_emu.features.settings.model.IntSetting
 import org.citra.citra_emu.features.settings.model.ScaledFloatSetting
 import org.citra.citra_emu.features.settings.model.SettingSection
@@ -253,6 +254,11 @@ object SettingsFile {
         if (stringSetting != null) {
             stringSetting.string = value
             return stringSetting
+        }
+
+        val intListSetting = IntListSetting.from(key)
+        if (intListSetting != null) {
+            intListSetting.list = value.split(", ").map { it.toInt() }
         }
 
         return null

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -361,6 +361,8 @@
     <string name="layout_screen_orientation_landscape_reverse">Reverse Landscape</string>
     <string name="layout_screen_orientation_portrait">Portrait</string>
     <string name="layout_screen_orientation_portrait_reverse">Reverse Portrait</string>
+    <string name="layouts_to_cycle">Layouts to Cycle</string>
+    <string name="layouts_to_cycle_description">Which layouts are cycled by the Cycle Layout hotkey</string>
     <string name="aspect_ratio_default">Default</string>
     <string name="aspect_ratio_16_9">16:9</string>
     <string name="aspect_ratio_4_3">4:3</string>

--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -49,6 +49,9 @@ add_library(citra_qt STATIC EXCLUDE_FROM_ALL
     configuration/configure_layout.cpp
     configuration/configure_layout.h
     configuration/configure_layout.ui
+    configuration/configure_layout_cycle.cpp
+    configuration/configure_layout_cycle.h
+    configuration/configure_layout_cycle.ui
     configuration/configure_dialog.cpp
     configuration/configure_dialog.h
     configuration/configure_general.cpp

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -2741,25 +2741,22 @@ void GMainWindow::AdjustSpeedLimit(bool increase) {
 
 void GMainWindow::ToggleScreenLayout() {
     const Settings::LayoutOption new_layout = []() {
-        switch (Settings::values.layout_option.GetValue()) {
-        case Settings::LayoutOption::Default:
-            return Settings::LayoutOption::SingleScreen;
-        case Settings::LayoutOption::SingleScreen:
-            return Settings::LayoutOption::LargeScreen;
-        case Settings::LayoutOption::LargeScreen:
-            return Settings::LayoutOption::HybridScreen;
-        case Settings::LayoutOption::HybridScreen:
-            return Settings::LayoutOption::SideScreen;
-        case Settings::LayoutOption::SideScreen:
-            return Settings::LayoutOption::SeparateWindows;
-        case Settings::LayoutOption::SeparateWindows:
-            return Settings::LayoutOption::CustomLayout;
-        case Settings::LayoutOption::CustomLayout:
-            return Settings::LayoutOption::Default;
-        default:
-            LOG_ERROR(Frontend, "Unknown layout option {}",
-                      Settings::values.layout_option.GetValue());
-            return Settings::LayoutOption::Default;
+        const Settings::LayoutOption current_layout = Settings::values.layout_option.GetValue();
+        std::vector<Settings::LayoutOption> layouts_to_cycle =
+            Settings::values.layouts_to_cycle.GetValue();
+        const auto current_pos =
+            distance(layouts_to_cycle.begin(),
+                     std::find(layouts_to_cycle.begin(), layouts_to_cycle.end(), current_layout));
+        // if the layouts_to_cycle setting has somehow been
+        // cleared out, add just default back in
+        if (layouts_to_cycle.size() == 0) {
+            layouts_to_cycle.push_back(Settings::LayoutOption::Default);
+        }
+        if (current_pos >= layouts_to_cycle.size() - 1) {
+            // either this layout wasn't found or it was last so move to the beginning
+            return layouts_to_cycle[0];
+        } else {
+            return layouts_to_cycle[current_pos + 1];
         }
     }();
 

--- a/src/citra_qt/configuration/config.h
+++ b/src/citra_qt/configuration/config.h
@@ -120,12 +120,19 @@ private:
     template <typename Type, bool ranged>
     void ReadBasicSetting(Settings::Setting<Type, ranged>& setting);
 
+    // Add overload for vectors
+    template <typename Type, bool ranged>
+    void ReadBasicSetting(Settings::Setting<std::vector<Type>, ranged>& setting);
+
     /** Sets a value from the setting in the qt_config using the setting's label and default value.
      *
      * @param The setting
      */
     template <typename Type, bool ranged>
     void WriteBasicSetting(const Settings::Setting<Type, ranged>& setting);
+
+    template <typename Type, bool ranged>
+    void WriteBasicSetting(const Settings::Setting<std::vector<Type>, ranged>& setting);
 
     ConfigType type;
     std::unique_ptr<QSettings> qt_config;

--- a/src/citra_qt/configuration/configure_layout.cpp
+++ b/src/citra_qt/configuration/configure_layout.cpp
@@ -6,6 +6,7 @@
 #include <QtGlobal>
 #include "citra_qt/configuration/configuration_shared.h"
 #include "citra_qt/configuration/configure_layout.h"
+#include "citra_qt/configuration/configure_layout_cycle.h"
 #include "common/settings.h"
 #include "ui_configure_layout.h"
 #ifdef ENABLE_OPENGL
@@ -110,6 +111,13 @@ ConfigureLayout::ConfigureLayout(QWidget* parent)
         const QIcon color_icon(pixmap);
         ui->bg_button->setIcon(color_icon);
         ui->bg_button->setEnabled(true);
+    });
+
+    connect(ui->customize_layouts_to_cycle, &QPushButton::clicked, this, [this] {
+        ui->customize_layouts_to_cycle->setEnabled(false);
+        QDialog* layout_cycle_dialog = new ConfigureLayoutCycle(this);
+        layout_cycle_dialog->exec();
+        ui->customize_layouts_to_cycle->setEnabled(true);
     });
 }
 

--- a/src/citra_qt/configuration/configure_layout.ui
+++ b/src/citra_qt/configuration/configure_layout.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>705</width>
-    <height>656</height>
+    <width>659</width>
+    <height>662</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -51,8 +51,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>688</width>
-        <height>799</height>
+        <width>646</width>
+        <height>824</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -130,18 +130,39 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="toggle_swap_screen">
-            <property name="text">
-             <string>Swap screens</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="toggle_upright_screen">
-            <property name="text">
-             <string>Rotate screens upright</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="horizontalLayout_7">
+            <item>
+             <layout class="QVBoxLayout" name="verticalLayout_2">
+              <item>
+               <widget class="QCheckBox" name="toggle_upright_screen">
+                <property name="text">
+                 <string>Rotate screens upright</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="toggle_swap_screen">
+                <property name="text">
+                 <string>Swap screens</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QPushButton" name="customize_layouts_to_cycle">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Customize layout cycling</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QWidget" name="widget" native="true">
@@ -356,7 +377,7 @@
                <item row="0" column="1">
                 <widget class="QSpinBox" name="custom_top_x">
                  <property name="buttonSymbols">
-                  <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                  <enum>QAbstractSpinBox::UpDownArrows</enum>
                  </property>
                  <property name="suffix">
                   <string>px</string>
@@ -376,7 +397,7 @@
                <item row="1" column="1">
                 <widget class="QSpinBox" name="custom_top_y">
                  <property name="buttonSymbols">
-                  <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                  <enum>QAbstractSpinBox::UpDownArrows</enum>
                  </property>
                  <property name="suffix">
                   <string>px</string>
@@ -396,7 +417,7 @@
                <item row="2" column="1">
                 <widget class="QSpinBox" name="custom_top_width">
                  <property name="buttonSymbols">
-                  <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                  <enum>QAbstractSpinBox::UpDownArrows</enum>
                  </property>
                  <property name="suffix">
                   <string>px</string>
@@ -416,7 +437,7 @@
                <item row="3" column="1">
                 <widget class="QSpinBox" name="custom_top_height">
                  <property name="buttonSymbols">
-                  <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                  <enum>QAbstractSpinBox::UpDownArrows</enum>
                  </property>
                  <property name="suffix">
                   <string>px</string>
@@ -440,6 +461,12 @@
               <property name="title">
                <string>Bottom Screen</string>
               </property>
+              <property name="checkable">
+               <bool>false</bool>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
               <layout class="QGridLayout" name="gridLayout_1">
                <item row="0" column="0">
                 <widget class="QLabel" name="lb_bottom_x">
@@ -451,7 +478,7 @@
                <item row="0" column="1">
                 <widget class="QSpinBox" name="custom_bottom_x">
                  <property name="buttonSymbols">
-                  <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                  <enum>QAbstractSpinBox::UpDownArrows</enum>
                  </property>
                  <property name="suffix">
                   <string>px</string>
@@ -471,7 +498,7 @@
                <item row="1" column="1">
                 <widget class="QSpinBox" name="custom_bottom_y">
                  <property name="buttonSymbols">
-                  <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                  <enum>QAbstractSpinBox::UpDownArrows</enum>
                  </property>
                  <property name="suffix">
                   <string>px</string>
@@ -491,7 +518,7 @@
                <item row="2" column="1">
                 <widget class="QSpinBox" name="custom_bottom_width">
                  <property name="buttonSymbols">
-                  <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                  <enum>QAbstractSpinBox::UpDownArrows</enum>
                  </property>
                  <property name="suffix">
                   <string>px</string>
@@ -511,7 +538,7 @@
                <item row="3" column="1">
                 <widget class="QSpinBox" name="custom_bottom_height">
                  <property name="buttonSymbols">
-                  <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                  <enum>QAbstractSpinBox::UpDownArrows</enum>
                  </property>
                  <property name="suffix">
                   <string>px</string>
@@ -538,7 +565,7 @@
             <item>
              <widget class="QSpinBox" name="custom_second_layer_opacity">
               <property name="buttonSymbols">
-               <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
+               <enum>QAbstractSpinBox::UpDownArrows</enum>
               </property>
               <property name="minimum">
                <number>10</number>
@@ -583,7 +610,7 @@
                <item row="1" column="1">
                 <widget class="QSpinBox" name="screen_top_leftright_padding">
                  <property name="buttonSymbols">
-                  <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                  <enum>QAbstractSpinBox::UpDownArrows</enum>
                  </property>
                  <property name="suffix">
                   <string>px</string>
@@ -610,7 +637,7 @@
                <item row="2" column="1">
                 <widget class="QSpinBox" name="screen_top_topbottom_padding">
                  <property name="buttonSymbols">
-                  <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                  <enum>QAbstractSpinBox::UpDownArrows</enum>
                  </property>
                  <property name="suffix">
                   <string>px</string>
@@ -659,7 +686,7 @@
                <item row="1" column="1">
                 <widget class="QSpinBox" name="screen_bottom_leftright_padding">
                  <property name="buttonSymbols">
-                  <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                  <enum>QAbstractSpinBox::UpDownArrows</enum>
                  </property>
                  <property name="suffix">
                   <string>px</string>
@@ -672,7 +699,7 @@
                <item row="2" column="1">
                 <widget class="QSpinBox" name="screen_bottom_topbottom_padding">
                  <property name="buttonSymbols">
-                  <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                  <enum>QAbstractSpinBox::UpDownArrows</enum>
                  </property>
                  <property name="suffix">
                   <string>px</string>
@@ -717,9 +744,6 @@
        </item>
        <item>
         <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>

--- a/src/citra_qt/configuration/configure_layout_cycle.cpp
+++ b/src/citra_qt/configuration/configure_layout_cycle.cpp
@@ -1,0 +1,81 @@
+#include <QCloseEvent>
+#include <QDialog>
+#include "citra_qt/configuration/configure_layout_cycle.h"
+#include "ui_configure_layout_cycle.h"
+
+ConfigureLayoutCycle::ConfigureLayoutCycle(QWidget* parent)
+    : QDialog(parent), ui(std::make_unique<Ui::ConfigureLayoutCycle>()) {
+    ui->setupUi(this);
+    SetConfiguration();
+    ConnectEvents();
+}
+
+// You MUST define the destructor in the .cpp file
+ConfigureLayoutCycle::~ConfigureLayoutCycle() = default;
+
+void ConfigureLayoutCycle::ConnectEvents() {
+    connect(ui->buttonBox, &QDialogButtonBox::accepted, this,
+            &ConfigureLayoutCycle::ApplyConfiguration);
+    connect(ui->globalCheck, &QCheckBox::stateChanged, this, &ConfigureLayoutCycle::UpdateGlobal);
+}
+
+void ConfigureLayoutCycle::SetConfiguration() {
+    if (Settings::IsConfiguringGlobal()) {
+        ui->globalCheck->setChecked(true);
+        ui->globalCheck->setVisible(false);
+    } else {
+        ui->globalCheck->setChecked(Settings::values.layouts_to_cycle.UsingGlobal());
+        ui->checkGroup->setDisabled(Settings::values.layouts_to_cycle.UsingGlobal());
+    }
+    for (auto option : Settings::values.layouts_to_cycle.GetValue()) {
+        switch (option) {
+        case Settings::LayoutOption::Default:
+            ui->defaultCheck->setChecked(true);
+            break;
+        case Settings::LayoutOption::SingleScreen:
+            ui->singleCheck->setChecked(true);
+            break;
+        case Settings::LayoutOption::LargeScreen:
+            ui->largeCheck->setChecked(true);
+            break;
+        case Settings::LayoutOption::SideScreen:
+            ui->sidebysideCheck->setChecked(true);
+            break;
+        case Settings::LayoutOption::SeparateWindows:
+            ui->separateCheck->setChecked(true);
+            break;
+        case Settings::LayoutOption::HybridScreen:
+            ui->hybridCheck->setChecked(true);
+            break;
+        case Settings::LayoutOption::CustomLayout:
+            ui->customCheck->setChecked(true);
+            break;
+        }
+    }
+}
+
+void ConfigureLayoutCycle::ApplyConfiguration() {
+    std::vector<Settings::LayoutOption> newSetting{};
+    if (ui->defaultCheck->isChecked())
+        newSetting.push_back(Settings::LayoutOption::Default);
+    if (ui->singleCheck->isChecked())
+        newSetting.push_back(Settings::LayoutOption::SingleScreen);
+    if (ui->sidebysideCheck->isChecked())
+        newSetting.push_back(Settings::LayoutOption::SideScreen);
+    if (ui->largeCheck->isChecked())
+        newSetting.push_back(Settings::LayoutOption::LargeScreen);
+    if (ui->separateCheck->isChecked())
+        newSetting.push_back(Settings::LayoutOption::SeparateWindows);
+    if (ui->hybridCheck->isChecked())
+        newSetting.push_back(Settings::LayoutOption::HybridScreen);
+    if (ui->customCheck->isChecked())
+        newSetting.push_back(Settings::LayoutOption::CustomLayout);
+    Settings::values.layouts_to_cycle = newSetting;
+    accept();
+}
+
+void ConfigureLayoutCycle::UpdateGlobal() {
+    Settings::values.layouts_to_cycle.SetGlobal(ui->globalCheck->isChecked());
+    ui->checkGroup->setDisabled(ui->globalCheck->isChecked());
+    ui->checkGroup->repaint(); // Force visual update
+}

--- a/src/citra_qt/configuration/configure_layout_cycle.cpp
+++ b/src/citra_qt/configuration/configure_layout_cycle.cpp
@@ -1,5 +1,6 @@
 #include <QCloseEvent>
 #include <QDialog>
+#include <QMessageBox>
 #include "citra_qt/configuration/configure_layout_cycle.h"
 #include "ui_configure_layout_cycle.h"
 
@@ -14,6 +15,7 @@ ConfigureLayoutCycle::ConfigureLayoutCycle(QWidget* parent)
 ConfigureLayoutCycle::~ConfigureLayoutCycle() = default;
 
 void ConfigureLayoutCycle::ConnectEvents() {
+    disconnect(ui->buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
     connect(ui->buttonBox, &QDialogButtonBox::accepted, this,
             &ConfigureLayoutCycle::ApplyConfiguration);
     connect(ui->globalCheck, &QCheckBox::stateChanged, this, &ConfigureLayoutCycle::UpdateGlobal);
@@ -70,8 +72,14 @@ void ConfigureLayoutCycle::ApplyConfiguration() {
         newSetting.push_back(Settings::LayoutOption::HybridScreen);
     if (ui->customCheck->isChecked())
         newSetting.push_back(Settings::LayoutOption::CustomLayout);
-    Settings::values.layouts_to_cycle = newSetting;
-    accept();
+    if (newSetting.empty()) {
+        QMessageBox::warning(this, tr("No Layout Selected"),
+                             tr("Please select at least one layout option to cycle through."));
+        return;
+    } else {
+        Settings::values.layouts_to_cycle = newSetting;
+        accept();
+    }
 }
 
 void ConfigureLayoutCycle::UpdateGlobal() {

--- a/src/citra_qt/configuration/configure_layout_cycle.cpp
+++ b/src/citra_qt/configuration/configure_layout_cycle.cpp
@@ -1,3 +1,6 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
 #include <QCloseEvent>
 #include <QDialog>
 #include <QMessageBox>

--- a/src/citra_qt/configuration/configure_layout_cycle.h
+++ b/src/citra_qt/configuration/configure_layout_cycle.h
@@ -1,0 +1,32 @@
+// Copyright 2018 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+#pragma once
+
+#include <memory>
+#include <QDialog>
+#include "common/settings.h"
+
+namespace Ui {
+class ConfigureLayoutCycle;
+}
+
+class ConfigureLayoutCycle : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit ConfigureLayoutCycle(QWidget* parent = nullptr);
+    ~ConfigureLayoutCycle() override;
+
+public slots:
+    void ApplyConfiguration();
+
+private slots:
+
+private:
+    void SetConfiguration();
+    void ConnectEvents();
+    void UpdateGlobal();
+
+    std::unique_ptr<Ui::ConfigureLayoutCycle> ui;
+};

--- a/src/citra_qt/configuration/configure_layout_cycle.h
+++ b/src/citra_qt/configuration/configure_layout_cycle.h
@@ -1,4 +1,4 @@
-// Copyright 2018 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 #pragma once

--- a/src/citra_qt/configuration/configure_layout_cycle.ui
+++ b/src/citra_qt/configuration/configure_layout_cycle.ui
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigureLayoutCycle</class>
+ <widget class="QDialog" name="ConfigureLayoutCycle">
+  <property name="windowModality">
+   <enum>Qt::ApplicationModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>395</width>
+    <height>334</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Configure Layout Cycling</string>
+  </property>
+  <widget class="QWidget" name="verticalLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>381</width>
+     <height>323</height>
+    </rect>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout" stretch="1,1,0,0,1">
+    <property name="sizeConstraint">
+     <enum>QLayout::SetDefaultConstraint</enum>
+    </property>
+    <item>
+     <widget class="QLabel" name="label">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>14</pointsize>
+       </font>
+      </property>
+      <property name="text">
+       <string>Screen Layout Cycling Customization</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QLabel" name="instructions">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="text">
+       <string>Select which screen layout options should be cycled with the &quot;Toggle Screen Layout&quot; hotkey</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QCheckBox" name="globalCheck">
+      <property name="text">
+       <string>Use Global Value</string>
+      </property>
+      <property name="checked">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QGroupBox" name="checkGroup">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <layout class="QVBoxLayout" name="vertLayout">
+       <item>
+        <widget class="Line" name="line">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="defaultCheck">
+         <property name="text">
+          <string>Default</string>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="singleCheck">
+         <property name="text">
+          <string>Single Screen</string>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="largeCheck">
+         <property name="text">
+          <string>Large Screen</string>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="sidebysideCheck">
+         <property name="text">
+          <string>Side by Side</string>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="separateCheck">
+         <property name="text">
+          <string>Separate Windows</string>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="hybridCheck">
+         <property name="text">
+          <string>Hybrid</string>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="customCheck">
+         <property name="text">
+          <string>Custom</string>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
+     <widget class="QDialogButtonBox" name="buttonBox">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="standardButtons">
+       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ConfigureLayoutCycle</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ConfigureLayoutCycle</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -124,6 +124,7 @@ void LogSettings() {
     log_setting("Layout_ScreenGap", values.screen_gap.GetValue());
     log_setting("Layout_LargeScreenProportion", values.large_screen_proportion.GetValue());
     log_setting("Layout_SmallScreenPosition", values.small_screen_position.GetValue());
+    // log_setting("Layout_LayoutsToCycle",values.layouts_to_cycle.GetValue());
     log_setting("Utility_DumpTextures", values.dump_textures.GetValue());
     log_setting("Utility_CustomTextures", values.custom_textures.GetValue());
     log_setting("Utility_PreloadTextures", values.preload_textures.GetValue());
@@ -215,6 +216,7 @@ void RestoreGlobalState(bool is_powered_on) {
     values.layout_option.SetGlobal(true);
     values.portrait_layout_option.SetGlobal(true);
     values.secondary_display_layout.SetGlobal(true);
+    values.layouts_to_cycle.SetGlobal(true);
     values.swap_screen.SetGlobal(true);
     values.upright_screen.SetGlobal(true);
     values.large_screen_proportion.SetGlobal(true);

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -538,6 +538,14 @@ struct Values {
     SwitchableSetting<bool> upright_screen{false, "upright_screen"};
     SwitchableSetting<SecondaryDisplayLayout> secondary_display_layout{SecondaryDisplayLayout::None,
                                                                        "secondary_display_layout"};
+    SwitchableSetting<std::vector<LayoutOption>> layouts_to_cycle{
+        {LayoutOption::Default, LayoutOption::SingleScreen, LayoutOption::LargeScreen,
+         LayoutOption::SideScreen,
+#ifndef ANDROID
+         LayoutOption::SeparateWindows,
+#endif
+         LayoutOption::HybridScreen, LayoutOption::CustomLayout},
+        "layouts_to_cycle"};
     SwitchableSetting<float, true> large_screen_proportion{4.f, 1.f, 16.f,
                                                            "large_screen_proportion"};
     SwitchableSetting<int> screen_gap{0, "screen_gap"};


### PR DESCRIPTION
Multiple people have requested the ability to only cycle through some layouts when using the "Cycle Layout" / "Toggle Layout" hotkey. This PR adds a setting for that and implements UI for it on both desktop and android.

The setting is implemented as an array of ints / enums, stored in the config.ini in the format "1,2,4" and so this also required building structures to support that INI format in both android and desktop. This should be relatively extensible to other array types (e.g. array of strings) if needed in the future.

UI screenshots:
<img width="200" alt="image" src="https://github.com/user-attachments/assets/9fff2131-1be5-42cd-a327-fa3ad3552f83" />

<img width="200" alt="image" src="https://github.com/user-attachments/assets/1e8049eb-ae6f-4d11-b13c-7448add224af" />

<img width="664" height="315" alt="image" src="https://github.com/user-attachments/assets/37d769a2-24a4-427a-a69c-2d029139e27c" />

<img width="437" height="361" alt="image" src="https://github.com/user-attachments/assets/de8746d4-93db-44e9-97c4-baec2ec75c0d" />
