### PR TITLE
video_core: Fixed occasional launch crash on certain platforms due to unsafe SDL_Init

### DIFF
--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -16,6 +16,10 @@
 #endif
 #include "video_core/video_core.h"
 
+#ifdef ENABLE_SDL2
+#include <SDL.h>
+#endif
+
 namespace VideoCore {
 
 std::unique_ptr<RendererBase> CreateRenderer(Frontend::EmuWindow& emu_window,
@@ -29,6 +33,12 @@ std::unique_ptr<RendererBase> CreateRenderer(Frontend::EmuWindow& emu_window,
 #endif
 #ifdef ENABLE_VULKAN
     case Settings::GraphicsAPI::Vulkan:
+#if defined(ENABLE_SDL2) && !defined(__APPLE__)
+        // TODO: When we migrate to SDL3, refactor so that we don't need to init here.
+        if (SDL_WasInit(SDL_INIT_VIDEO) == 0) {
+            SDL_Init(SDL_INIT_VIDEO);
+        }
+#endif // ENABLE_SDL2
         return std::make_unique<Vulkan::RendererVulkan>(system, pica, emu_window, secondary_window);
 #endif
 #ifdef ENABLE_OPENGL


### PR DESCRIPTION
This pull request fixes a regression which was introduced in 2123 which could occasionally cause a crash when launching an application with the Vulkan renderer on certain platforms. I only ever observed this issue happening on Linux, but given the nature of the code, it is possible that this also affected Windows. It is impossible for this issue to occur on macOS, which I was using when I wrote the original code, which resulted in me not catching the issue.

This was caused by SDL_Init being used in a non-main thread, which is problematic because SDL_Init is not thread safe. I didn't know this at the time when I was writing the original code.

This corrected implementation is somewhat hacky, and moves the initialization of SDL to the creation of the Vulkan renderer. This is intended to be a stop-gap measure until we migrate to SDL3, as indicated by the added comment. SDL3 seems to have added thread-safe ways of initializing SDL outside of the main thread, so this stop-gap will no longer be necessary then, but in SDL2 this seems to be impossible.

I have used the new stress testing code which was recently added, and left a game rebooting for 5 minutes with no crashes observed, so this appears to correctly address the issue.