### PR TITLE
Android dual-screen bug fix: change polling to allow extending to non-presentable displays

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/display/SecondaryDisplay.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/display/SecondaryDisplay.kt
@@ -47,9 +47,18 @@ class SecondaryDisplay(val context: Context) : DisplayManager.DisplayListener {
 
     private fun getExternalDisplay(context: Context): Display? {
         val dm = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
-        val internalId = context.display.displayId ?: Display.DEFAULT_DISPLAY
-        val displays = dm.getDisplays(DisplayManager.DISPLAY_CATEGORY_PRESENTATION)
-        return displays.firstOrNull { it.displayId != internalId && it.name != "HiddenDisplay" }
+        val currentDisplayId = context.display.displayId
+        val displays = dm.displays
+        val presDisplays = dm.getDisplays(DisplayManager.DISPLAY_CATEGORY_PRESENTATION);
+        return displays.firstOrNull {
+            val isPresentable = presDisplays.any { pd -> pd.displayId == it.displayId }
+            val isNotDefaultOrPresentable = it.displayId != Display.DEFAULT_DISPLAY || isPresentable
+            isNotDefaultOrPresentable &&
+                    it.displayId != currentDisplayId &&
+                    it.name != "HiddenDisplay" &&
+                    it.state != Display.STATE_OFF &&
+                    it.isValid
+        }
     }
 
     fun updateDisplay() {


### PR DESCRIPTION
This code change was made to address an issue where Discord breaks detection of the secondary displays on dual-screen devices by removing the Presentable flag from the display, so screen-sharing from discord makes it impossible for the user to see the second display on azahar. Although this bug has other implications on dual-screen devices and will hopefully be fixed by Discord eventually, this workaround should still be safe in the meantime, and allows for this use case on devices such as the Thor.