### PR TITLE
Default VSync to false on Android

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
@@ -44,7 +44,7 @@ enum class BooleanSetting(
     CPU_JIT("use_cpu_jit", Settings.SECTION_CORE, true),
     HW_SHADER("use_hw_shader", Settings.SECTION_RENDERER, true),
     SHADER_JIT("use_shader_jit", Settings.SECTION_RENDERER, true),
-    VSYNC("use_vsync_new", Settings.SECTION_RENDERER, false),
+    VSYNC("use_vsync", Settings.SECTION_RENDERER, false),
     USE_FRAME_LIMIT("use_frame_limit", Settings.SECTION_RENDERER, true),
     DEBUG_RENDERER("renderer_debug", Settings.SECTION_DEBUG, false),
     DISABLE_RIGHT_EYE_RENDER("disable_right_eye_render", Settings.SECTION_RENDERER, false),

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
@@ -44,7 +44,7 @@ enum class BooleanSetting(
     CPU_JIT("use_cpu_jit", Settings.SECTION_CORE, true),
     HW_SHADER("use_hw_shader", Settings.SECTION_RENDERER, true),
     SHADER_JIT("use_shader_jit", Settings.SECTION_RENDERER, true),
-    VSYNC("use_vsync_new", Settings.SECTION_RENDERER, true),
+    VSYNC("use_vsync_new", Settings.SECTION_RENDERER, false),
     USE_FRAME_LIMIT("use_frame_limit", Settings.SECTION_RENDERER, true),
     DEBUG_RENDERER("renderer_debug", Settings.SECTION_DEBUG, false),
     DISABLE_RIGHT_EYE_RENDER("disable_right_eye_render", Settings.SECTION_RENDERER, false),

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -147,7 +147,7 @@ void Config::ReadValues() {
     ReadSetting("Renderer", Settings::values.use_shader_jit);
     ReadSetting("Renderer", Settings::values.resolution_factor);
     ReadSetting("Renderer", Settings::values.use_disk_shader_cache);
-    ReadSetting("Renderer", Settings::values.use_vsync_new);
+    ReadSetting("Renderer", Settings::values.use_vsync);
     ReadSetting("Renderer", Settings::values.texture_filter);
     ReadSetting("Renderer", Settings::values.texture_sampling);
     ReadSetting("Renderer", Settings::values.turbo_limit);

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -134,9 +134,9 @@ use_shader_jit =
 # 0 (default): Game Controlled, 1: Nearest Neighbor, 2: Linear
 texture_sampling =
 
-# Forces VSync on the display thread. Usually doesn't impact performance, but on some drivers it can
-# so only turn this off if you notice a speed difference.
-# 0: Off, 1 (default): On
+# Forces VSync on the display thread. Can cause input delay, so only turn this on
+# if you have screen tearing, which is unusual on Android
+# false (default): Off, true: On
 use_vsync_new =
 
 # Reduce stuttering by storing and loading generated shaders to disk

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -137,7 +137,7 @@ texture_sampling =
 # Forces VSync on the display thread. Can cause input delay, so only turn this on
 # if you have screen tearing, which is unusual on Android
 # 0 (default): Off, 1: On
-use_vsync_new =
+use_vsync =
 
 # Reduce stuttering by storing and loading generated shaders to disk
 # 0: Off, 1 (default. On)
@@ -147,10 +147,6 @@ use_disk_shader_cache =
 # 0: Auto (scales resolution to window size), 1: Native 3DS screen resolution, Otherwise a scale
 # factor for the 3DS resolution
 resolution_factor =
-
-# Whether to enable V-Sync (caps the framerate at 60FPS) or not.
-# 0 (default): Off, 1: On
-vsync_enabled =
 
 # Turns on the frame limiter, which will limit frames output to the target game speed
 # 0: Off, 1: On (default)

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -136,7 +136,7 @@ texture_sampling =
 
 # Forces VSync on the display thread. Can cause input delay, so only turn this on
 # if you have screen tearing, which is unusual on Android
-# false (default): Off, true: On
+# 0 (default): Off, 1: On
 use_vsync_new =
 
 # Reduce stuttering by storing and loading generated shaders to disk

--- a/src/android/app/src/main/jni/emu_window/emu_window_gl.cpp
+++ b/src/android/app/src/main/jni/emu_window/emu_window_gl.cpp
@@ -122,7 +122,7 @@ EmuWindow_Android_OpenGL::EmuWindow_Android_OpenGL(Core::System& system_, ANativ
         LOG_CRITICAL(Frontend, "gladLoadGLES2Loader() failed");
         return;
     }
-    if (!eglSwapInterval(egl_display, Settings::values.use_vsync_new ? 1 : 0)) {
+    if (!eglSwapInterval(egl_display, Settings::values.use_vsync ? 1 : 0)) {
         LOG_CRITICAL(Frontend, "eglSwapInterval() failed");
         return;
     }
@@ -218,7 +218,7 @@ void EmuWindow_Android_OpenGL::TryPresenting() {
     }
     eglMakeCurrent(egl_display, egl_surface, egl_surface, egl_context);
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
-    eglSwapInterval(egl_display, Settings::values.use_vsync_new ? 1 : 0);
+    eglSwapInterval(egl_display, Settings::values.use_vsync ? 1 : 0);
     system.GPU().Renderer().TryPresent(0, is_secondary);
     eglSwapBuffers(egl_display, egl_surface);
 }

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -320,7 +320,7 @@
     <string name="hw_shaders_description">Uses hardware to emulate 3DS shaders. When enabled, game performance will be significantly improved.</string>
     <string name="cpu_clock_speed">CPU Clock Speed</string>
     <string name="vsync">Enable V-Sync</string>
-    <string name="vsync_description">Synchronizes the game frame rate to the refresh rate of your device.</string>
+    <string name="vsync_description">Synchronizes the game frame rate to the refresh rate of your device. Can cause additional input latency but may reduce tearing in some cases.</string>
     <string name="renderer_debug">Debug Renderer</string>
     <string name="renderer_debug_description">Log additional graphics related debug information. When enabled, game performance will be significantly reduced.</string>
     <string name="instant_debug_log">Flush Log Output on Every Message</string>

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -754,7 +754,7 @@ bool GRenderWindow::InitializeOpenGL() {
     child->SetContext(std::move(child_context));
 
     auto format = child_widget->windowHandle()->format();
-    format.setSwapInterval(Settings::values.use_vsync_new.GetValue());
+    format.setSwapInterval(Settings::values.use_vsync.GetValue());
     child_widget->windowHandle()->setFormat(format);
 
     return true;

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -685,7 +685,7 @@ void QtConfig::ReadRendererValues() {
     ReadGlobalSetting(Settings::values.use_hw_shader);
     ReadGlobalSetting(Settings::values.shaders_accurate_mul);
     ReadGlobalSetting(Settings::values.use_disk_shader_cache);
-    ReadGlobalSetting(Settings::values.use_vsync_new);
+    ReadGlobalSetting(Settings::values.use_vsync);
     ReadGlobalSetting(Settings::values.resolution_factor);
     ReadGlobalSetting(Settings::values.frame_limit);
     ReadGlobalSetting(Settings::values.turbo_limit);
@@ -1216,7 +1216,7 @@ void QtConfig::SaveRendererValues() {
     WriteGlobalSetting(Settings::values.use_hw_shader);
     WriteGlobalSetting(Settings::values.shaders_accurate_mul);
     WriteGlobalSetting(Settings::values.use_disk_shader_cache);
-    WriteGlobalSetting(Settings::values.use_vsync_new);
+    WriteGlobalSetting(Settings::values.use_vsync);
     WriteGlobalSetting(Settings::values.resolution_factor);
     WriteGlobalSetting(Settings::values.frame_limit);
     WriteGlobalSetting(Settings::values.turbo_limit);

--- a/src/citra_qt/configuration/configure_graphics.cpp
+++ b/src/citra_qt/configuration/configure_graphics.cpp
@@ -142,7 +142,7 @@ void ConfigureGraphics::SetConfiguration() {
     ui->toggle_hw_shader->setChecked(Settings::values.use_hw_shader.GetValue());
     ui->toggle_accurate_mul->setChecked(Settings::values.shaders_accurate_mul.GetValue());
     ui->toggle_disk_shader_cache->setChecked(Settings::values.use_disk_shader_cache.GetValue());
-    ui->toggle_vsync_new->setChecked(Settings::values.use_vsync_new.GetValue());
+    ui->toggle_vsync->setChecked(Settings::values.use_vsync.GetValue());
     ui->spirv_shader_gen->setChecked(Settings::values.spirv_shader_gen.GetValue());
     ui->disable_spirv_optimizer->setChecked(Settings::values.disable_spirv_optimizer.GetValue());
     ui->toggle_async_shaders->setChecked(Settings::values.async_shader_compilation.GetValue());
@@ -174,8 +174,8 @@ void ConfigureGraphics::ApplyConfiguration() {
                                              ui->texture_sampling_combobox);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_disk_shader_cache,
                                              ui->toggle_disk_shader_cache, use_disk_shader_cache);
-    ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_vsync_new, ui->toggle_vsync_new,
-                                             use_vsync_new);
+    ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_vsync, ui->toggle_vsync,
+                                             use_vsync);
     ConfigurationShared::ApplyPerGameSetting(
         &Settings::values.delay_game_render_thread_us, ui->delay_render_combo,
         [this](s32) { return ui->delay_render_slider->value(); });
@@ -197,8 +197,8 @@ void ConfigureGraphics::SetupPerGameUI() {
         ui->toggle_accurate_mul->setEnabled(Settings::values.shaders_accurate_mul.UsingGlobal());
         ui->toggle_disk_shader_cache->setEnabled(
             Settings::values.use_disk_shader_cache.UsingGlobal());
-        ui->toggle_vsync_new->setEnabled(ui->toggle_vsync_new->isEnabled() &&
-                                         Settings::values.use_vsync_new.UsingGlobal());
+        ui->toggle_vsync->setEnabled(ui->toggle_vsync->isEnabled() &&
+                                         Settings::values.use_vsync.UsingGlobal());
         ui->toggle_async_shaders->setEnabled(
             Settings::values.async_shader_compilation.UsingGlobal());
         ui->widget_texture_sampling->setEnabled(Settings::values.texture_sampling.UsingGlobal());
@@ -236,8 +236,8 @@ void ConfigureGraphics::SetupPerGameUI() {
     ConfigurationShared::SetColoredTristate(ui->toggle_disk_shader_cache,
                                             Settings::values.use_disk_shader_cache,
                                             use_disk_shader_cache);
-    ConfigurationShared::SetColoredTristate(ui->toggle_vsync_new, Settings::values.use_vsync_new,
-                                            use_vsync_new);
+    ConfigurationShared::SetColoredTristate(ui->toggle_vsync, Settings::values.use_vsync,
+                                            use_vsync);
     ConfigurationShared::SetColoredTristate(ui->toggle_async_shaders,
                                             Settings::values.async_shader_compilation,
                                             async_shader_compilation);

--- a/src/citra_qt/configuration/configure_graphics.h
+++ b/src/citra_qt/configuration/configure_graphics.h
@@ -38,7 +38,7 @@ private:
     ConfigurationShared::CheckState use_hw_shader;
     ConfigurationShared::CheckState shaders_accurate_mul;
     ConfigurationShared::CheckState use_disk_shader_cache;
-    ConfigurationShared::CheckState use_vsync_new;
+    ConfigurationShared::CheckState use_vsync;
     ConfigurationShared::CheckState async_shader_compilation;
     ConfigurationShared::CheckState async_presentation;
     ConfigurationShared::CheckState spirv_shader_gen;

--- a/src/citra_qt/configuration/configure_graphics.ui
+++ b/src/citra_qt/configuration/configure_graphics.ui
@@ -308,7 +308,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="toggle_vsync_new">
+       <widget class="QCheckBox" name="toggle_vsync">
         <property name="toolTip">
          <string>VSync prevents the screen from tearing, but some graphics cards have lower performance with VSync enabled. Keep it enabled if you don't notice a performance difference.</string>
         </property>
@@ -416,7 +416,7 @@
   <tabstop>toggle_accurate_mul</tabstop>
   <tabstop>toggle_shader_jit</tabstop>
   <tabstop>toggle_disk_shader_cache</tabstop>
-  <tabstop>toggle_vsync_new</tabstop>
+  <tabstop>toggle_vsync</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/citra_sdl/config.cpp
+++ b/src/citra_sdl/config.cpp
@@ -145,7 +145,7 @@ void SdlConfig::ReadValues() {
     ReadSetting("Renderer", Settings::values.resolution_factor);
     ReadSetting("Renderer", Settings::values.use_disk_shader_cache);
     ReadSetting("Renderer", Settings::values.frame_limit);
-    ReadSetting("Renderer", Settings::values.use_vsync_new);
+    ReadSetting("Renderer", Settings::values.use_vsync);
     ReadSetting("Renderer", Settings::values.texture_filter);
     ReadSetting("Renderer", Settings::values.texture_sampling);
     ReadSetting("Renderer", Settings::values.delay_game_render_thread_us);

--- a/src/citra_sdl/default_ini.h
+++ b/src/citra_sdl/default_ini.h
@@ -121,7 +121,7 @@ use_shader_jit =
 # Forces VSync on the display thread. Usually doesn't impact performance, but on some drivers it can
 # so only turn this off if you notice a speed difference.
 # 0: Off, 1 (default): On
-use_vsync_new =
+use_vsync =
 
 # Reduce stuttering by storing and loading generated shaders to disk
 # 0: Off, 1 (default. On)

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -98,7 +98,7 @@ void LogSettings() {
     log_setting("Renderer_UseShaderJit", values.use_shader_jit.GetValue());
     log_setting("Renderer_UseResolutionFactor", values.resolution_factor.GetValue());
     log_setting("Renderer_FrameLimit", values.frame_limit.GetValue());
-    log_setting("Renderer_VSyncNew", values.use_vsync_new.GetValue());
+    log_setting("Renderer_VSyncNew", values.use_vsync.GetValue());
     log_setting("Renderer_PostProcessingShader", values.pp_shader_name.GetValue());
     log_setting("Renderer_FilterMode", values.filter_mode.GetValue());
     log_setting("Renderer_TextureFilter", GetTextureFilterName(values.texture_filter.GetValue()));
@@ -200,7 +200,7 @@ void RestoreGlobalState(bool is_powered_on) {
     values.use_hw_shader.SetGlobal(true);
     values.use_disk_shader_cache.SetGlobal(true);
     values.shaders_accurate_mul.SetGlobal(true);
-    values.use_vsync_new.SetGlobal(true);
+    values.use_vsync.SetGlobal(true);
     values.resolution_factor.SetGlobal(true);
     values.frame_limit.SetGlobal(true);
     values.texture_filter.SetGlobal(true);

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -506,7 +506,7 @@ struct Values {
     SwitchableSetting<bool> use_hw_shader{true, "use_hw_shader"};
     SwitchableSetting<bool> use_disk_shader_cache{true, "use_disk_shader_cache"};
     SwitchableSetting<bool> shaders_accurate_mul{true, "shaders_accurate_mul"};
-    SwitchableSetting<bool> use_vsync_new{true, "use_vsync_new"};
+    SwitchableSetting<bool> use_vsync{true, "use_vsync"};
     Setting<bool> use_shader_jit{true, "use_shader_jit"};
     SwitchableSetting<u32, true> resolution_factor{1, 0, 10, "resolution_factor"};
     SwitchableSetting<double, true> frame_limit{100, 0, 1000, "frame_limit"};

--- a/src/video_core/renderer_vulkan/vk_present_window.cpp
+++ b/src/video_core/renderer_vulkan/vk_present_window.cpp
@@ -105,7 +105,7 @@ PresentWindow::PresentWindow(Frontend::EmuWindow& emu_window_, const Instance& i
       swapchain{instance, emu_window.GetFramebufferLayout().width,
                 emu_window.GetFramebufferLayout().height, surface, low_refresh_rate_},
       graphics_queue{instance.GetGraphicsQueue()}, present_renderpass{CreateRenderpass()},
-      vsync_enabled{Settings::values.use_vsync_new.GetValue()},
+      vsync_enabled{Settings::values.use_vsync.GetValue()},
       blit_supported{
           CanBlitToSwapchain(instance.GetPhysicalDevice(), swapchain.GetSurfaceFormat().format)},
       use_present_thread{Settings::values.async_presentation.GetValue()},
@@ -360,7 +360,7 @@ void PresentWindow::CopyToSwapchain(Frame* frame) {
     };
 
 #ifndef ANDROID
-    const bool use_vsync = Settings::values.use_vsync_new.GetValue();
+    const bool use_vsync = Settings::values.use_vsync.GetValue();
     const bool size_changed =
         swapchain.GetWidth() != frame->width || swapchain.GetHeight() != frame->height;
     const bool vsync_changed = vsync_enabled != use_vsync;

--- a/src/video_core/renderer_vulkan/vk_swapchain.cpp
+++ b/src/video_core/renderer_vulkan/vk_swapchain.cpp
@@ -161,7 +161,7 @@ void Swapchain::FindPresentFormat() {
 
 void Swapchain::SetPresentMode() {
     const auto modes = instance.GetPhysicalDevice().getSurfacePresentModesKHR(surface);
-    const bool use_vsync = Settings::values.use_vsync_new.GetValue();
+    const bool use_vsync = Settings::values.use_vsync.GetValue();
     const auto find_mode = [&modes](vk::PresentModeKHR requested) {
         const auto it =
             std::find_if(modes.begin(), modes.end(),


### PR DESCRIPTION
VSync on android seems to have very little effect on screen tearing (android has built-in frame pacing to avoid it) and has a noticeable effect on input latency, so it seems appropriate to default the setting to Off and update the descriptions appropriately.

This update only changes the default, so anybody who has *ever* changed the setting to false and then back to true will still need to change it to false manually. But I expect the vast majority of users have either manually turned it to false OR never touched it at all, so this should change the default correctly for most.