### PR TITLE
Android bugfix: Long press and "clear defaults" now correctly clears setting for input bindings

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/InputBindingSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/InputBindingSetting.kt
@@ -16,6 +16,7 @@ import org.citra.citra_emu.NativeLibrary
 import org.citra.citra_emu.R
 import org.citra.citra_emu.features.hotkeys.Hotkey
 import org.citra.citra_emu.features.settings.model.AbstractSetting
+import org.citra.citra_emu.features.settings.model.AbstractStringSetting
 import org.citra.citra_emu.features.settings.model.Settings
 
 class InputBindingSetting(
@@ -161,6 +162,7 @@ class InputBindingSetting(
     fun removeOldMapping() {
         // Try remove all possible keys we wrote for this setting
         val oldKey = preferences.getString(reverseKey, "")
+        (setting as AbstractStringSetting).string = ""
         if (oldKey != "") {
             preferences.edit()
                 .remove(abstractSetting.key) // Used for ui text

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsAdapter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsAdapter.kt
@@ -555,6 +555,21 @@ class SettingsAdapter(
         return true
     }
 
+    fun onInputBindingLongClick(setting: InputBindingSetting, position: Int): Boolean {
+        MaterialAlertDialogBuilder(context)
+            .setMessage(R.string.reset_setting_confirmation)
+            .setPositiveButton(android.R.string.ok) { _: DialogInterface, _: Int ->
+                setting.removeOldMapping()
+                notifyItemChanged(position)
+                fragmentView.onSettingChanged()
+                fragmentView.loadSettingsList()
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+
+        return true
+    }
+
     fun onClickDisabledSetting(isRuntimeDisabled: Boolean) {
         val titleId = if (isRuntimeDisabled)
             R.string.setting_not_editable

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/viewholder/InputBindingSettingViewHolder.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/viewholder/InputBindingSettingViewHolder.kt
@@ -51,7 +51,7 @@ class InputBindingSettingViewHolder(val binding: ListItemSettingBinding, adapter
 
     override fun onLongClick(clicked: View): Boolean {
         if (setting.isEditable) {
-            adapter.onLongClick(setting.setting!!, bindingAdapterPosition)
+            adapter.onInputBindingLongClick(setting, bindingAdapterPosition)
         } else {
             adapter.onClickDisabledSetting(!setting.isEditable)
         }


### PR DESCRIPTION
Previously, long-pressing and choosing "clear defaults" for bindings did not clear the actual binding setting, so bindings would continue to function. This fixes that bug.