### PR TITLE
Android: Hotkey Enable Button

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.kt
@@ -267,48 +267,23 @@ class EmulationActivity : AppCompatActivity() {
             return super.dispatchKeyEvent(event)
         }
 
-        val buttonSet = InputBindingSetting.getButtonSet(event)
-
         when (event.action) {
             KeyEvent.ACTION_DOWN -> {
-                var handled = false;
                 // On some devices, the back gesture / button press is not intercepted by androidx
                 // and fails to open the emulation menu. So we're stuck running deprecated code to
                 // cover for either a fault on androidx's side or in OEM skins (MIUI at least)
+
                 if (event.keyCode == KeyEvent.KEYCODE_BACK) {
                     // If the hotkey is pressed, we don't want to open the drawer
-                    if (!hotkeyUtility.HotkeyIsPressed) {
+                    if (!hotkeyUtility.hotkeyIsPressed) {
                         onBackPressed()
-                        handled = true;
+                        return true
                     }
                 }
-                for (button in buttonSet) {
-                    if (hotkeyUtility.handleHotkey(button)) {
-                        handled = true;
-                    }else {
-                        handled = NativeLibrary.onGamePadEvent(
-                            event.device.descriptor,
-                            button,
-                            NativeLibrary.ButtonState.PRESSED) || handled
-
-                    }
-                }
-                return handled;
+                return hotkeyUtility.handleKeyPress(event)
             }
             KeyEvent.ACTION_UP -> {
-                var handled = false;
-                for (button in buttonSet) {
-                    if (hotkeyUtility.handleButtonRelease(button)) {
-                        handled = true;
-                    }else {
-                        handled = NativeLibrary.onGamePadEvent(
-                            event.device.descriptor,
-                            button,
-                            NativeLibrary.ButtonState.RELEASED
-                        ) || handled
-                    }
-                }
-                return handled;
+                return hotkeyUtility.handleKeyRelease(event)
             }
             else -> {
                 return false;

--- a/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.kt
@@ -267,7 +267,7 @@ class EmulationActivity : AppCompatActivity() {
             return super.dispatchKeyEvent(event)
         }
 
-        val buttonSet = getButtonSet(event)
+        val buttonSet = InputBindingSetting.getButtonSet(event)
 
         when (event.action) {
             KeyEvent.ACTION_DOWN -> {
@@ -314,26 +314,6 @@ class EmulationActivity : AppCompatActivity() {
                 return false;
             }
         }
-    }
-
-    /**
-     * Get the mutable set of int button values this key should map to
-     */
-    private fun getButtonSet(keyCode: KeyEvent):MutableSet<Int> {
-       val key = InputBindingSetting.getInputButtonKey(keyCode)
-        var buttonCodes = try {
-           preferences.getStringSet(key, mutableSetOf<String>())
-        } catch (e: ClassCastException) {
-            val prefInt = preferences.getInt(key, -1);
-            val migratedSet = if (prefInt != -1) {
-                mutableSetOf(prefInt.toString())
-            } else {
-                mutableSetOf<String>()
-            }
-            migratedSet
-        }
-        if (buttonCodes == null) buttonCodes = mutableSetOf<String>()
-        return buttonCodes.mapNotNull { it.toIntOrNull() }.toMutableSet()
     }
 
     private fun onAmiiboSelected(selectedFile: String) {

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/hotkeys/Hotkey.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/hotkeys/Hotkey.kt
@@ -11,5 +11,6 @@ enum class Hotkey(val button: Int) {
     PAUSE_OR_RESUME(10004),
     QUICKSAVE(10005),
     QUICKLOAD(10006),
-    TURBO_LIMIT(10007);
+    TURBO_LIMIT(10007),
+    ENABLE(10008);
 }

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/hotkeys/HotkeyUtility.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/hotkeys/HotkeyUtility.kt
@@ -17,10 +17,16 @@ class HotkeyUtility(
     private val context: Context) {
 
     private val hotkeyButtons = Hotkey.entries.map { it.button }
+    private var hotkeyIsEnabled = false;
     var HotkeyIsPressed = false
 
     fun handleHotkey(bindedButton: Int): Boolean {
-        if(hotkeyButtons.contains(bindedButton)) {
+        if (bindedButton == Hotkey.ENABLE.button) {
+            hotkeyIsEnabled = true;
+            return true;
+        }
+        if(hotkeyButtons.contains(bindedButton) &&
+            (hotkeyIsEnabled || !hotkeyButtons.contains(Hotkey.ENABLE.button))) {
             when (bindedButton) {
                 Hotkey.SWAP_SCREEN.button -> screenAdjustmentUtil.swapScreen()
                 Hotkey.CYCLE_LAYOUT.button -> screenAdjustmentUtil.cycleLayouts()
@@ -50,5 +56,15 @@ class HotkeyUtility(
             return true
         }
         return false
+    }
+
+    fun handleButtonRelease(bindedButton: Int): Boolean {
+        if (! hotkeyButtons.contains(bindedButton)) return false;
+        if (bindedButton == Hotkey.ENABLE.button) {
+            hotkeyIsEnabled = false;
+        }else {
+            HotkeyIsPressed = false;
+        }
+        return true;
     }
 }

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/hotkeys/HotkeyUtility.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/hotkeys/HotkeyUtility.kt
@@ -5,66 +5,140 @@
 package org.citra.citra_emu.features.hotkeys
 
 import android.content.Context
+import android.view.KeyEvent
 import android.widget.Toast
+import androidx.preference.PreferenceManager
+import org.citra.citra_emu.CitraApplication
 import org.citra.citra_emu.NativeLibrary
 import org.citra.citra_emu.R
 import org.citra.citra_emu.utils.EmulationLifecycleUtil
 import org.citra.citra_emu.utils.TurboHelper
 import org.citra.citra_emu.display.ScreenAdjustmentUtil
+import org.citra.citra_emu.features.settings.model.view.InputBindingSetting
+import org.citra.citra_emu.features.settings.model.Settings
 
 class HotkeyUtility(
     private val screenAdjustmentUtil: ScreenAdjustmentUtil,
-    private val context: Context) {
+    private val context: Context
+) {
 
     private val hotkeyButtons = Hotkey.entries.map { it.button }
-    private var hotkeyIsEnabled = false;
-    var HotkeyIsPressed = false
+    private var hotkeyIsEnabled = false
+    var hotkeyIsPressed = false
+    private val currentlyPressedButtons = mutableSetOf<Int>()
 
-    fun handleHotkey(bindedButton: Int): Boolean {
-        if (bindedButton == Hotkey.ENABLE.button) {
-            hotkeyIsEnabled = true;
-            return true;
-        }
-        if(hotkeyButtons.contains(bindedButton) &&
-            (hotkeyIsEnabled || !hotkeyButtons.contains(Hotkey.ENABLE.button))) {
-            when (bindedButton) {
-                Hotkey.SWAP_SCREEN.button -> screenAdjustmentUtil.swapScreen()
-                Hotkey.CYCLE_LAYOUT.button -> screenAdjustmentUtil.cycleLayouts()
-                Hotkey.CLOSE_GAME.button -> EmulationLifecycleUtil.closeGame()
-                Hotkey.PAUSE_OR_RESUME.button -> EmulationLifecycleUtil.pauseOrResume()
-                Hotkey.TURBO_LIMIT.button -> TurboHelper.toggleTurbo(true)
-                Hotkey.QUICKSAVE.button -> {
-                    NativeLibrary.saveState(NativeLibrary.QUICKSAVE_SLOT)
-                    Toast.makeText(context,
-                        context.getString(R.string.saving),
-                        Toast.LENGTH_SHORT).show()
-                }
-                Hotkey.QUICKLOAD.button -> {
-                    val wasLoaded = NativeLibrary.loadStateIfAvailable(NativeLibrary.QUICKSAVE_SLOT)
-                    val stringRes = if(wasLoaded) {
-                        R.string.loading
-                    } else {
-                        R.string.quickload_not_found
-                    }
-                    Toast.makeText(context,
-                        context.getString(stringRes),
-                        Toast.LENGTH_SHORT).show()
-                }
-                else -> {}
+    fun handleKeyPress(keyEvent: KeyEvent): Boolean {
+        var handled = false
+        val buttonSet = InputBindingSetting.getButtonSet(keyEvent)
+        val enableButton =
+            PreferenceManager.getDefaultSharedPreferences(CitraApplication.appContext)
+                .getString(Settings.HOTKEY_ENABLE, "")
+        val thisKeyIsEnableButton = buttonSet.contains(Hotkey.ENABLE.button)
+        val thisKeyIsHotkey =
+            !thisKeyIsEnableButton && Hotkey.entries.any { buttonSet.contains(it.button) }
+        hotkeyIsEnabled = hotkeyIsEnabled || enableButton == "" || thisKeyIsEnableButton
+
+        // Now process all internal buttons associated with this keypress
+        for (button in buttonSet) {
+            currentlyPressedButtons.add(button)
+            //option 1 - this is the enable command, which was already handled
+            if (button == Hotkey.ENABLE.button) {
+                handled = true
             }
-            HotkeyIsPressed = true
-            return true
+            // option 2 - this is a different hotkey command
+            else if (hotkeyButtons.contains(button)) {
+                if (hotkeyIsEnabled) {
+                    handled = handleHotkey(button) || handled
+                }
+            }
+            // option 3 - this is a normal key
+            else {
+                // if this key press is ALSO associated with a hotkey that will process, skip
+                // the normal key event.
+                if (!thisKeyIsHotkey || !hotkeyIsEnabled) {
+                    handled = NativeLibrary.onGamePadEvent(
+                        keyEvent.device.descriptor,
+                        button,
+                        NativeLibrary.ButtonState.PRESSED
+                    ) || handled
+                }
+            }
         }
-        return false
+        return handled
     }
 
-    fun handleButtonRelease(bindedButton: Int): Boolean {
-        if (! hotkeyButtons.contains(bindedButton)) return false;
-        if (bindedButton == Hotkey.ENABLE.button) {
-            hotkeyIsEnabled = false;
-        }else {
-            HotkeyIsPressed = false;
+    fun handleKeyRelease(keyEvent: KeyEvent): Boolean {
+        var handled = false
+        val buttonSet = InputBindingSetting.getButtonSet(keyEvent)
+        val thisKeyIsEnableButton = buttonSet.contains(Hotkey.ENABLE.button)
+        val thisKeyIsHotkey =
+            !thisKeyIsEnableButton && Hotkey.entries.any { buttonSet.contains(it.button) }
+        if (thisKeyIsEnableButton) {
+            handled = true; hotkeyIsEnabled = false
         }
-        return true;
+
+        for (button in buttonSet) {
+            // this is a hotkey button
+            if (hotkeyButtons.contains(button)) {
+                currentlyPressedButtons.remove(button)
+                if (!currentlyPressedButtons.any { hotkeyButtons.contains(it) }) {
+                    // all hotkeys are no longer pressed
+                    hotkeyIsPressed = false
+                }
+            } else {
+                // if this key ALSO sends a hotkey command that we already/will handle,
+                // or if we did not register the press of this button, e.g. if this key
+                // was also a hotkey pressed after enable, but released after enable button release, then
+                // skip the normal key event
+                if ((!thisKeyIsHotkey || !hotkeyIsEnabled) && currentlyPressedButtons.contains(
+                        button
+                    )
+                ) {
+                    handled = NativeLibrary.onGamePadEvent(
+                        keyEvent.device.descriptor,
+                        button,
+                        NativeLibrary.ButtonState.RELEASED
+                    ) || handled
+                    currentlyPressedButtons.remove(button)
+                }
+            }
+        }
+        return handled
+    }
+
+    fun handleHotkey(bindedButton: Int): Boolean {
+        when (bindedButton) {
+            Hotkey.SWAP_SCREEN.button -> screenAdjustmentUtil.swapScreen()
+            Hotkey.CYCLE_LAYOUT.button -> screenAdjustmentUtil.cycleLayouts()
+            Hotkey.CLOSE_GAME.button -> EmulationLifecycleUtil.closeGame()
+            Hotkey.PAUSE_OR_RESUME.button -> EmulationLifecycleUtil.pauseOrResume()
+            Hotkey.TURBO_LIMIT.button -> TurboHelper.toggleTurbo(true)
+            Hotkey.QUICKSAVE.button -> {
+                NativeLibrary.saveState(NativeLibrary.QUICKSAVE_SLOT)
+                Toast.makeText(
+                    context,
+                    context.getString(R.string.saving),
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+
+            Hotkey.QUICKLOAD.button -> {
+                val wasLoaded = NativeLibrary.loadStateIfAvailable(NativeLibrary.QUICKSAVE_SLOT)
+                val stringRes = if (wasLoaded) {
+                    R.string.loading
+                } else {
+                    R.string.quickload_not_found
+                }
+                Toast.makeText(
+                    context,
+                    context.getString(stringRes),
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+
+            else -> {}
+        }
+        hotkeyIsPressed = true
+        return true
     }
 }

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/Settings.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/Settings.kt
@@ -135,6 +135,7 @@ class Settings {
         const val KEY_CSTICK_AXIS_HORIZONTAL = "cstick_axis_horizontal"
         const val KEY_DPAD_AXIS_VERTICAL = "dpad_axis_vertical"
         const val KEY_DPAD_AXIS_HORIZONTAL = "dpad_axis_horizontal"
+        const val HOTKEY_ENABLE = "hotkey_enable"
         const val HOTKEY_SCREEN_SWAP = "hotkey_screen_swap"
         const val HOTKEY_CYCLE_LAYOUT = "hotkey_toggle_layout"
         const val HOTKEY_CLOSE_GAME = "hotkey_close_game"
@@ -202,6 +203,7 @@ class Settings {
             R.string.button_zr
         )
         val hotKeys = listOf(
+            HOTKEY_ENABLE,
             HOTKEY_SCREEN_SWAP,
             HOTKEY_CYCLE_LAYOUT,
             HOTKEY_CLOSE_GAME,
@@ -211,6 +213,7 @@ class Settings {
             HOTKEY_TURBO_LIMIT
         )
         val hotkeyTitles = listOf(
+            R.string.controller_hotkey_enable_button,
             R.string.emulation_swap_screens,
             R.string.emulation_cycle_landscape_layouts,
             R.string.emulation_close_game,

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -811,7 +811,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                 add(InputBindingSetting(button, Settings.triggerTitles[i]))
             }
 
-            add(HeaderSetting(R.string.controller_hotkeys))
+            add(HeaderSetting(R.string.controller_hotkeys,R.string.controller_hotkeys_description))
             Settings.hotKeys.forEachIndexed { i: Int, key: String ->
                 val button = getInputObject(key)
                 add(InputBindingSetting(button, Settings.hotkeyTitles[i]))

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -122,6 +122,8 @@
     <string name="controller_circlepad">Circle Pad</string>
     <string name="controller_c">C-Stick</string>
     <string name="controller_hotkeys">Hotkeys</string>
+    <string name="controller_hotkeys_description">If the "Hotkey Enable" key is mapped, that key must be pressed in addition to the mapped hotkey</string>
+    <string name="controller_hotkey_enable_button">Hotkey Enable</string>
     <string name="controller_triggers">Triggers</string>
     <string name="controller_trigger">Trigger</string>
     <string name="controller_dpad">D-Pad</string>


### PR DESCRIPTION
This adds a Hotkey Enable button on android. 

## How this works
Users can map the "Hotkey Enable" hotkey on android just like any other hotkey. If it is bound, then it becomes a required part of any hotkey chord. For example, if the user binds their controller's Select key to the Hotkey Enable button, and then binds D-pad Right to Save State, then they now have to press Select + D-pad Right in order to save a state.

## Reasoning
Many controllers have few or no buttons that are not on the 3ds - often L3 and R3 are the only options on modern x-input style controllers. If a user wishes to bind more than 2 hotkeys, they may not be able to do so without conflicting with a 3ds button. This allows for users to bind as many hotkeys as they want without worrying about that conflict (though in the example I gave, the Select action *would* still happen - but if the user has any buttons that are not mapped to 3ds buttons, they can use that as the Hotkey Enable button, which is ideal behavior.)

This feature works similar to other emulators, and specifically it is the same as how Retroarch implements chording for hotkeys.

## Changes

In addition to adding the hotkey setting and adjusting how the input manager and hotkey utility classes handle hotkeys, this required significant changes to how input settings are stored in SharedPreferences, specifically replacing some Int settings with StringSet settings so that we could store multiple keys for certain hotkeys.

## Screenshot and demo video

![Screenshot_20260226-170049.png](https://github.com/user-attachments/assets/b8e34bdd-be98-4f72-9856-cddb201ec1e4)

The video below shows me pressing Select to no effect, then B to no effect, then I press both and the screen swaps. This matches the mapping above. 

https://github.com/user-attachments/assets/6b0604e3-d99d-4230-b3da-1e1e6c44ceb7



