### PR TITLE
Android: Hotkey Enable Button (version 2)

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/hotkeys/Hotkey.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/hotkeys/Hotkey.kt
@@ -11,5 +11,6 @@ enum class Hotkey(val button: Int) {
     PAUSE_OR_RESUME(10004),
     QUICKSAVE(10005),
     QUICKLOAD(10006),
-    TURBO_LIMIT(10007);
+    TURBO_LIMIT(10007),
+    ENABLE(10008);
 }

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/hotkeys/HotkeyUtility.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/hotkeys/HotkeyUtility.kt
@@ -18,9 +18,16 @@ class HotkeyUtility(
 
     private val hotkeyButtons = Hotkey.entries.map { it.button }
     var HotkeyIsPressed = false
+    var enabled = false
 
+    fun enableHotkeys() {
+        enabled = true
+    }
+    fun disableHotkeys() {
+        enabled = false
+    }
     fun handleHotkey(bindedButton: Int): Boolean {
-        if(hotkeyButtons.contains(bindedButton)) {
+        if(hotkeyButtons.contains(bindedButton) && enabled) {
             when (bindedButton) {
                 Hotkey.SWAP_SCREEN.button -> screenAdjustmentUtil.swapScreen()
                 Hotkey.CYCLE_LAYOUT.button -> screenAdjustmentUtil.cycleLayouts()

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/Settings.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/Settings.kt
@@ -135,6 +135,7 @@ class Settings {
         const val KEY_CSTICK_AXIS_HORIZONTAL = "cstick_axis_horizontal"
         const val KEY_DPAD_AXIS_VERTICAL = "dpad_axis_vertical"
         const val KEY_DPAD_AXIS_HORIZONTAL = "dpad_axis_horizontal"
+        const val HOTKEY_ENABLE = "hotkey_enable"
         const val HOTKEY_SCREEN_SWAP = "hotkey_screen_swap"
         const val HOTKEY_CYCLE_LAYOUT = "hotkey_toggle_layout"
         const val HOTKEY_CLOSE_GAME = "hotkey_close_game"
@@ -202,6 +203,7 @@ class Settings {
             R.string.button_zr
         )
         val hotKeys = listOf(
+            HOTKEY_ENABLE,
             HOTKEY_SCREEN_SWAP,
             HOTKEY_CYCLE_LAYOUT,
             HOTKEY_CLOSE_GAME,
@@ -211,6 +213,7 @@ class Settings {
             HOTKEY_TURBO_LIMIT
         )
         val hotkeyTitles = listOf(
+            R.string.controller_hotkey_enable_button,
             R.string.emulation_swap_screens,
             R.string.emulation_cycle_landscape_layouts,
             R.string.emulation_close_game,

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/InputBindingSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/InputBindingSetting.kt
@@ -16,6 +16,7 @@ import org.citra.citra_emu.NativeLibrary
 import org.citra.citra_emu.R
 import org.citra.citra_emu.features.hotkeys.Hotkey
 import org.citra.citra_emu.features.settings.model.AbstractSetting
+import org.citra.citra_emu.features.settings.model.AbstractStringSetting
 import org.citra.citra_emu.features.settings.model.Settings
 
 class InputBindingSetting(
@@ -161,6 +162,7 @@ class InputBindingSetting(
     fun removeOldMapping() {
         // Try remove all possible keys we wrote for this setting
         val oldKey = preferences.getString(reverseKey, "")
+        (setting as AbstractStringSetting).string = ""
         if (oldKey != "") {
             preferences.edit()
                 .remove(abstractSetting.key) // Used for ui text

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsAdapter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsAdapter.kt
@@ -555,6 +555,21 @@ class SettingsAdapter(
         return true
     }
 
+    fun onInputBindingLongClick(setting: InputBindingSetting, position: Int): Boolean {
+        MaterialAlertDialogBuilder(context)
+            .setMessage(R.string.reset_setting_confirmation)
+            .setPositiveButton(android.R.string.ok) { _: DialogInterface, _: Int ->
+                setting.removeOldMapping()
+                notifyItemChanged(position)
+                fragmentView.onSettingChanged()
+                fragmentView.loadSettingsList()
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+
+        return true
+    }
+
     fun onClickDisabledSetting(isRuntimeDisabled: Boolean) {
         val titleId = if (isRuntimeDisabled)
             R.string.setting_not_editable

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -796,7 +796,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                 add(InputBindingSetting(button, Settings.triggerTitles[i]))
             }
 
-            add(HeaderSetting(R.string.controller_hotkeys))
+            add(HeaderSetting(R.string.controller_hotkeys,R.string.controller_hotkeys_description))
             Settings.hotKeys.forEachIndexed { i: Int, key: String ->
                 val button = getInputObject(key)
                 add(InputBindingSetting(button, Settings.hotkeyTitles[i]))

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/viewholder/InputBindingSettingViewHolder.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/viewholder/InputBindingSettingViewHolder.kt
@@ -51,7 +51,7 @@ class InputBindingSettingViewHolder(val binding: ListItemSettingBinding, adapter
 
     override fun onLongClick(clicked: View): Boolean {
         if (setting.isEditable) {
-            adapter.onLongClick(setting.setting!!, bindingAdapterPosition)
+            adapter.onInputBindingLongClick(setting, bindingAdapterPosition)
         } else {
             adapter.onClickDisabledSetting(!setting.isEditable)
         }

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -116,6 +116,8 @@
     <string name="controller_circlepad">Circle Pad</string>
     <string name="controller_c">C-Stick</string>
     <string name="controller_hotkeys">Hotkeys</string>
+    <string name="controller_hotkeys_description">If the "Hotkey Enable" key is mapped, that key must be pressed in addition to the mapped hotkey</string>
+    <string name="controller_hotkey_enable_button">Hotkey Enable</string>
     <string name="controller_triggers">Triggers</string>
     <string name="controller_trigger">Trigger</string>
     <string name="controller_dpad">D-Pad</string>


### PR DESCRIPTION
This is a simpler implementation of the Hotkey Enable button on Android. This version simply leverages the existing setting for the hotkey to skip regular input binding and perform the special hotkey feature instead - less flexible to other potential uses, but probably the better choice so I will leave this one as the open one for now.

If the Hotkey Enable Button is bound, then you must be holding that button for any of the other Hotkey binds to work. This can allow you to, for example, map the right trigger to save state so that select + right trigger saves states, while normally the trigger is just a trigger. 