### PR TITLE
Android: Keep track of the axis direction when mapping axes (also allows inversion for external pads)

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.kt
@@ -342,6 +342,7 @@ class EmulationActivity : AppCompatActivity() {
                 preferences.getInt(InputBindingSetting.getInputAxisButtonKey(axis), -1)
             val guestOrientation =
                 preferences.getInt(InputBindingSetting.getInputAxisOrientationKey(axis), -1)
+            val inverted = preferences.getBoolean(InputBindingSetting.getInputAxisInvertedKey(axis),false);
             if (nextMapping == -1 || guestOrientation == -1) {
                 // Axis is unmapped
                 continue
@@ -350,6 +351,8 @@ class EmulationActivity : AppCompatActivity() {
                 // Skip joystick wobble
                 value = 0f
             }
+            if (inverted) value = -value;
+
             when (nextMapping) {
                 NativeLibrary.ButtonType.STICK_LEFT -> {
                     axisValuesCirclePad[guestOrientation] = value

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/InputBindingSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/InputBindingSetting.kt
@@ -169,6 +169,7 @@ class InputBindingSetting(
                 .remove(oldKey) // Used for button mapping
                 .remove(oldKey + "_GuestOrientation") // Used for axis orientation
                 .remove(oldKey + "_GuestButton") // Used for axis button
+                .remove(oldKey + "_Inverted") // used for axis inversion
                 .apply()
         }
     }
@@ -202,7 +203,7 @@ class InputBindingSetting(
     /**
      * Helper function to write a gamepad axis mapping for the setting.
      */
-    private fun writeAxisMapping(axis: Int, value: Int) {
+    private fun writeAxisMapping(axis: Int, value: Int, inverted: Boolean) {
         // Cleanup old mapping
         removeOldMapping()
 
@@ -210,6 +211,7 @@ class InputBindingSetting(
         preferences.edit()
             .putInt(getInputAxisOrientationKey(axis), if (isHorizontalOrientation()) 0 else 1)
             .putInt(getInputAxisButtonKey(axis), value)
+            .putBoolean(getInputAxisInvertedKey(axis),inverted)
             // Write next reverse mapping for future cleanup
             .putString(reverseKey, getInputAxisKey(axis))
             .apply()
@@ -253,8 +255,8 @@ class InputBindingSetting(
         } else {
             buttonCode
         }
-        writeAxisMapping(motionRange.axis, button)
-        val uiString = "${device.name}: Axis ${motionRange.axis}"
+        writeAxisMapping(motionRange.axis, button, axisDir == '-')
+        val uiString = "${device.name}: Axis ${motionRange.axis}" + axisDir
         value = uiString
     }
 
@@ -308,6 +310,11 @@ class InputBindingSetting(
          * Helper function to get the settings key for an gamepad axis button (stick or trigger).
          */
         fun getInputAxisButtonKey(axis: Int): String = "${getInputAxisKey(axis)}_GuestButton"
+
+        /**
+         * Helper function to get the settings key for an whether a gamepad axis is inverted.
+         */
+        fun getInputAxisInvertedKey(axis: Int): String = "${getInputAxisKey(axis)}_Inverted"
 
         /**
          * Helper function to get the settings key for an gamepad axis orientation.

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/InputBindingSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/InputBindingSetting.kt
@@ -239,7 +239,7 @@ class InputBindingSetting(
      *
      * @param device      InputDevice from which the input event originated.
      * @param motionRange MotionRange of the movement
-     * @param axisDir     Either '-' or '+' (currently unused)
+     * @param axisDir     Either '-' or '+'
      */
     fun onMotionInput(device: InputDevice, motionRange: MotionRange, axisDir: Char) {
         if (!isAxisMappingSupported()) {

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -140,8 +140,8 @@
     <string name="input_dialog_description">Press or move an input.</string>
     <string name="input_binding">Input Binding</string>
     <string name="input_binding_description">Press or move an input to bind it to %1$s.</string>
-    <string name="input_binding_description_vertical_axis">Move your joystick up or down.</string>
-    <string name="input_binding_description_horizontal_axis">Move your joystick left or right.</string>
+    <string name="input_binding_description_vertical_axis">Move your joystick down</string>
+    <string name="input_binding_description_horizontal_axis">Move your joystick right</string>
     <string name="button_a" translatable="false">A</string>
     <string name="button_b" translatable="false">B</string>
     <string name="button_select" translatable="false">SELECT</string>


### PR DESCRIPTION
Some third-party gamepads reverse the expected direction of axes, using positive values for up rather than the expected down, for example. This changes the mapping experience so that users are asked specifically to press Down or Right when mapping the gamepad, and it stores the direction as a separate setting.

This would also allow users who are using a gamepad to invert the x or y axis simply by reversing their inputs while mapping, though it will have no effect on the touch controller. It may make sense to add a separate boolean "axis invert" setting later which would be honored by all controllers including the touch one, but this PR does not do that.