### PR TITLE
Increase maximum emulation speed input in frontend configuration UIs

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/SliderSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/SliderSetting.kt
@@ -20,7 +20,8 @@ class SliderSetting(
     val units: String,
     val key: String? = null,
     val defaultValue: Float? = null,
-    override var isEnabled: Boolean = true
+    override var isEnabled: Boolean = true,
+    val showSlider: Boolean = true
 ) : SettingsItem(setting, titleId, descriptionId) {
     override val type = TYPE_SLIDER
     val selectedFloat: Float

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsAdapter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsAdapter.kt
@@ -15,6 +15,7 @@ import android.text.InputType
 import android.text.TextWatcher
 import android.text.format.DateFormat
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -315,7 +316,6 @@ class SettingsAdapter(
         clickedPosition = position
         sliderProgress = (item.selectedFloat * 100f).roundToInt() / 100f
 
-
         val inflater = LayoutInflater.from(context)
         val sliderBinding = DialogSliderBinding.inflate(inflater)
         textInputLayout = sliderBinding.textInput
@@ -335,6 +335,11 @@ class SettingsAdapter(
             valueFrom = item.min.toFloat()
             valueTo = item.max.toFloat()
             value = sliderProgress
+            if (!item.showSlider) {
+                isEnabled = false
+                visibility = View.GONE
+            }
+
             textSliderValue?.addTextChangedListener(object : TextWatcher {
                 override fun afterTextChanged(s: Editable) {
                     var textValue = s.toString().toFloatOrNull();

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsAdapter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsAdapter.kt
@@ -15,6 +15,7 @@ import android.text.InputType
 import android.text.TextWatcher
 import android.text.format.DateFormat
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -354,7 +355,6 @@ class SettingsAdapter(
         clickedPosition = position
         sliderProgress = (item.selectedFloat * 100f).roundToInt() / 100f
 
-
         val inflater = LayoutInflater.from(context)
         val sliderBinding = DialogSliderBinding.inflate(inflater)
         textInputLayout = sliderBinding.textInput
@@ -374,6 +374,11 @@ class SettingsAdapter(
             valueFrom = item.min.toFloat()
             valueTo = item.max.toFloat()
             value = sliderProgress
+            if (!item.showSlider) {
+                isEnabled = false
+                visibility = View.GONE
+            }
+
             textSliderValue?.addTextChangedListener(object : TextWatcher {
                 override fun afterTextChanged(s: Editable) {
                     var textValue = s.toString().toFloatOrNull();

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -236,10 +236,11 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     R.string.frame_limit_slider,
                     R.string.frame_limit_slider_description,
                     1,
-                    200,
+                    9999,
                     "%",
                     IntSetting.FRAME_LIMIT.key,
-                    IntSetting.FRAME_LIMIT.defaultValue.toFloat()
+                    IntSetting.FRAME_LIMIT.defaultValue.toFloat(),
+                    showSlider = false
                 )
             )
             add(
@@ -247,11 +248,12 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     IntSetting.TURBO_LIMIT,
                     R.string.turbo_limit,
                     R.string.turbo_limit_description,
-                    100,
-                    400,
+                    1,
+                    9999,
                     "%",
                     IntSetting.TURBO_LIMIT.key,
-                    IntSetting.TURBO_LIMIT.defaultValue.toFloat()
+                    IntSetting.TURBO_LIMIT.defaultValue.toFloat(),
+                    showSlider = false
                 )
             )
             add(

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -239,10 +239,11 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     R.string.frame_limit_slider,
                     R.string.frame_limit_slider_description,
                     1,
-                    200,
+                    9999,
                     "%",
                     IntSetting.FRAME_LIMIT.key,
-                    IntSetting.FRAME_LIMIT.defaultValue.toFloat()
+                    IntSetting.FRAME_LIMIT.defaultValue.toFloat(),
+                    showSlider = false
                 )
             )
             add(
@@ -250,11 +251,12 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     IntSetting.TURBO_LIMIT,
                     R.string.turbo_limit,
                     R.string.turbo_limit_description,
-                    100,
-                    400,
+                    1,
+                    9999,
                     "%",
                     IntSetting.TURBO_LIMIT.key,
-                    IntSetting.TURBO_LIMIT.defaultValue.toFloat()
+                    IntSetting.TURBO_LIMIT.defaultValue.toFloat(),
+                    showSlider = false
                 )
             )
             add(

--- a/src/citra_qt/configuration/configure_general.ui
+++ b/src/citra_qt/configuration/configure_general.ui
@@ -135,44 +135,32 @@
            <item>
             <widget class="QLabel" name="label_emulation_speed">
              <property name="text">
-              <string>Emulation Speed</string>
+              <string>Emulation Speed:</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QSlider" name="frame_limit">
-             <property name="minimum">
-              <number>0</number>
-             </property>
+            <widget class="QSpinBox" name="frame_limit">
              <property name="maximum">
-              <number>199</number>
+              <number>9999</number>
              </property>
-             <property name="singleStep">
-              <number>5</number>
-             </property>
-             <property name="pageStep">
-              <number>15</number>
-             </property>
-             <property name="value">
-              <number>19</number>
-             </property>
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="tickPosition">
-              <enum>QSlider::TicksBelow</enum>
+             <property name="suffix">
+              <string>%</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QLabel" name="emulation_speed_display_label">
-             <property name="text">
-              <string/>
+            <spacer name="horizontalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
-             <property name="alignment">
-              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
              </property>
-            </widget>
+            </spacer>
            </item>
           </layout>
          </widget>
@@ -200,55 +188,27 @@
             </widget>
            </item>
            <item>
-            <widget class="QSlider" name="turbo_limit">
-             <property name="minimum">
-              <number>0</number>
-             </property>
+            <widget class="QSpinBox" name="turbo_limit">
              <property name="maximum">
-              <number>198</number>
+              <number>9999</number>
              </property>
-             <property name="singleStep">
-              <number>5</number>
-             </property>
-             <property name="pageStep">
-              <number>15</number>
-             </property>
-             <property name="value">
-              <number>19</number>
-             </property>
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="tickPosition">
-              <enum>QSlider::TicksBelow</enum>
+             <property name="suffix">
+              <string>%</string>
              </property>
             </widget>
            </item>
            <item>
             <spacer name="horizontalSpacer">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeType">
-              <enum>QSizePolicy::Fixed</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
-               <width>32</width>
+               <width>40</width>
                <height>20</height>
               </size>
              </property>
             </spacer>
-           </item>
-           <item>
-            <widget class="QLabel" name="turbo_limit_display_label">
-             <property name="text">
-              <string/>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-             </property>
-            </widget>
            </item>
           </layout>
          </widget>
@@ -317,7 +277,7 @@
        </layout>
       </widget>
      </item>
-     <item alignment="Qt::AlignRight">
+     <item alignment="Qt::AlignmentFlag::AlignRight">
       <widget class="QPushButton" name="button_reset_defaults">
        <property name="text">
         <string>Reset All Settings</string>
@@ -327,7 +287,7 @@
      <item>
       <spacer name="verticalSpacer">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -524,8 +524,8 @@ struct Values {
         true, "use_display_refresh_rate_detection"};
     Setting<bool> use_shader_jit{true, "use_shader_jit"};
     SwitchableSetting<u32, true> resolution_factor{1, 0, 10, "resolution_factor"};
-    SwitchableSetting<double, true> frame_limit{100, 0, 1000, "frame_limit"};
-    SwitchableSetting<double, true> turbo_limit{200, 0, 1000, "turbo_limit"};
+    SwitchableSetting<double, true> frame_limit{100, 1, 9999, "frame_limit"};
+    SwitchableSetting<double, true> turbo_limit{200, 1, 9999, "turbo_limit"};
     SwitchableSetting<TextureFilter> texture_filter{TextureFilter::NoFilter, "texture_filter"};
     SwitchableSetting<TextureSampling> texture_sampling{TextureSampling::GameControlled,
                                                         "texture_sampling"};

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -545,8 +545,8 @@ struct Values {
     Setting<bool> use_shader_jit{true, Keys::use_shader_jit};
     SwitchableSetting<u32, true> resolution_factor{1, 0, 10, Keys::resolution_factor};
     SwitchableSetting<bool> use_integer_scaling{false, Keys::use_integer_scaling};
-    SwitchableSetting<double, true> frame_limit{100, 0, 1000, Keys::frame_limit};
-    SwitchableSetting<double, true> turbo_limit{200, 0, 1000, Keys::turbo_limit};
+    SwitchableSetting<double, true> frame_limit{100, 0, 9999, Keys::frame_limit};
+    SwitchableSetting<double, true> turbo_limit{200, 0, 9999, Keys::turbo_limit};
     SwitchableSetting<TextureFilter> texture_filter{TextureFilter::NoFilter, Keys::texture_filter};
     SwitchableSetting<TextureSampling> texture_sampling{TextureSampling::GameControlled,
                                                         Keys::texture_sampling};


### PR DESCRIPTION
Closes #1224

On both desktop and Android, this PR does two things:

1. Increases the limit for both the emulation speed and turbo speed to 9999%
2. Removes the slider for adjusting emulation speed, instead favouring text entry

---

TODO:

- Implement some functionality in the Qt frontend equivalent to the "Limit Speed" checkbox on Android