### PR TITLE
Android: Bug fix for incorrect screen size detection

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -113,18 +113,24 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
     /** Returns the portrait mode width */
     private fun getWidth(): Int {
         val dm = Resources.getSystem().displayMetrics;
-        return if (dm.widthPixels < dm.heightPixels)
-            dm.widthPixels
+        val wm = settingsActivity.windowManager.maximumWindowMetrics;
+        val height = wm.bounds.height().coerceAtLeast(dm.heightPixels);
+        val width  = wm.bounds.width().coerceAtLeast(dm.widthPixels);
+        return if (width < height)
+            width
         else
-            dm.heightPixels
+            height
     }
 
     private fun getHeight(): Int {
         val dm = Resources.getSystem().displayMetrics;
-        return if (dm.widthPixels < dm.heightPixels)
-            dm.heightPixels
+        val wm = settingsActivity.windowManager.maximumWindowMetrics;
+        val height = wm.bounds.height().coerceAtLeast(dm.heightPixels);
+        val width  = wm.bounds.width().coerceAtLeast(dm.widthPixels);
+        return if (width < height)
+            height
         else
-            dm.widthPixels
+            width
     }
 
     private fun addConfigSettings(sl: ArrayList<SettingsItem>) {

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -44,7 +44,6 @@ import org.citra.citra_emu.utils.BirthdayMonth
 import org.citra.citra_emu.utils.Log
 import org.citra.citra_emu.utils.SystemSaveGame
 import org.citra.citra_emu.utils.ThemeUtil
-import org.citra.citra_emu.utils.EmulationMenuSettings
 
 class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) {
     private var menuTag: String? = null
@@ -111,26 +110,24 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
     }
 
     /** Returns the portrait mode width */
-    private fun getWidth(): Int {
-        val dm = Resources.getSystem().displayMetrics;
-        val wm = settingsActivity.windowManager.maximumWindowMetrics;
-        val height = wm.bounds.height().coerceAtLeast(dm.heightPixels);
-        val width  = wm.bounds.width().coerceAtLeast(dm.widthPixels);
-        return if (width < height)
-            width
-        else
-            height
+    private fun getDimensions(): IntArray {
+        val dm = Resources.getSystem().displayMetrics
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val wm = settingsActivity.windowManager.maximumWindowMetrics
+            val height = wm.bounds.height().coerceAtLeast(dm.heightPixels)
+            val width = wm.bounds.width().coerceAtLeast(dm.widthPixels)
+            intArrayOf(width, height)
+        } else {
+            intArrayOf(dm.widthPixels, dm.heightPixels)
+        }
     }
 
-    private fun getHeight(): Int {
-        val dm = Resources.getSystem().displayMetrics;
-        val wm = settingsActivity.windowManager.maximumWindowMetrics;
-        val height = wm.bounds.height().coerceAtLeast(dm.heightPixels);
-        val width  = wm.bounds.width().coerceAtLeast(dm.widthPixels);
-        return if (width < height)
-            height
-        else
-            width
+    private fun getSmallerDimension(): Int {
+        return getDimensions().min()
+    }
+
+    private fun getLargerDimension(): Int {
+        return getDimensions().max()
     }
 
     private fun addConfigSettings(sl: ArrayList<SettingsItem>) {
@@ -1411,7 +1408,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     R.string.emulation_custom_layout_x,
                     0,
                     0,
-                    getHeight(),
+                    getLargerDimension(),
                     "px",
                     IntSetting.LANDSCAPE_TOP_X.key,
                     IntSetting.LANDSCAPE_TOP_X.defaultValue.toFloat()
@@ -1423,7 +1420,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     R.string.emulation_custom_layout_y,
                     0,
                     0,
-                    getWidth(),
+                    getSmallerDimension(),
                     "px",
                     IntSetting.LANDSCAPE_TOP_Y.key,
                     IntSetting.LANDSCAPE_TOP_Y.defaultValue.toFloat()
@@ -1435,7 +1432,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     R.string.emulation_custom_layout_width,
                     0,
                     0,
-                    getHeight(),
+                    getLargerDimension(),
                     "px",
                     IntSetting.LANDSCAPE_TOP_WIDTH.key,
                     IntSetting.LANDSCAPE_TOP_WIDTH.defaultValue.toFloat()
@@ -1447,7 +1444,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     R.string.emulation_custom_layout_height,
                     0,
                     0,
-                    getWidth(),
+                    getSmallerDimension(),
                     "px",
                     IntSetting.LANDSCAPE_TOP_HEIGHT.key,
                     IntSetting.LANDSCAPE_TOP_HEIGHT.defaultValue.toFloat()
@@ -1460,7 +1457,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     R.string.emulation_custom_layout_x,
                     0,
                     0,
-                    getHeight(),
+                    getLargerDimension(),
                     "px",
                     IntSetting.LANDSCAPE_BOTTOM_X.key,
                     IntSetting.LANDSCAPE_BOTTOM_X.defaultValue.toFloat()
@@ -1472,7 +1469,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     R.string.emulation_custom_layout_y,
                     0,
                     0,
-                    getWidth(),
+                    getSmallerDimension(),
                     "px",
                     IntSetting.LANDSCAPE_BOTTOM_Y.key,
                     IntSetting.LANDSCAPE_BOTTOM_Y.defaultValue.toFloat()
@@ -1484,7 +1481,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     R.string.emulation_custom_layout_width,
                     0,
                     0,
-                    getHeight(),
+                    getLargerDimension(),
                     "px",
                     IntSetting.LANDSCAPE_BOTTOM_WIDTH.key,
                     IntSetting.LANDSCAPE_BOTTOM_WIDTH.defaultValue.toFloat()
@@ -1496,7 +1493,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     R.string.emulation_custom_layout_height,
                     0,
                     0,
-                    getWidth(),
+                    getSmallerDimension(),
                     "px",
                     IntSetting.LANDSCAPE_BOTTOM_HEIGHT.key,
                     IntSetting.LANDSCAPE_BOTTOM_HEIGHT.defaultValue.toFloat()
@@ -1516,7 +1513,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     R.string.emulation_custom_layout_x,
                     0,
                     0,
-                    getWidth(),
+                    getSmallerDimension(),
                     "px",
                     IntSetting.PORTRAIT_TOP_X.key,
                     IntSetting.PORTRAIT_TOP_X.defaultValue.toFloat()
@@ -1528,7 +1525,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     R.string.emulation_custom_layout_y,
                     0,
                     0,
-                    getHeight(),
+                    getLargerDimension(),
                     "px",
                     IntSetting.PORTRAIT_TOP_Y.key,
                     IntSetting.PORTRAIT_TOP_Y.defaultValue.toFloat()
@@ -1540,7 +1537,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     R.string.emulation_custom_layout_width,
                     0,
                     0,
-                    getWidth(),
+                    getSmallerDimension(),
                     "px",
                     IntSetting.PORTRAIT_TOP_WIDTH.key,
                     IntSetting.PORTRAIT_TOP_WIDTH.defaultValue.toFloat()
@@ -1552,7 +1549,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     R.string.emulation_custom_layout_height,
                     0,
                     0,
-                    getHeight(),
+                    getLargerDimension(),
                     "px",
                     IntSetting.PORTRAIT_TOP_HEIGHT.key,
                     IntSetting.PORTRAIT_TOP_HEIGHT.defaultValue.toFloat()
@@ -1565,7 +1562,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     R.string.emulation_custom_layout_x,
                     0,
                     0,
-                    getWidth(),
+                    getSmallerDimension(),
                     "px",
                     IntSetting.PORTRAIT_BOTTOM_X.key,
                     IntSetting.PORTRAIT_BOTTOM_X.defaultValue.toFloat()
@@ -1577,7 +1574,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     R.string.emulation_custom_layout_y,
                     0,
                     0,
-                    getHeight(),
+                    getLargerDimension(),
                     "px",
                     IntSetting.PORTRAIT_BOTTOM_Y.key,
                     IntSetting.PORTRAIT_BOTTOM_Y.defaultValue.toFloat()
@@ -1589,7 +1586,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     R.string.emulation_custom_layout_width,
                     0,
                     0,
-                    getWidth(),
+                    getSmallerDimension(),
                     "px",
                     IntSetting.PORTRAIT_BOTTOM_WIDTH.key,
                     IntSetting.PORTRAIT_BOTTOM_WIDTH.defaultValue.toFloat()
@@ -1601,7 +1598,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     R.string.emulation_custom_layout_height,
                     0,
                     0,
-                    getHeight(),
+                    getLargerDimension(),
                     "px",
                     IntSetting.PORTRAIT_BOTTOM_HEIGHT.key,
                     IntSetting.PORTRAIT_BOTTOM_HEIGHT.defaultValue.toFloat()


### PR DESCRIPTION
This PR updates the code that finds the maximum height/width of the screen (used to set max values for width/height in the Custom Layout slider) to use up-to-date APIs, with a fallback for older devices. In addition to being more up-to-date, it also fixes an issue on some devices where the maximum value doesn't include the status bar / notification bar, even though those will disappear once the game launches.

It also refactors some of the methods to have more clear naming (`getSmallerDimension()` rather than `getWidth()`) 