### PR TITLE
Bug Fix: Apply Opacity Only for Custom Layout

### DIFF
--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -365,6 +365,12 @@ FramebufferLayout CustomFrameLayout(u32 width, u32 height, bool is_swapped, bool
     }
     FramebufferLayout res{
         width, height, true, true, {}, {}, !Settings::values.upright_screen, is_portrait_mode};
+    float opacity_value = Settings::values.custom_second_layer_opacity.GetValue() / 100.0f;
+
+    if (!is_portrait_mode && opacity_value < 1) {
+        is_swapped ? res.top_opacity = opacity_value : res.bottom_opacity = opacity_value;
+    }
+
     const u16 top_x = is_portrait_mode ? Settings::values.custom_portrait_top_x.GetValue()
                                        : Settings::values.custom_top_x.GetValue();
     const u16 top_width = is_portrait_mode ? Settings::values.custom_portrait_top_width.GetValue()

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -35,6 +35,8 @@ struct FramebufferLayout {
     bool is_rotated = true;
     bool is_portrait = false;
     bool additional_screen_enabled;
+    float top_opacity = 1.0f;
+    float bottom_opacity = 1.0f;
     Common::Rectangle<u32> additional_screen;
 
     CardboardSettings cardboard;

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -689,12 +689,12 @@ void RendererOpenGL::DrawScreens(const Layout::FramebufferLayout& layout, bool f
     if (!Settings::values.swap_screen.GetValue()) {
         DrawTopScreen(layout, top_screen);
         glUniform1i(uniform_layer, 0);
-        ApplySecondLayerOpacity(layout.is_portrait);
+        ApplySecondLayerOpacity(layout.bottom_opacity);
         DrawBottomScreen(layout, bottom_screen);
     } else {
         DrawBottomScreen(layout, bottom_screen);
         glUniform1i(uniform_layer, 0);
-        ApplySecondLayerOpacity(layout.is_portrait);
+        ApplySecondLayerOpacity(layout.top_opacity);
         DrawTopScreen(layout, top_screen);
     }
 
@@ -706,29 +706,23 @@ void RendererOpenGL::DrawScreens(const Layout::FramebufferLayout& layout, bool f
             DrawBottomScreen(layout, additional_screen);
         }
     }
-    ResetSecondLayerOpacity(layout.is_portrait);
+    ResetSecondLayerOpacity();
 }
 
-void RendererOpenGL::ApplySecondLayerOpacity(bool isPortrait) {
-    if (Settings::values.layout_option.GetValue() == Settings::LayoutOption::CustomLayout &&
-        Settings::values.custom_second_layer_opacity.GetValue() < 100) {
-        state.blend.src_rgb_func = GL_CONSTANT_ALPHA;
-        state.blend.src_a_func = GL_CONSTANT_ALPHA;
-        state.blend.dst_a_func = GL_ONE_MINUS_CONSTANT_ALPHA;
-        state.blend.dst_rgb_func = GL_ONE_MINUS_CONSTANT_ALPHA;
-        state.blend.color.alpha = Settings::values.custom_second_layer_opacity.GetValue() / 100.0f;
-    }
+void RendererOpenGL::ApplySecondLayerOpacity(float opacity) {
+    state.blend.src_rgb_func = GL_CONSTANT_ALPHA;
+    state.blend.src_a_func = GL_CONSTANT_ALPHA;
+    state.blend.dst_a_func = GL_ONE_MINUS_CONSTANT_ALPHA;
+    state.blend.dst_rgb_func = GL_ONE_MINUS_CONSTANT_ALPHA;
+    state.blend.color.alpha = opacity;
 }
 
-void RendererOpenGL::ResetSecondLayerOpacity(bool isPortrait) {
-    if (Settings::values.layout_option.GetValue() == Settings::LayoutOption::CustomLayout &&
-        Settings::values.custom_second_layer_opacity.GetValue() < 100) {
-        state.blend.src_rgb_func = GL_ONE;
-        state.blend.dst_rgb_func = GL_ZERO;
-        state.blend.src_a_func = GL_ONE;
-        state.blend.dst_a_func = GL_ZERO;
-        state.blend.color.alpha = 0.0f;
-    }
+void RendererOpenGL::ResetSecondLayerOpacity() {
+    state.blend.src_rgb_func = GL_ONE;
+    state.blend.dst_rgb_func = GL_ZERO;
+    state.blend.src_a_func = GL_ONE;
+    state.blend.dst_a_func = GL_ZERO;
+    state.blend.color.alpha = 0.0f;
 }
 
 void RendererOpenGL::DrawTopScreen(const Layout::FramebufferLayout& layout,

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -65,8 +65,8 @@ private:
                                      const Pica::FramebufferConfig& framebuffer,
                                      const Pica::ColorFill& color_fill);
     void DrawScreens(const Layout::FramebufferLayout& layout, bool flipped);
-    void ApplySecondLayerOpacity(bool isPortrait = false);
-    void ResetSecondLayerOpacity(bool isPortrait = false);
+    void ApplySecondLayerOpacity(float opacity = 1.0f);
+    void ResetSecondLayerOpacity();
     void DrawBottomScreen(const Layout::FramebufferLayout& layout,
                           const Common::Rectangle<u32>& bottom_screen);
     void DrawTopScreen(const Layout::FramebufferLayout& layout,

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -885,25 +885,18 @@ void RendererVulkan::DrawScreens(Frame* frame, const Layout::FramebufferLayout& 
     // Apply the initial default opacity value; Needed to avoid flickering
     ApplySecondLayerOpacity(1.0f);
 
-    bool use_custom_opacity =
-        Settings::values.layout_option.GetValue() == Settings::LayoutOption::CustomLayout &&
-        Settings::values.custom_second_layer_opacity.GetValue() < 100;
-    float second_alpha = use_custom_opacity
-                             ? Settings::values.custom_second_layer_opacity.GetValue() / 100.0f
-                             : 1.0f;
-
     if (!Settings::values.swap_screen.GetValue()) {
         DrawTopScreen(layout, top_screen);
         draw_info.layer = 0;
-        if (use_custom_opacity) {
-            ApplySecondLayerOpacity(second_alpha);
+        if (layout.bottom_opacity < 1) {
+            ApplySecondLayerOpacity(layout.bottom_opacity);
         }
         DrawBottomScreen(layout, bottom_screen);
     } else {
         DrawBottomScreen(layout, bottom_screen);
         draw_info.layer = 0;
-        if (use_custom_opacity) {
-            ApplySecondLayerOpacity(second_alpha);
+        if (layout.top_opacity < 1) {
+            ApplySecondLayerOpacity(layout.top_opacity);
         }
         DrawTopScreen(layout, top_screen);
     }


### PR DESCRIPTION
Opacity setting should only apply to the Custom Layout, and only on desktop or android landscape. However, it was also being applied in portrait layouts or the secondary screen in android before.

**Reason**: the logic to detect if opacity should be applied was in the renderers, and polled the settings directly, rather than being specific to the screen being laid out. This PR moves that logic into the framebuffer layout, which has all the needed information to store the opacity correctly, simplifying code in the renderer and unifying the layout information in one place.