### PR TITLE
Split AppImage build into two binaries, one with and one without Wayland support

### DIFF
--- a/.ci/linux.sh
+++ b/.ci/linux.sh
@@ -1,14 +1,16 @@
 #!/bin/bash -ex
 
-if [ "$TARGET" = "appimage" ]; then
+if [[ "$TARGET" == "appimage"* ]]; then
     # Compile the AppImage we distribute with Clang.
     export EXTRA_CMAKE_FLAGS=(-DCMAKE_CXX_COMPILER=clang++
                               -DCMAKE_C_COMPILER=clang
                               -DCMAKE_LINKER=/etc/bin/ld.lld
                               -DENABLE_ROOM_STANDALONE=OFF)
-    # Bundle required QT wayland libraries
-    export EXTRA_QT_PLUGINS="waylandcompositor"
-    export EXTRA_PLATFORM_PLUGINS="libqwayland-egl.so;libqwayland-generic.so"
+    if [ "$TARGET" = "appimage-wayland" ]; then
+        # Bundle required QT wayland libraries
+        export EXTRA_QT_PLUGINS="waylandcompositor"
+        export EXTRA_PLATFORM_PLUGINS="libqwayland-egl.so;libqwayland-generic.so"
+    fi
 else
     # For the linux-fresh verification target, verify compilation without PCH as well.
     export EXTRA_CMAKE_FLAGS=(-DCITRA_USE_PRECOMPILED_HEADERS=OFF)
@@ -30,7 +32,7 @@ cmake .. -G Ninja \
 ninja
 strip -s bin/Release/*
 
-if [ "$TARGET" = "appimage" ]; then
+if [[ "$TARGET" == "appimage"* ]]; then
     ninja bundle
     # TODO: Our AppImage environment currently uses an older ccache version without the verbose flag.
     ccache -s

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ["appimage", "fresh"]
+        target: ["appimage", "appimage-wayland", "fresh"]
     container:
       image: opensauce04/azahar-build-environment:latest
       options: -u 1001
@@ -52,12 +52,16 @@ jobs:
       - name: Build
         run: ./.ci/linux.sh
       - name: Move AppImage to artifacts directory
-        if: ${{ matrix.target == 'appimage' }}
+        if: ${{ contains(matrix.target, 'appimage') }}
         run: |
           mkdir -p artifacts
           mv build/bundle/*.AppImage artifacts/
+      - name: Rename AppImage
+        if: ${{ matrix.target == 'appimage-wayland' }}
+        run: |
+          mv artifacts/azahar.AppImage artifacts/azahar-wayland.AppImage
       - name: Upload
-        if: ${{ matrix.target == 'appimage' }}
+        if: ${{ contains(matrix.target, 'appimage') }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.OS }}-${{ env.TARGET }}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Download the latest release from [Releases](https://github.com/azahar-emu/azahar
 If you are unsure of whether you want to use MSYS2 or MSVC, use MSYS2.
 
 ---
-
 ### MacOS
 
 To download a build that will work on all Macs, you can download the `macos-universal` build on the [Releases](https://github.com/azahar-emu/azahar/releases) page.
@@ -55,6 +54,11 @@ The recommended format for using Azahar on Linux is the Flatpak available on Fla
 
 Azahar is also available as an AppImage on the [Releases](https://github.com/azahar-emu/azahar/releases) page.
 
+If you are unsure of which variant to use, we recommend using the default `azahar.AppImage`. This is because of upstream issues in the Wayland ecosystem which may cause problems when running the emulator (e.g. [#1162](https://github.com/azahar-emu/azahar/issues/1162)).
+
+Unless you explicitly require native Wayland support (e.g. you are running a system with no Xwayland), the non-Wayland variant is recommended.
+
+If you are using the Flatpak and run into issues with Wayland, you can disable Wayland support for the Azahar Flatpak using [Flatseal](https://flathub.org/en/apps/com.github.tchx84.Flatseal).
 
 # Build instructions
 


### PR DESCRIPTION
Workaround for #1162, #1155, and any other Wayland issues.

There are issues with the Wayland ecosystem at the moment which cause Azahar to have strange behaviour, such as the issues above. The first of these issues is an upstream problem in Mutter that we can't really do anything about, and there are other issues we may or may not be able to address on our end as the root cause hasn't yet been determined.

Until we can iron out these Wayland issues, this pull request does two things:

1. It removes Wayland support from our primary `azahar.AppImage`.
2. It adds a new AppImage, `azahar-wayland.AppImage`, which includes Wayland support.

I've also added additional information to the readme to help inform users when deciding on which variant to use. This should be noted in the changelog as well.
