### PR TITLE
core: Temporary workaround for MSVC compiler bug

### DIFF
--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -178,7 +178,7 @@ void ServiceFrameworkBase::ReportUnimplementedFunction(u32* cmd_buf, const Funct
 void ServiceFrameworkBase::HandleSyncRequest(Kernel::HLERequestContext& context) {
     auto itr = handlers.find(context.CommandHeader().command_id.Value());
     const FunctionInfoBase* info = itr == handlers.end() ? nullptr : &itr->second;
-    if (info == nullptr || info->handler_callback == nullptr) {
+    if (info == nullptr || !info->implemented) {
         context.ReportUnimplemented();
         return ReportUnimplementedFunction(context.CommandBuffer(), info);
     }

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -82,6 +82,7 @@ private:
 
     struct FunctionInfoBase {
         u32 command_id;
+        bool implemented;
         HandlerFnP<ServiceFrameworkBase> handler_callback;
         const char* name;
     };
@@ -95,6 +96,8 @@ private:
 
     void RegisterHandlersBase(const FunctionInfoBase* functions, std::size_t n);
     void ReportUnimplementedFunction(u32* cmd_buf, const FunctionInfoBase* info);
+
+    void Empty(Kernel::HLERequestContext& ctx) {}
 
     /// Identifier string used to connect to the service.
     std::string service_name;
@@ -134,9 +137,11 @@ protected:
          */
         constexpr FunctionInfo(u32 command_id, HandlerFnP<Self> handler_callback, const char* name)
             : FunctionInfoBase{
-                  command_id,
+                  command_id, handler_callback != nullptr,
                   // Type-erase member function pointer by casting it down to the base class.
-                  static_cast<HandlerFnP<ServiceFrameworkBase>>(handler_callback), name} {}
+                  handler_callback ? static_cast<HandlerFnP<ServiceFrameworkBase>>(handler_callback)
+                                   : &ServiceFrameworkBase::Empty,
+                  name} {}
     };
 
     /**


### PR DESCRIPTION
This changes the behaviour of `FuntionInfo` struct so that it never sets the `handler_callback` to `nullptr`. Instead it sets the callback to an empty handler and sets a boolean `implemented` to indicate if the handler is implemented or not.

This is a temporary fix intended to bypass a compiler bug introduced in the build tools that come with Visual Studio 2026, and will be reverted once it is fixed.

The compiler bug is tracked in:
https://developercommunity.visualstudio.com/t/Incorrect-struct-array-memory-layout/11011322