### PR TITLE
android: Fix incorrect implementation of FileUtil::Rename

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
@@ -691,6 +691,19 @@ object NativeLibrary {
 
     @Keep
     @JvmStatic
+    fun moveFile(filename: String, sourceDirPath: String, destinationDirPath: String): Boolean =
+        if (FileUtil.isNativePath(sourceDirPath)) {
+            try {
+                CitraApplication.documentsTree.moveFile(filename, sourceDirPath, destinationDirPath)
+            } catch (e: Exception) {
+                false
+            }
+        } else {
+            FileUtil.moveFile(filename, sourceDirPath, destinationDirPath)
+        }
+
+    @Keep
+    @JvmStatic
     fun deleteDocument(path: String): Boolean =
         if (FileUtil.isNativePath(path)) {
             CitraApplication.documentsTree.deleteDocument(path)

--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
@@ -683,6 +683,9 @@ object NativeLibrary {
             try {
                 CitraApplication.documentsTree.renameFile(path, destinationFilename)
             } catch (e: Exception) {
+                if (e.message != null) {
+                    Log.error(e.message!!)
+                }
                 false
             }
         } else {
@@ -696,6 +699,9 @@ object NativeLibrary {
             try {
                 CitraApplication.documentsTree.moveFile(filename, sourceDirPath, destinationDirPath)
             } catch (e: Exception) {
+                if (e.message != null) {
+                    Log.error(e.message!!)
+                }
                 false
             }
         } else {

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/DocumentsTree.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/DocumentsTree.kt
@@ -191,7 +191,7 @@ class DocumentsTree {
     }
 
     @Synchronized
-    fun renameFile(filepath: String, destinationFilename: String?): Boolean {
+    fun renameFile(filepath: String, destinationFilename: String): Boolean {
         val node = resolvePath(filepath) ?: return false
         try {
             val filename = URLDecoder.decode(destinationFilename, FileUtil.DECODE_METHOD)
@@ -200,6 +200,20 @@ class DocumentsTree {
             return true
         } catch (e: Exception) {
             error("[DocumentsTree]: Cannot rename file, error: " + e.message)
+        }
+    }
+
+    @Synchronized
+    fun moveFile(filename: String, sourceDirPath: String, destDirPath: String): Boolean {
+        val sourceFileNode = resolvePath(sourceDirPath + "/" + filename) ?: return false
+        val sourceDirNode = resolvePath(sourceDirPath) ?: return false
+        val destDirNode = resolvePath(destDirPath) ?: return false
+        try {
+            val newUri = DocumentsContract.moveDocument(context.contentResolver, sourceFileNode.uri!!, sourceDirNode.uri!!, destDirNode.uri!!)
+            sourceFileNode.rename(filename, newUri)
+            return true
+        } catch (e: Exception) {
+            error("[DocumentsTree]: Cannot move file, error: " + e.message)
         }
     }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/DocumentsTree.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/DocumentsTree.kt
@@ -192,7 +192,9 @@ class DocumentsTree {
 
     @Synchronized
     fun renameFile(filepath: String, destinationFilename: String): Boolean {
-        val node = resolvePath(filepath) ?: return false
+        val node = resolvePath(filepath) ?: run {
+            error("[DocumentsTree]: Failed to resolve path during rename: $filepath")
+        }
         try {
             val filename = URLDecoder.decode(destinationFilename, FileUtil.DECODE_METHOD)
             val newUri = DocumentsContract.renameDocument(context.contentResolver, node.uri!!, filename)
@@ -205,9 +207,16 @@ class DocumentsTree {
 
     @Synchronized
     fun moveFile(filename: String, sourceDirPath: String, destDirPath: String): Boolean {
-        val sourceFileNode = resolvePath(sourceDirPath + "/" + filename) ?: return false
-        val sourceDirNode = resolvePath(sourceDirPath) ?: return false
-        val destDirNode = resolvePath(destDirPath) ?: return false
+        val resolutionErrorMessage = "[DocumentsTree]: Failed to resolve path during move: "
+        val sourceFileNode = resolvePath(sourceDirPath + "/" + filename) ?: run {
+            error(resolutionErrorMessage + (sourceDirPath + "/" + filename))
+        }
+        val sourceDirNode = resolvePath(sourceDirPath) ?: run {
+            error(resolutionErrorMessage + sourceDirPath)
+        }
+        val destDirNode = resolvePath(destDirPath) ?: run {
+            error(resolutionErrorMessage + destDirPath)
+        }
         try {
             val newUri = DocumentsContract.moveDocument(context.contentResolver, sourceFileNode.uri!!, sourceDirNode.uri!!, destDirNode.uri!!)
             sourceFileNode.rename(filename, newUri)
@@ -229,7 +238,7 @@ class DocumentsTree {
             }
             return true
         } catch (e: Exception) {
-            error("[DocumentsTree]: Cannot rename file, error: " + e.message)
+            error("[DocumentsTree]: Cannot delete file, error: " + e.message)
         }
     }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -11,6 +11,7 @@ import android.net.Uri
 import android.provider.DocumentsContract
 import android.system.Os
 import android.util.Pair
+import androidx.core.net.toUri
 import androidx.documentfile.provider.DocumentFile
 import org.citra.citra_emu.CitraApplication
 import org.citra.citra_emu.model.CheapDocument
@@ -430,6 +431,20 @@ object FileUtil {
             return true
         } catch (e: Exception) {
             Log.error("[FileUtil]: Cannot rename file, error: " + e.message)
+        }
+        return false
+    }
+
+    @JvmStatic
+    fun moveFile(filename: String, sourceDirUriString: String, destDirUriString: String): Boolean {
+        try {
+            val sourceFileUri = ("$sourceDirUriString%2F$filename").toUri()
+            val sourceDirUri = sourceDirUriString.toUri()
+            val destDirUri = destDirUriString.toUri()
+            DocumentsContract.moveDocument(context.contentResolver, sourceFileUri, sourceDirUri, destDirUri)
+            return true
+        } catch (e: Exception) {
+            Log.error("[FileUtil]: Cannot move file, error: " + e.message)
         }
         return false
     }

--- a/src/common/android_storage.h
+++ b/src/common/android_storage.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -24,7 +24,11 @@
        const std::string& destination_filename),                                                   \
       copy_file, "copyFile", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z")          \
     V(RenameFile, bool, (const std::string& source, const std::string& filename), rename_file,     \
-      "renameFile", "(Ljava/lang/String;Ljava/lang/String;)Z")
+      "renameFile", "(Ljava/lang/String;Ljava/lang/String;)Z")                                     \
+    V(MoveFile, bool,                                                                              \
+      (const std::string& filename, const std::string& source_dir_path,                            \
+       const std::string& destination_dir_path),                                                   \
+      move_file, "moveFile", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z")
 #define ANDROID_SINGLE_PATH_DETERMINE_FUNCTIONS(V)                                                 \
     V(IsDirectory, bool, is_directory, CallStaticBooleanMethod, "isDirectory",                     \
       "(Ljava/lang/String;)Z")                                                                     \
@@ -44,6 +48,7 @@ ANDROID_STORAGE_FUNCTIONS(FS)
 #undef F
 #undef FS
 #undef FR
+bool MoveAndRenameFile(const std::string& src_full_path, const std::string& dest_full_path);
 // Reference:
 // https://developer.android.com/reference/android/os/ParcelFileDescriptor#parseMode(java.lang.String)
 enum class AndroidOpenMode {

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -304,20 +304,20 @@ bool DeleteDir(const std::string& filename) {
     return false;
 }
 
-bool Rename(const std::string& srcFilename, const std::string& destFilename) {
-    LOG_TRACE(Common_Filesystem, "{} --> {}", srcFilename, destFilename);
+bool Rename(const std::string& srcFullPath, const std::string& destFullPath) {
+    LOG_TRACE(Common_Filesystem, "{} --> {}", srcFullPath, destFullPath);
 #ifdef _WIN32
-    if (_wrename(Common::UTF8ToUTF16W(srcFilename).c_str(),
-                 Common::UTF8ToUTF16W(destFilename).c_str()) == 0)
+    if (_wrename(Common::UTF8ToUTF16W(srcFullPath).c_str(),
+                 Common::UTF8ToUTF16W(destFullPath).c_str()) == 0)
         return true;
 #elif ANDROID
-    if (AndroidStorage::RenameFile(srcFilename, std::string(GetFilename(destFilename))))
+    if (AndroidStorage::MoveAndRenameFile(srcFullPath, destFullPath))
         return true;
 #else
-    if (rename(srcFilename.c_str(), destFilename.c_str()) == 0)
+    if (rename(srcFullPath.c_str(), destFullPath.c_str()) == 0)
         return true;
 #endif
-    LOG_ERROR(Common_Filesystem, "failed {} --> {}: {}", srcFilename, destFilename,
+    LOG_ERROR(Common_Filesystem, "failed {} --> {}: {}", srcFullPath, destFullPath,
               GetLastErrorMsg());
     return false;
 }

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -136,13 +136,13 @@ bool Delete(const std::string& filename);
 // Deletes a directory filename, returns true on success
 bool DeleteDir(const std::string& filename);
 
-// renames file srcFilename to destFilename, returns true on success
-bool Rename(const std::string& srcFilename, const std::string& destFilename);
+// Renames file srcFullPath to destFullPath, returns true on success
+bool Rename(const std::string& srcFullPath, const std::string& destFullPath);
 
-// copies file srcFilename to destFilename, returns true on success
+// Copies file srcFilename to destFilename, returns true on success
 bool Copy(const std::string& srcFilename, const std::string& destFilename);
 
-// creates an empty file filename, returns true on success
+// Creates an empty file filename, returns true on success
 bool CreateEmptyFile(const std::string& filename);
 
 /**


### PR DESCRIPTION
Currently, on Android, `FileUtil::Rename` only renames a given file, and is incapable of moving files to new locations. Even if it is provided with a full destination path which differs from the source, the source file is simply renamed in the same directory.

This differs from the behaviour on desktop Azahar platforms and on real hardware, where the file is moved in addition to being renamed.

This incorrect functionality affects all 3DS applications which attempt to use `std::rename` or related functions to move a file in addition to/ instead of renaming the file. Notably, this incorrect behaviour results in Nimbus 2.0 from Pretendo failing to install its files correctly.

This problem has existed seemingly since Citra introduced the Android build.