### PR TITLE
android: Begin migration to raw fs access, starting with Rename reimplementation

### DIFF
--- a/src/android/app/src/main/AndroidManifest.xml
+++ b/src/android/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
         android:name="org.citra.citra_emu.CitraApplication"

--- a/src/android/app/src/main/AndroidManifest.xml
+++ b/src/android/app/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 
     <application
         android:name="org.citra.citra_emu.CitraApplication"

--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
@@ -653,7 +653,9 @@ object NativeLibrary {
             val udRemovablePath = RemovableStorageHelper.getRemovableStoragePath(storageIdString)
 
             if (udRemovablePath == null) {
-                error("Unknown mount location for storage device '$storageIdString'")
+                android.util.Log.e("NativeLibrary",
+                    "Unknown mount location for storage device '$storageIdString' (URI: $udUri)"
+                )
             }
             return udRemovablePath + dirSep + udVirtualPath + dirSep
         }

--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
@@ -711,6 +711,11 @@ object NativeLibrary {
 
     @Keep
     @JvmStatic
+    fun updateDocumentLocation(sourcePath: String, destinationPath: String): Boolean =
+        CitraApplication.documentsTree.updateDocumentLocation(sourcePath, destinationPath)
+
+    @Keep
+    @JvmStatic
     fun deleteDocument(path: String): Boolean =
         if (FileUtil.isNativePath(path)) {
             CitraApplication.documentsTree.deleteDocument(path)

--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
@@ -636,12 +636,13 @@ object NativeLibrary {
 
     @Keep
     @JvmStatic
-    fun getUserDirectory(): String {
+    fun getUserDirectory(uriOverride: Uri? = null): String {
         val preferences: SharedPreferences =
             PreferenceManager.getDefaultSharedPreferences(CitraApplication.appContext)
 
         val dirSep = "/"
-        val udUri = preferences.getString("CITRA_DIRECTORY", "")!!.toUri()
+        val udUri = uriOverride ?:
+                    preferences.getString("CITRA_DIRECTORY", "")!!.toUri()
         val udPathSegment = udUri.lastPathSegment!!
         val udVirtualPath = udPathSegment.substringAfter(":")
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
@@ -656,6 +656,7 @@ object NativeLibrary {
                 android.util.Log.e("NativeLibrary",
                     "Unknown mount location for storage device '$storageIdString' (URI: $udUri)"
                 )
+                return ""
             }
             return udRemovablePath + dirSep + udVirtualPath + dirSep
         }

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/CitraDirectoryDialogFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/CitraDirectoryDialogFragment.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -60,7 +60,7 @@ class CitraDirectoryDialogFragment : DialogFragment() {
             }
             .setNegativeButton(android.R.string.cancel) { _: DialogInterface?, _: Int ->
                 if (!PermissionsHandler.hasWriteAccess(requireContext())) {
-                    (requireActivity() as MainActivity)?.openCitraDirectory?.launch(null)
+                    PermissionsHandler.compatibleSelectDirectory((requireActivity() as MainActivity).openCitraDirectory)
                 }
             }
             .show()

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/GrantMissingFilesystemPermissionFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/GrantMissingFilesystemPermissionFragment.kt
@@ -4,6 +4,7 @@
 
 package org.citra.citra_emu.fragments
 
+import android.Manifest
 import android.app.Dialog
 import android.content.DialogInterface
 import android.content.Intent
@@ -37,8 +38,7 @@ class GrantMissingFilesystemPermissionFragment : DialogFragment() {
                     )
                 }
             } else {
-                // TODO: Android <11 support
-                {}
+                { permissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE) }
             }
 
 
@@ -56,6 +56,13 @@ class GrantMissingFilesystemPermissionFragment : DialogFragment() {
     private val manageExternalStoragePermissionLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
             if (Environment.isExternalStorageManager()) {
+                return@registerForActivityResult
+            }
+        }
+
+    private val permissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            if (isGranted) {
                 return@registerForActivityResult
             }
         }

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/GrantMissingFilesystemPermissionFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/GrantMissingFilesystemPermissionFragment.kt
@@ -1,0 +1,53 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+package org.citra.citra_emu.fragments
+
+import android.app.Dialog
+import android.content.DialogInterface
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.os.Environment
+import android.provider.Settings
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.fragment.app.DialogFragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import org.citra.citra_emu.R
+import org.citra.citra_emu.ui.main.MainActivity
+class GrantMissingFilesystemPermissionFragment : DialogFragment() {
+    private lateinit var mainActivity: MainActivity
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        mainActivity = requireActivity() as MainActivity
+
+        isCancelable = false
+
+        return MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.filesystem_permission_warning)
+            .setMessage(R.string.filesystem_permission_lost)
+            .setPositiveButton(android.R.string.ok) { _: DialogInterface, _: Int ->
+                manageExternalStoragePermissionLauncher.launch(Intent(
+                    Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
+                    Uri.fromParts("package", mainActivity.packageName, null)
+                ))
+            }
+            .show()
+    }
+
+    private val manageExternalStoragePermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            if (Environment.isExternalStorageManager()) {
+                return@registerForActivityResult
+            }
+        }
+
+    companion object {
+        const val TAG = "GrantMissingFilesystemPermissionFragment"
+
+        fun newInstance(): GrantMissingFilesystemPermissionFragment {
+            return GrantMissingFilesystemPermissionFragment()
+        }
+    }
+}

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/HomeSettingsFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/HomeSettingsFragment.kt
@@ -159,7 +159,7 @@ class HomeSettingsFragment : Fragment() {
                 R.string.select_citra_user_folder,
                 R.string.select_citra_user_folder_home_description,
                 R.drawable.ic_home,
-                { mainActivity?.openCitraDirectory?.launch(null) },
+                { PermissionsHandler.compatibleSelectDirectory(mainActivity.openCitraDirectory) },
                 details = homeViewModel.userDir
             ),
             HomeSetting(

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/SelectUserDirectoryDialogFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/SelectUserDirectoryDialogFragment.kt
@@ -16,8 +16,11 @@ import org.citra.citra_emu.ui.main.MainActivity
 import org.citra.citra_emu.utils.PermissionsHandler
 import org.citra.citra_emu.viewmodel.HomeViewModel
 
-class SelectUserDirectoryDialogFragment : DialogFragment() {
+class SelectUserDirectoryDialogFragment(titleOverride: Int? = null, descriptionOverride: Int? = null) : DialogFragment() {
     private lateinit var mainActivity: MainActivity
+
+    private val title = titleOverride ?: R.string.select_citra_user_folder
+    private val description = descriptionOverride ?: R.string.selecting_user_directory_without_write_permissions
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         mainActivity = requireActivity() as MainActivity
@@ -25,8 +28,8 @@ class SelectUserDirectoryDialogFragment : DialogFragment() {
         isCancelable = false
 
         return MaterialAlertDialogBuilder(requireContext())
-            .setTitle(R.string.select_citra_user_folder)
-            .setMessage(R.string.selecting_user_directory_without_write_permissions)
+            .setTitle(title)
+            .setMessage(description)
             .setPositiveButton(android.R.string.ok) { _: DialogInterface, _: Int ->
                 PermissionsHandler.compatibleSelectDirectory(mainActivity.openCitraDirectoryLostPermission)
             }
@@ -36,9 +39,10 @@ class SelectUserDirectoryDialogFragment : DialogFragment() {
     companion object {
         const val TAG = "SelectUserDirectoryDialogFragment"
 
-        fun newInstance(activity: FragmentActivity): SelectUserDirectoryDialogFragment {
+        fun newInstance(activity: FragmentActivity, titleOverride: Int? = null, descriptionOverride: Int? = null):
+                SelectUserDirectoryDialogFragment {
             ViewModelProvider(activity)[HomeViewModel::class.java].setPickingUserDir(true)
-            return SelectUserDirectoryDialogFragment()
+            return SelectUserDirectoryDialogFragment(titleOverride, descriptionOverride)
         }
     }
 }

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/SelectUserDirectoryDialogFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/SelectUserDirectoryDialogFragment.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.citra.citra_emu.R
 import org.citra.citra_emu.ui.main.MainActivity
+import org.citra.citra_emu.utils.PermissionsHandler
 import org.citra.citra_emu.viewmodel.HomeViewModel
 
 class SelectUserDirectoryDialogFragment : DialogFragment() {
@@ -27,7 +28,7 @@ class SelectUserDirectoryDialogFragment : DialogFragment() {
             .setTitle(R.string.select_citra_user_folder)
             .setMessage(R.string.selecting_user_directory_without_write_permissions)
             .setPositiveButton(android.R.string.ok) { _: DialogInterface, _: Int ->
-                mainActivity?.openCitraDirectoryLostPermission?.launch(null)
+                PermissionsHandler.compatibleSelectDirectory(mainActivity.openCitraDirectoryLostPermission)
             }
             .show()
     }

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
@@ -164,7 +164,7 @@ class SetupFragment : Fragment() {
                                             )
                                         )
                                     } else {
-                                        // TODO: Android <11 support
+                                        permissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
                                     }
                                 },
                                 buttonState = {
@@ -175,8 +175,15 @@ class SetupFragment : Fragment() {
                                             ButtonState.BUTTON_ACTION_INCOMPLETE
                                         }
                                     } else {
-                                        // TODO: Android <11 support
-                                        ButtonState.BUTTON_ACTION_INCOMPLETE
+                                        if (ContextCompat.checkSelfPermission(
+                                                requireContext(),
+                                                Manifest.permission.WRITE_EXTERNAL_STORAGE
+                                            ) == PackageManager.PERMISSION_GRANTED
+                                        ) {
+                                            ButtonState.BUTTON_ACTION_COMPLETE
+                                        } else {
+                                            ButtonState.BUTTON_ACTION_INCOMPLETE
+                                        }
                                     }
                                 },
                                 isUnskippable = true,
@@ -275,8 +282,10 @@ class SetupFragment : Fragment() {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                         permissionsComplete = (permissionsComplete && Environment.isExternalStorageManager())
                     } else {
-                        // TODO: Android <11 support
-                        permissionsComplete = false
+                        permissionsComplete = (permissionsComplete && ContextCompat.checkSelfPermission(
+                            requireContext(),
+                            Manifest.permission.WRITE_EXTERNAL_STORAGE
+                        ) == PackageManager.PERMISSION_GRANTED)
                     }
 
                     if (permissionsComplete) {
@@ -303,7 +312,7 @@ class SetupFragment : Fragment() {
                                 R.string.select_citra_user_folder_description,
                                 buttonAction = {
                                     pageButtonCallback = it
-                                    openCitraDirectory.launch(null)
+                                    PermissionsHandler.compatibleSelectDirectory(openCitraDirectory)
                                 },
                                 buttonState = {
                                     if (PermissionsHandler.hasWriteAccess(requireContext())) {

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
@@ -5,7 +5,6 @@
 package org.citra.citra_emu.fragments
 
 import android.Manifest
-import android.app.Activity
 import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
@@ -34,6 +33,7 @@ import androidx.viewpager2.widget.ViewPager2.OnPageChangeCallback
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.transition.MaterialFadeThrough
 import org.citra.citra_emu.CitraApplication
+import org.citra.citra_emu.NativeLibrary
 import org.citra.citra_emu.R
 import org.citra.citra_emu.adapters.SetupAdapter
 import org.citra.citra_emu.databinding.FragmentSetupBinding
@@ -554,6 +554,15 @@ class SetupFragment : Fragment() {
         ActivityResultContracts.OpenDocumentTree()
     ) { result: Uri? ->
         if (result == null) {
+            return@registerForActivityResult
+        }
+
+        if (NativeLibrary.getUserDirectory(result) == "") {
+            SelectUserDirectoryDialogFragment.newInstance(
+                mainActivity,
+                R.string.invalid_selection,
+                R.string.invalid_user_directory
+            ).show(mainActivity.supportFragmentManager, SelectUserDirectoryDialogFragment.TAG)
             return@registerForActivityResult
         }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
@@ -18,6 +18,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
@@ -144,32 +145,47 @@ class SetupFragment : Fragment() {
                     false,
                     0,
                     pageButtons = mutableListOf<PageButton>().apply {
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                            add(
-                                PageButton(
-                                    R.drawable.ic_folder,
-                                    R.string.filesystem_permission,
-                                    R.string.filesystem_permission_description,
-                                    buttonAction = {
-                                        pageButtonCallback = it
-                                        manageExternalStoragePermissionLauncher.launch(Intent(
-                                            android.provider.Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
-                                            Uri.fromParts("package", requireActivity().packageName, null)
-                                        ))
-                                    },
-                                    buttonState = {
+                        add(
+                            PageButton(
+                                R.drawable.ic_folder,
+                                R.string.filesystem_permission,
+                                R.string.filesystem_permission_description,
+                                buttonAction = {
+                                    pageButtonCallback = it
+                                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                                        manageExternalStoragePermissionLauncher.launch(
+                                            Intent(
+                                                android.provider.Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
+                                                Uri.fromParts(
+                                                    "package",
+                                                    requireActivity().packageName,
+                                                    null
+                                                )
+                                            )
+                                        )
+                                    } else {
+                                        // TODO: Android <11 support
+                                    }
+                                },
+                                buttonState = {
+                                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                                         if (Environment.isExternalStorageManager()) {
                                             ButtonState.BUTTON_ACTION_COMPLETE
                                         } else {
                                             ButtonState.BUTTON_ACTION_INCOMPLETE
                                         }
-                                    },
-                                    isUnskippable = true,
-                                    hasWarning = true,
-                                    R.string.filesystem_permission_warning,
-                                    R.string.filesystem_permission_warning_description,
-                                )
+                                    } else {
+                                        // TODO: Android <11 support
+                                        ButtonState.BUTTON_ACTION_INCOMPLETE
+                                    }
+                                },
+                                isUnskippable = true,
+                                hasWarning = true,
+                                R.string.filesystem_permission_warning,
+                                R.string.filesystem_permission_warning_description,
                             )
+                        )
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                             add(
                                 PageButton(
                                     R.drawable.ic_notification,
@@ -503,6 +519,7 @@ class SetupFragment : Fragment() {
         }
 
     // We can't use permissionLauncher because MANAGE_EXTERNAL_STORAGE is a special snowflake
+    @RequiresApi(Build.VERSION_CODES.R)
     private val manageExternalStoragePermissionLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
             if (Environment.isExternalStorageManager()) {

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
@@ -152,7 +152,7 @@ class SetupFragment : Fragment() {
                                     R.string.filesystem_permission_description,
                                     buttonAction = {
                                         pageButtonCallback = it
-                                        filesystemPermissionLauncher.launch(Intent(
+                                        manageExternalStoragePermissionLauncher.launch(Intent(
                                             android.provider.Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
                                             Uri.fromParts("package", requireActivity().packageName, null)
                                         ))
@@ -503,7 +503,7 @@ class SetupFragment : Fragment() {
         }
 
     // We can't use permissionLauncher because MANAGE_EXTERNAL_STORAGE is a special snowflake
-    private val filesystemPermissionLauncher =
+    private val manageExternalStoragePermissionLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
             if (Environment.isExternalStorageManager()) {
                 checkForButtonState.invoke()

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
@@ -257,18 +257,29 @@ class SetupFragment : Fragment() {
                         )
                     },
                 ) {
-                    if (
+                    var permissionsComplete =
+                        // Microphone
                         ContextCompat.checkSelfPermission(
                             requireContext(),
                             Manifest.permission.RECORD_AUDIO
                         ) == PackageManager.PERMISSION_GRANTED &&
+                        // Camera
                         ContextCompat.checkSelfPermission(
                             requireContext(),
                             Manifest.permission.CAMERA
                         ) == PackageManager.PERMISSION_GRANTED &&
+                        // Notifications
                         NotificationManagerCompat.from(requireContext())
                             .areNotificationsEnabled()
-                    ) {
+                    // External Storage
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                        permissionsComplete = (permissionsComplete && Environment.isExternalStorageManager())
+                    } else {
+                        // TODO: Android <11 support
+                        permissionsComplete = false
+                    }
+
+                    if (permissionsComplete) {
                         PageState.PAGE_STEPS_COMPLETE
                     } else {
                         PageState.PAGE_STEPS_INCOMPLETE

--- a/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
@@ -4,7 +4,9 @@
 
 package org.citra.citra_emu.ui.main
 
+import android.Manifest
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -205,15 +207,23 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
                 .show(supportFragmentManager,UpdateUserDirectoryDialogFragment.TAG)
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            if (!Environment.isExternalStorageManager() &&
-                supportFragmentManager.findFragmentByTag(GrantMissingFilesystemPermissionFragment.TAG) == null
-            ) {
-                GrantMissingFilesystemPermissionFragment.newInstance()
-                    .show(supportFragmentManager,GrantMissingFilesystemPermissionFragment.TAG)
+        fun requestMissingFilesystemPermission() =
+            GrantMissingFilesystemPermissionFragment.newInstance()
+                .show(supportFragmentManager,GrantMissingFilesystemPermissionFragment.TAG)
+
+        if (supportFragmentManager.findFragmentByTag(GrantMissingFilesystemPermissionFragment.TAG) == null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                if (!Environment.isExternalStorageManager()) {
+                    requestMissingFilesystemPermission()
+                }
+            } else {
+                if (ContextCompat.checkSelfPermission(
+                    this,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE
+                ) != PackageManager.PERMISSION_GRANTED) {
+                    requestMissingFilesystemPermission()
+                }
             }
-        } else {
-            // TODO: Android <11 support
         }
     }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
@@ -6,6 +6,7 @@ package org.citra.citra_emu.ui.main
 
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.os.Environment
 import android.view.View
@@ -204,11 +205,15 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
                 .show(supportFragmentManager,UpdateUserDirectoryDialogFragment.TAG)
         }
 
-        if (!Environment.isExternalStorageManager() &&
-            supportFragmentManager.findFragmentByTag(GrantMissingFilesystemPermissionFragment.TAG) == null
-        ) {
-            GrantMissingFilesystemPermissionFragment.newInstance()
-                .show(supportFragmentManager,GrantMissingFilesystemPermissionFragment.TAG)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            if (!Environment.isExternalStorageManager() &&
+                supportFragmentManager.findFragmentByTag(GrantMissingFilesystemPermissionFragment.TAG) == null
+            ) {
+                GrantMissingFilesystemPermissionFragment.newInstance()
+                    .show(supportFragmentManager,GrantMissingFilesystemPermissionFragment.TAG)
+            }
+        } else {
+            // TODO: Android <11 support
         }
     }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
@@ -6,8 +6,8 @@ package org.citra.citra_emu.ui.main
 
 import android.content.Intent
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
+import android.os.Environment
 import android.view.View
 import android.view.ViewGroup.MarginLayoutParams
 import android.view.WindowManager
@@ -44,6 +44,7 @@ import org.citra.citra_emu.features.settings.model.Settings
 import org.citra.citra_emu.features.settings.model.SettingsViewModel
 import org.citra.citra_emu.features.settings.ui.SettingsActivity
 import org.citra.citra_emu.features.settings.utils.SettingsFile
+import org.citra.citra_emu.fragments.GrantMissingFilesystemPermissionFragment
 import org.citra.citra_emu.fragments.SelectUserDirectoryDialogFragment
 import org.citra.citra_emu.fragments.UpdateUserDirectoryDialogFragment
 import org.citra.citra_emu.utils.CiaInstallWorker
@@ -197,6 +198,13 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
         } else if (!firstTimeSetup && !homeViewModel.isPickingUserDir.value && CitraDirectoryUtils.needToUpdateManually()) {
             UpdateUserDirectoryDialogFragment.newInstance(this)
                 .show(supportFragmentManager,UpdateUserDirectoryDialogFragment.TAG)
+        }
+
+        if (!Environment.isExternalStorageManager() &&
+            supportFragmentManager.findFragmentByTag(GrantMissingFilesystemPermissionFragment.TAG) == null
+        ) {
+            GrantMissingFilesystemPermissionFragment.newInstance()
+                .show(supportFragmentManager,GrantMissingFilesystemPermissionFragment.TAG)
         }
     }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
@@ -11,7 +11,6 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Environment
-import android.util.Log
 import android.view.View
 import android.view.ViewGroup.MarginLayoutParams
 import android.view.WindowManager
@@ -357,6 +356,15 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
     ): ActivityResultLauncher<Uri?> {
         return registerForActivityResult(ActivityResultContracts.OpenDocumentTree()) { result: Uri? ->
             if (result == null) {
+                return@registerForActivityResult
+            }
+
+            if (NativeLibrary.getUserDirectory(result) == "") {
+                SelectUserDirectoryDialogFragment.newInstance(
+                    this,
+                    R.string.invalid_selection,
+                    R.string.invalid_user_directory
+                ).show(supportFragmentManager, SelectUserDirectoryDialogFragment.TAG)
                 return@registerForActivityResult
             }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
@@ -11,6 +11,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Environment
+import android.util.Log
 import android.view.View
 import android.view.ViewGroup.MarginLayoutParams
 import android.view.WindowManager
@@ -40,6 +41,7 @@ import androidx.work.WorkManager
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.navigation.NavigationBarView
 import kotlinx.coroutines.launch
+import org.citra.citra_emu.NativeLibrary
 import org.citra.citra_emu.R
 import org.citra.citra_emu.contracts.OpenFileResultContract
 import org.citra.citra_emu.databinding.ActivityMainBinding
@@ -197,16 +199,6 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
             return
         }
 
-        if (!PermissionsHandler.hasWriteAccess(this) &&
-            !homeViewModel.isPickingUserDir.value
-        ) {
-            SelectUserDirectoryDialogFragment.newInstance(this)
-                .show(supportFragmentManager, SelectUserDirectoryDialogFragment.TAG)
-        } else if (!homeViewModel.isPickingUserDir.value && CitraDirectoryUtils.needToUpdateManually()) {
-            UpdateUserDirectoryDialogFragment.newInstance(this)
-                .show(supportFragmentManager,UpdateUserDirectoryDialogFragment.TAG)
-        }
-
         fun requestMissingFilesystemPermission() =
             GrantMissingFilesystemPermissionFragment.newInstance()
                 .show(supportFragmentManager,GrantMissingFilesystemPermissionFragment.TAG)
@@ -223,6 +215,27 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
                 ) != PackageManager.PERMISSION_GRANTED) {
                     requestMissingFilesystemPermission()
                 }
+            }
+        }
+
+        if (homeViewModel.isPickingUserDir.value) {
+            return
+        }
+
+        if (!PermissionsHandler.hasWriteAccess(this)) {
+            SelectUserDirectoryDialogFragment.newInstance(this)
+                .show(supportFragmentManager, SelectUserDirectoryDialogFragment.TAG)
+            return
+        } else if (CitraDirectoryUtils.needToUpdateManually()) {
+            UpdateUserDirectoryDialogFragment.newInstance(this)
+                .show(supportFragmentManager,UpdateUserDirectoryDialogFragment.TAG)
+            return
+        }
+
+        if (supportFragmentManager.findFragmentByTag(SelectUserDirectoryDialogFragment.TAG) == null) {
+            if (NativeLibrary.getUserDirectory() == "") {
+                SelectUserDirectoryDialogFragment.newInstance(this)
+                    .show(supportFragmentManager, SelectUserDirectoryDialogFragment.TAG)
             }
         }
     }

--- a/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
@@ -190,12 +190,16 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
         val firstTimeSetup = PreferenceManager.getDefaultSharedPreferences(applicationContext)
             .getBoolean(Settings.PREF_FIRST_APP_LAUNCH, true)
 
-        if (!firstTimeSetup && !PermissionsHandler.hasWriteAccess(this) &&
+        if (firstTimeSetup) {
+            return
+        }
+
+        if (!PermissionsHandler.hasWriteAccess(this) &&
             !homeViewModel.isPickingUserDir.value
         ) {
             SelectUserDirectoryDialogFragment.newInstance(this)
                 .show(supportFragmentManager, SelectUserDirectoryDialogFragment.TAG)
-        } else if (!firstTimeSetup && !homeViewModel.isPickingUserDir.value && CitraDirectoryUtils.needToUpdateManually()) {
+        } else if (!homeViewModel.isPickingUserDir.value && CitraDirectoryUtils.needToUpdateManually()) {
             UpdateUserDirectoryDialogFragment.newInstance(this)
                 .show(supportFragmentManager,UpdateUserDirectoryDialogFragment.TAG)
         }

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/DocumentsTree.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/DocumentsTree.kt
@@ -191,19 +191,6 @@ class DocumentsTree {
     }
 
     @Synchronized
-    fun renameFile(filepath: String, destinationFilename: String?): Boolean {
-        val node = resolvePath(filepath) ?: return false
-        try {
-            val filename = URLDecoder.decode(destinationFilename, FileUtil.DECODE_METHOD)
-            val newUri = DocumentsContract.renameDocument(context.contentResolver, node.uri!!, filename)
-            node.rename(filename, newUri)
-            return true
-        } catch (e: Exception) {
-            error("[DocumentsTree]: Cannot rename file, error: " + e.message)
-        }
-    }
-
-    @Synchronized
     fun deleteDocument(filepath: String): Boolean {
         val node = resolvePath(filepath) ?: return false
         try {

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.kt
@@ -423,18 +423,6 @@ object FileUtil {
     }
 
     @JvmStatic
-    fun renameFile(path: String, destinationFilename: String): Boolean {
-        try {
-            val uri = Uri.parse(path)
-            DocumentsContract.renameDocument(context.contentResolver, uri, destinationFilename)
-            return true
-        } catch (e: Exception) {
-            Log.error("[FileUtil]: Cannot rename file, error: " + e.message)
-        }
-        return false
-    }
-
-    @JvmStatic
     fun deleteDocument(path: String): Boolean {
         try {
             val uri = Uri.parse(path)

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/PermissionsHandler.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/PermissionsHandler.kt
@@ -8,6 +8,9 @@ import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import android.net.Uri
+import android.os.Build
+import android.provider.DocumentsContract
+import androidx.activity.result.ActivityResultLauncher
 import androidx.preference.PreferenceManager
 import androidx.documentfile.provider.DocumentFile
 import org.citra.citra_emu.CitraApplication
@@ -48,4 +51,17 @@ object PermissionsHandler {
 
     fun setCitraDirectory(uriString: String?) =
         preferences.edit().putString(CITRA_DIRECTORY, uriString).apply()
+
+    fun compatibleSelectDirectory(activityLauncher: ActivityResultLauncher<Uri?>) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            activityLauncher.launch(null)
+        } else {
+            val initialUri = DocumentsContract.buildRootUri(
+                "com.android.externalstorage.documents",
+                "primary"
+            )
+            activityLauncher.launch(initialUri)
+        }
+
+    }
 }

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/RemovableStorageHelper.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/RemovableStorageHelper.kt
@@ -1,0 +1,24 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+package org.citra.citra_emu.utils
+
+import java.io.File
+
+object RemovableStorageHelper {
+    // This really shouldn't be necessary, but the Android API seemingly
+    // doesn't have a way of doing this?
+    // Apparently, on certain devices the mount location can vary, so add
+    // extra cases here if we discover any new ones.
+    fun getRemovableStoragePath(idString: String): String? {
+        var pathFile: File
+
+        pathFile = File("/mnt/media_rw/$idString");
+        if (pathFile.exists()) {
+            return pathFile.absolutePath
+        }
+
+        return null
+    }
+}

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -76,10 +76,14 @@
     <string name="give_permission">Grant permission</string>
     <string name="notification_warning">Skip granting the notification permission?</string>
     <string name="notification_warning_description">Azahar won\'t be able to notify you of important information.</string>
+    <string name="filesystem_permission_warning">Missing Permissions</string>
+    <string name="filesystem_permission_warning_description">Azahar requires permission to manage files on this device in order to store and manage its data.\n\nPlease grant the \"Filesystem\" permission before continuing.</string>
     <string name="camera_permission">Camera</string>
     <string name="camera_permission_description">Grant the camera permission below to emulate the 3DS camera.</string>
     <string name="microphone_permission">Microphone</string>
     <string name="microphone_permission_description">Grant the microphone permission below to emulate the 3DS microphone.</string>
+    <string name="filesystem_permission">Filesystem</string>
+    <string name="filesystem_permission_description">Grant the filesystem permission below to allow Azahar to store files.</string>
     <string name="permission_denied">Permission denied</string>
     <string name="add_games_warning">Skip selecting applications folder?</string>
     <string name="add_games_warning_description">Software won\'t be displayed in the Applications list if a folder isn\'t selected.</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -104,6 +104,7 @@
     <string name="cannot_skip">You can\'t skip setting up the user folder</string>
     <string name="cannot_skip_directory_description">This step is required to allow Azahar to work. Please select a directory and then you can continue.</string>
     <string name="selecting_user_directory_without_write_permissions">You have lost write permissions on your <a href="https://web.archive.org/web/20240304193549/https://github.com/citra-emu/citra/wiki/Citra-Android-user-data-and-storage">user data</a> directory, where saves and other information are stored. This can happen after some app or Android updates. Please re-select the directory to regain permissions so you can continue.</string>
+    <string name="filesystem_permission_lost">Azahar has lost permission to manage files on this device. This can happen after some app or Android updates. Please re-grant this permission on the next screen to continue using the app.</string>
     <string name="cannot_skip_directory_help" translatable="false">https://web.archive.org/web/20240304193549/https://github.com/citra-emu/citra/wiki/Citra-Android-user-data-and-storage</string>
     <string name="set_up_theme_settings">Theme Settings</string>
     <string name="setup_theme_settings_description">Configure your theme preferences for Azahar.</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -104,6 +104,8 @@
     <string name="cannot_skip">You can\'t skip setting up the user folder</string>
     <string name="cannot_skip_directory_description">This step is required to allow Azahar to work. Please select a directory and then you can continue.</string>
     <string name="selecting_user_directory_without_write_permissions">You have lost write permissions on your <a href="https://web.archive.org/web/20240304193549/https://github.com/citra-emu/citra/wiki/Citra-Android-user-data-and-storage">user data</a> directory, where saves and other information are stored. This can happen after some app or Android updates. Please re-select the directory to regain permissions so you can continue.</string>
+    <string name="invalid_selection">Invalid Selection</string>
+    <string name="invalid_user_directory">The user directory selection was invalid.\nPlease re-select the user directory, ensuring that you navigate to it from the root of your device\'s storage.</string>
     <string name="filesystem_permission_lost">Azahar has lost permission to manage files on this device. This can happen after some app or Android updates. Please re-grant this permission on the next screen to continue using the app.</string>
     <string name="cannot_skip_directory_help" translatable="false">https://web.archive.org/web/20240304193549/https://github.com/citra-emu/citra/wiki/Citra-Android-user-data-and-storage</string>
     <string name="set_up_theme_settings">Theme Settings</string>

--- a/src/common/android_storage.cpp
+++ b/src/common/android_storage.cpp
@@ -156,7 +156,7 @@ std::optional<std::string> GetUserDirectory() {
             "Unable to locate user directory: Function with ID 'get_user_directory' is missing");
     auto env = GetEnvForThread();
     auto j_user_directory =
-        (jstring)(env->CallStaticObjectMethod(native_library, get_user_directory));
+        (jstring)(env->CallStaticObjectMethod(native_library, get_user_directory, nullptr));
     auto result = env->GetStringUTFChars(j_user_directory, nullptr);
     if (result == "") {
         return std::nullopt;

--- a/src/common/android_storage.cpp
+++ b/src/common/android_storage.cpp
@@ -150,14 +150,18 @@ std::vector<std::string> GetFilesName(const std::string& filepath) {
     return vector;
 }
 
-std::string GetUserDirectory() {
+std::optional<std::string> GetUserDirectory() {
     if (get_user_directory == nullptr)
         throw std::runtime_error(
             "Unable to locate user directory: Function with ID 'get_user_directory' is missing");
     auto env = GetEnvForThread();
     auto j_user_directory =
         (jstring)(env->CallStaticObjectMethod(native_library, get_user_directory));
-    return env->GetStringUTFChars(j_user_directory, nullptr);
+    auto result = env->GetStringUTFChars(j_user_directory, nullptr);
+    if (result == "") {
+        return std::nullopt;
+    }
+    return result;
 }
 
 bool CopyFile(const std::string& source, const std::string& destination_path,

--- a/src/common/android_storage.cpp
+++ b/src/common/android_storage.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -152,9 +152,11 @@ std::vector<std::string> GetFilesName(const std::string& filepath) {
 
 std::string GetUserDirectory() {
     if (get_user_directory == nullptr)
-        throw std::runtime_error("Unable to locate user directory: Function with ID 'get_user_directory' is missing");
+        throw std::runtime_error(
+            "Unable to locate user directory: Function with ID 'get_user_directory' is missing");
     auto env = GetEnvForThread();
-    auto j_user_directory = (jstring)(env->CallStaticObjectMethod(native_library, get_user_directory));
+    auto j_user_directory =
+        (jstring)(env->CallStaticObjectMethod(native_library, get_user_directory));
     return env->GetStringUTFChars(j_user_directory, nullptr);
 }
 

--- a/src/common/android_storage.cpp
+++ b/src/common/android_storage.cpp
@@ -172,6 +172,16 @@ bool CopyFile(const std::string& source, const std::string& destination_path,
                                         j_destination_path, j_destination_filename);
 }
 
+bool UpdateDocumentLocation(const std::string& source_path, const std::string& destination_path) {
+    if (update_document_location == nullptr)
+        return false;
+    auto env = GetEnvForThread();
+    jstring j_source_path = env->NewStringUTF(source_path.c_str());
+    jstring j_destination_path = env->NewStringUTF(destination_path.c_str());
+    return env->CallStaticBooleanMethod(native_library, update_document_location, j_source_path,
+                                        j_destination_path);
+}
+
 #define FR(FunctionName, ReturnValue, JMethodID, Caller, JMethodName, Signature)                   \
     F(FunctionName, ReturnValue, JMethodID, Caller)
 #define F(FunctionName, ReturnValue, JMethodID, Caller)                                            \

--- a/src/common/android_storage.cpp
+++ b/src/common/android_storage.cpp
@@ -150,6 +150,14 @@ std::vector<std::string> GetFilesName(const std::string& filepath) {
     return vector;
 }
 
+std::string GetUserDirectory() {
+    if (get_user_directory == nullptr)
+        throw std::runtime_error("Unable to locate user directory: Function with ID 'get_user_directory' is missing");
+    auto env = GetEnvForThread();
+    auto j_user_directory = (jstring)(env->CallStaticObjectMethod(native_library, get_user_directory));
+    return env->GetStringUTFChars(j_user_directory, nullptr);
+}
+
 bool CopyFile(const std::string& source, const std::string& destination_path,
               const std::string& destination_filename) {
     if (copy_file == nullptr)
@@ -160,16 +168,6 @@ bool CopyFile(const std::string& source, const std::string& destination_path,
     jstring j_destination_filename = env->NewStringUTF(destination_filename.c_str());
     return env->CallStaticBooleanMethod(native_library, copy_file, j_source_path,
                                         j_destination_path, j_destination_filename);
-}
-
-bool RenameFile(const std::string& source, const std::string& filename) {
-    if (rename_file == nullptr)
-        return false;
-    auto env = GetEnvForThread();
-    jstring j_source_path = env->NewStringUTF(source.c_str());
-    jstring j_destination_path = env->NewStringUTF(filename.c_str());
-    return env->CallStaticBooleanMethod(native_library, rename_file, j_source_path,
-                                        j_destination_path);
 }
 
 #define FR(FunctionName, ReturnValue, JMethodID, Caller, JMethodName, Signature)                   \

--- a/src/common/android_storage.h
+++ b/src/common/android_storage.h
@@ -19,12 +19,12 @@
       open_content_uri, "openContentUri", "(Ljava/lang/String;Ljava/lang/String;)I")               \
     V(GetFilesName, std::vector<std::string>, (const std::string& filepath), get_files_name,       \
       "getFilesName", "(Ljava/lang/String;)[Ljava/lang/String;")                                   \
+    V(GetUserDirectory, std::string, (), get_user_directory, "getUserDirectory",                   \
+      "()Ljava/lang/String;")                                                                          \
     V(CopyFile, bool,                                                                              \
       (const std::string& source, const std::string& destination_path,                             \
        const std::string& destination_filename),                                                   \
-      copy_file, "copyFile", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z")          \
-    V(RenameFile, bool, (const std::string& source, const std::string& filename), rename_file,     \
-      "renameFile", "(Ljava/lang/String;Ljava/lang/String;)Z")
+      copy_file, "copyFile", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z")
 #define ANDROID_SINGLE_PATH_DETERMINE_FUNCTIONS(V)                                                 \
     V(IsDirectory, bool, is_directory, CallStaticBooleanMethod, "isDirectory",                     \
       "(Ljava/lang/String;)Z")                                                                     \

--- a/src/common/android_storage.h
+++ b/src/common/android_storage.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -20,7 +20,7 @@
     V(GetFilesName, std::vector<std::string>, (const std::string& filepath), get_files_name,       \
       "getFilesName", "(Ljava/lang/String;)[Ljava/lang/String;")                                   \
     V(GetUserDirectory, std::string, (), get_user_directory, "getUserDirectory",                   \
-      "()Ljava/lang/String;")                                                                          \
+      "()Ljava/lang/String;")                                                                      \
     V(CopyFile, bool,                                                                              \
       (const std::string& source, const std::string& destination_path,                             \
        const std::string& destination_filename),                                                   \

--- a/src/common/android_storage.h
+++ b/src/common/android_storage.h
@@ -19,7 +19,7 @@
       open_content_uri, "openContentUri", "(Ljava/lang/String;Ljava/lang/String;)I")               \
     V(GetFilesName, std::vector<std::string>, (const std::string& filepath), get_files_name,       \
       "getFilesName", "(Ljava/lang/String;)[Ljava/lang/String;")                                   \
-    V(GetUserDirectory, std::string, (), get_user_directory, "getUserDirectory",                   \
+    V(GetUserDirectory, std::optional<std::string>, (), get_user_directory, "getUserDirectory",    \
       "()Ljava/lang/String;")                                                                      \
     V(CopyFile, bool,                                                                              \
       (const std::string& source, const std::string& destination_path,                             \

--- a/src/common/android_storage.h
+++ b/src/common/android_storage.h
@@ -20,7 +20,7 @@
     V(GetFilesName, std::vector<std::string>, (const std::string& filepath), get_files_name,       \
       "getFilesName", "(Ljava/lang/String;)[Ljava/lang/String;")                                   \
     V(GetUserDirectory, std::optional<std::string>, (), get_user_directory, "getUserDirectory",    \
-      "()Ljava/lang/String;")                                                                      \
+      "(Landroid/net/Uri;)Ljava/lang/String;")                                                     \
     V(CopyFile, bool,                                                                              \
       (const std::string& source, const std::string& destination_path,                             \
        const std::string& destination_filename),                                                   \

--- a/src/common/android_storage.h
+++ b/src/common/android_storage.h
@@ -24,7 +24,11 @@
     V(CopyFile, bool,                                                                              \
       (const std::string& source, const std::string& destination_path,                             \
        const std::string& destination_filename),                                                   \
-      copy_file, "copyFile", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z")
+      copy_file, "copyFile", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z")          \
+    V(UpdateDocumentLocation, bool,                                                                \
+      (const std::string& source_path, const std::string& destination_path),                       \
+      update_document_location, "updateDocumentLocation",                                          \
+      "(Ljava/lang/String;Ljava/lang/String;)Z")
 #define ANDROID_SINGLE_PATH_DETERMINE_FUNCTIONS(V)                                                 \
     V(IsDirectory, bool, is_directory, CallStaticBooleanMethod, "isDirectory",                     \
       "(Ljava/lang/String;)Z")                                                                     \

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -311,9 +311,9 @@ bool Rename(const std::string& srcFilename, const std::string& destFilename) {
                  Common::UTF8ToUTF16W(destFilename).c_str()) == 0)
         return true;
 #elif ANDROID
-    const std::string userDirLocation = AndroidStorage::GetUserDirectory();
-    if (rename((userDirLocation + srcFilename).c_str(), (userDirLocation + destFilename).c_str()) ==
-        0) {
+    std::optional<std::string> userDirLocation = AndroidStorage::GetUserDirectory();
+    if (userDirLocation && rename((*userDirLocation + srcFilename).c_str(),
+                                  (*userDirLocation + destFilename).c_str()) == 0) {
         AndroidStorage::UpdateDocumentLocation(srcFilename, destFilename);
         // ^ TODO: This shouldn't fail, but what should we do if it somehow does?
         return true;

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -313,8 +313,11 @@ bool Rename(const std::string& srcFilename, const std::string& destFilename) {
 #elif ANDROID
     const std::string userDirLocation = AndroidStorage::GetUserDirectory();
     if (rename((userDirLocation + srcFilename).c_str(), (userDirLocation + destFilename).c_str()) ==
-        0)
+        0) {
+        AndroidStorage::UpdateDocumentLocation(srcFilename, destFilename);
+        // ^ TODO: This shouldn't fail, but what should we do if it somehow does?
         return true;
+    }
 #else
     if (rename(srcFilename.c_str(), destFilename.c_str()) == 0)
         return true;

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -312,8 +312,8 @@ bool Rename(const std::string& srcFilename, const std::string& destFilename) {
         return true;
 #elif ANDROID
     const std::string userDirLocation = AndroidStorage::GetUserDirectory();
-    if (rename((userDirLocation + srcFilename).c_str(),
-               (userDirLocation + destFilename).c_str()) == 0)
+    if (rename((userDirLocation + srcFilename).c_str(), (userDirLocation + destFilename).c_str()) ==
+        0)
         return true;
 #else
     if (rename(srcFilename.c_str(), destFilename.c_str()) == 0)

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -311,7 +311,9 @@ bool Rename(const std::string& srcFilename, const std::string& destFilename) {
                  Common::UTF8ToUTF16W(destFilename).c_str()) == 0)
         return true;
 #elif ANDROID
-    if (AndroidStorage::RenameFile(srcFilename, std::string(GetFilename(destFilename))))
+    const std::string userDirLocation = AndroidStorage::GetUserDirectory();
+    if (rename((userDirLocation + srcFilename).c_str(),
+               (userDirLocation + destFilename).c_str()) == 0)
         return true;
 #else
     if (rename(srcFilename.c_str(), destFilename.c_str()) == 0)


### PR DESCRIPTION
This PR marks a shift in how we plan on handling file I/O in the Android build of Azahar. Because of the reasons listed below, we have collectively decided to move away from the current SAF implementation, and move to accessing files directly via the `MANAGE_EXTERNAL_STORAGE` permission:

1. The SAF API very slow, and this is noticeable within the emulator, often resulting in slow load times in various areas of the app.
2. The SAF API has no reliable or clean way of implementing a Rename function which moves *and* renames a file at the same time. The current implementation is incorrect, not moving files at all, and the solution would result in ugly code and even slower FS access.
3. Direct filesystem access makes managing file I/O significantly more simple code-wise, allowing us for the most part to just re-use or slightly alter code we've already written for Linux.

This pull request is a work in progress. The following are still to-do:

- [x] Handle cases where a user has their data directory located on a non-primary storage medium, such as an SD card or USB media device.
- [x] Alert users if their user directory cannot be located as a native path, and request that they re-select it.
- [x] Detect if Azahar has lost access to the `MANAGE_EXTERNAL_STORAGE` permission, and re-request it.
- [x] Support Android <11
- [x] Detect if a user selects an invalid user directory, and prompt a re-selection