### PR TITLE
macos: Fixed real camera not activating during emulation

### DIFF
--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -287,7 +287,9 @@ if (NOT WIN32)
     endif()
 endif()
 
-if (UNIX AND NOT APPLE)
+if (APPLE)
+    target_link_libraries(citra_qt PRIVATE Qt6::QDarwinCameraPermissionPlugin)
+elseif (UNIX)
     target_link_libraries(citra_qt PRIVATE Qt6::DBus gamemode)
 endif()
 

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -115,6 +115,7 @@
 
 #ifdef __APPLE__
 #include "common/apple_authorization.h"
+Q_IMPORT_PLUGIN(QDarwinCameraPermissionPlugin);
 #endif
 
 #ifdef USE_DISCORD_PRESENCE


### PR DESCRIPTION
Previously, the camera would display a green output when attempting to use a real camera. This was due to a plugin which is required for handling camera permissions being missing. After linking the required plugin using CMake and importing it using `Q_IMPORT_PLUGIN`, video output works as expected.

Before:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/01f59caa-8361-4f4a-8db8-feb9d23e42e7" />

After:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/29732b93-deb9-4781-a32a-a02ce129f9c7" />
