### PR TITLE
audio_core: Move DSP memory ownership and update teakra

### DIFF
--- a/src/audio_core/dsp_interface.cpp
+++ b/src/audio_core/dsp_interface.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/audio_core/dsp_interface.h
+++ b/src/audio_core/dsp_interface.h
@@ -1,4 +1,4 @@
-// Copyright 2017 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/audio_core/dsp_interface.h
+++ b/src/audio_core/dsp_interface.h
@@ -86,9 +86,6 @@ public:
      */
     virtual void PipeWrite(DspPipe pipe_number, std::span<const u8> buffer) = 0;
 
-    /// Returns a reference to the array backing DSP memory
-    virtual std::array<u8, Memory::DSP_RAM_SIZE>& GetDspMemory() = 0;
-
     /// Sets the handler for the interrupts we trigger
     virtual void SetInterruptHandler(
         std::function<void(Service::DSP::InterruptType type, DspPipe pipe)> handler) = 0;

--- a/src/audio_core/hle/hle.cpp
+++ b/src/audio_core/hle/hle.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -113,7 +113,7 @@ private:
 
 DspHle::Impl::Impl(DspHle& parent_, Memory::MemorySystem& memory, Core::Timing& timing)
     : parent(parent_), core_timing(timing) {
-    dsp_memory = reinterpret_cast<HLE::DspMemory*>(memory.GetDspMemory().data());
+    dsp_memory = reinterpret_cast<HLE::DspMemory*>(memory.GetDspMemory(0));
     dsp_memory->raw_memory.fill(0);
 
     for (auto& source : sources) {

--- a/src/audio_core/hle/hle.h
+++ b/src/audio_core/hle/hle.h
@@ -1,4 +1,4 @@
-// Copyright 2017 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/audio_core/hle/hle.h
+++ b/src/audio_core/hle/hle.h
@@ -37,8 +37,6 @@ public:
     std::size_t GetPipeReadableSize(DspPipe pipe_number) const override;
     void PipeWrite(DspPipe pipe_number, std::span<const u8> buffer) override;
 
-    std::array<u8, Memory::DSP_RAM_SIZE>& GetDspMemory() override;
-
     void SetInterruptHandler(
         std::function<void(Service::DSP::InterruptType type, DspPipe pipe)> handler) override;
 

--- a/src/audio_core/lle/lle.cpp
+++ b/src/audio_core/lle/lle.cpp
@@ -403,10 +403,6 @@ void DspLle::PipeWrite(DspPipe pipe_number, std::span<const u8> buffer) {
     impl->WritePipe(static_cast<u8>(pipe_number), buffer);
 }
 
-std::array<u8, Memory::DSP_RAM_SIZE>& DspLle::GetDspMemory() {
-    return impl->teakra.GetDspMemory();
-}
-
 void DspLle::SetInterruptHandler(
     std::function<void(Service::DSP::InterruptType type, DspPipe pipe)> handler) {
     impl->teakra.SetRecvDataHandler(0, [this, handler]() {

--- a/src/audio_core/lle/lle.cpp
+++ b/src/audio_core/lle/lle.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -121,7 +121,9 @@ static u8 PipeIndexToSlotIndex(u8 pipe_index, PipeDirection direction) {
 }
 
 struct DspLle::Impl final {
-    Impl(Core::Timing& timing, bool multithread) : core_timing(timing), multithread(multithread) {
+    Impl(Core::Timing& timing, Memory::MemorySystem& memory, bool multithread)
+        : teakra(Teakra::UserConfig{.dsp_memory = memory.GetDspMemory(0)}), core_timing(timing),
+          multithread(multithread) {
         teakra_slice_event = core_timing.RegisterEvent(
             "DSP slice", [this](u64, int late) { TeakraSliceEvent(static_cast<u64>(late)); });
     }
@@ -189,12 +191,12 @@ struct DspLle::Impl final {
     }
 
     u8* GetDspDataPointer(u32 baddr) {
-        auto& memory = teakra.GetDspMemory();
+        uint8_t* memory = teakra.GetDspMemory();
         return &memory[DspDataOffset + baddr];
     }
 
     const u8* GetDspDataPointer(u32 baddr) const {
-        auto& memory = teakra.GetDspMemory();
+        const uint8_t* memory = teakra.GetDspMemory();
         return &memory[DspDataOffset + baddr];
     }
 
@@ -312,9 +314,9 @@ struct DspLle::Impl final {
         teakra.Reset();
 
         Dsp1 dsp(buffer);
-        auto& dsp_memory = teakra.GetDspMemory();
-        u8* program = dsp_memory.data();
-        u8* data = dsp_memory.data() + DspDataOffset;
+        auto dsp_memory = teakra.GetDspMemory();
+        u8* program = dsp_memory;
+        u8* data = dsp_memory + DspDataOffset;
         for (const auto& segment : dsp.segments) {
             if (segment.memory_type == SegmentType::ProgramA ||
                 segment.memory_type == SegmentType::ProgramB) {
@@ -465,7 +467,7 @@ DspLle::DspLle(Core::System& system, bool multithread)
 
 DspLle::DspLle(Core::System& system, Memory::MemorySystem& memory, Core::Timing& timing,
                bool multithread)
-    : DspInterface(system), impl(std::make_unique<Impl>(timing, multithread)) {
+    : DspInterface(system), impl(std::make_unique<Impl>(timing, memory, multithread)) {
     Teakra::AHBMCallback ahbm;
     ahbm.read8 = [&memory](u32 address) -> u8 {
         return *memory.GetFCRAMPointer(address - Memory::FCRAM_PADDR);

--- a/src/audio_core/lle/lle.h
+++ b/src/audio_core/lle/lle.h
@@ -1,4 +1,4 @@
-// Copyright 2018 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/audio_core/lle/lle.h
+++ b/src/audio_core/lle/lle.h
@@ -31,8 +31,6 @@ public:
     std::size_t GetPipeReadableSize(DspPipe pipe_number) const override;
     void PipeWrite(DspPipe pipe_number, std::span<const u8> buffer) override;
 
-    std::array<u8, Memory::DSP_RAM_SIZE>& GetDspMemory() override;
-
     void SetInterruptHandler(
         std::function<void(Service::DSP::InterruptType type, DspPipe pipe)> handler) override;
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -496,8 +496,6 @@ System::ResultStatus System::Init(Frontend::EmuWindow& emu_window,
         dsp_core = std::make_unique<AudioCore::DspLle>(*this, multithread);
     }
 
-    memory->SetDSP(*dsp_core);
-
     dsp_core->SetSink(Settings::values.output_type.GetValue(),
                       Settings::values.output_device.GetValue());
     dsp_core->EnableStretching(Settings::values.enable_audio_stretching.GetValue());
@@ -819,7 +817,6 @@ void System::serialize(Archive& ar, const unsigned int file_version) {
         u32 cheats_pid;
         ar & cheats_pid;
         timing->UnlockEventQueue();
-        memory->SetDSP(*dsp_core);
         cheat_engine.Connect(cheats_pid);
 
         // Re-register gpu callback, because gsp service changed after service_manager got

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -989,8 +989,9 @@ MemoryRef MemorySystem::GetFCRAMRef(std::size_t offset) const {
     return MemoryRef(impl->fcram_mem, offset);
 }
 
-std::span<u8, DSP_RAM_SIZE> MemorySystem::GetDspMemory() const {
-    return std::span<u8, DSP_RAM_SIZE>{impl->dsp_ram.get(), DSP_RAM_SIZE};
+u8* MemorySystem::GetDspMemory(std::size_t offset) const {
+    ASSERT(offset <= Memory::DSP_RAM_SIZE);
+    return impl->dsp_ram.get() + offset;
 }
 
 } // namespace Memory

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -641,7 +641,7 @@ public:
     /// Unregisters page table for rasterizer cache marking
     void UnregisterPageTable(std::shared_ptr<PageTable> page_table);
 
-    void SetDSP(AudioCore::DspInterface& dsp);
+    std::span<u8, DSP_RAM_SIZE> GetDspMemory() const;
 
     void RasterizerFlushVirtualRegion(VAddr start, u32 size, FlushMode mode);
 

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -641,7 +641,8 @@ public:
     /// Unregisters page table for rasterizer cache marking
     void UnregisterPageTable(std::shared_ptr<PageTable> page_table);
 
-    std::span<u8, DSP_RAM_SIZE> GetDspMemory() const;
+    /// Gets pointer to DSP shared memory with given offset
+    u8* GetDspMemory(std::size_t offset) const;
 
     void RasterizerFlushVirtualRegion(VAddr start, u32 size, FlushMode mode);
 

--- a/src/tests/audio_core/merryhime_3ds_audio/merry_audio/service_fixture.cpp
+++ b/src/tests/audio_core/merryhime_3ds_audio/merry_audio/service_fixture.cpp
@@ -1,3 +1,7 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
 #include "audio_core/hle/hle.h"
 #include "audio_core/lle/lle.h"
 #include "common/settings.h"
@@ -85,8 +89,7 @@ Result ServiceFixture::DSP_ReadPipeIfPossible(u32 channel, u32 /*peer*/, void* o
 Result ServiceFixture::ServiceFixture::DSP_ConvertProcessAddressFromDspDram(u32 dsp_address,
                                                                             u16** host_address) {
     *host_address = reinterpret_cast<u16*>(
-        (dsp_address << 1) +
-        (reinterpret_cast<uintptr_t>(memory.GetDspMemory().data()) + 0x40000u));
+        (dsp_address << 1) + (reinterpret_cast<uintptr_t>(memory.GetDspMemory(0)) + 0x40000u));
     return ResultSuccess;
 }
 

--- a/src/tests/audio_core/merryhime_3ds_audio/merry_audio/service_fixture.cpp
+++ b/src/tests/audio_core/merryhime_3ds_audio/merry_audio/service_fixture.cpp
@@ -85,7 +85,8 @@ Result ServiceFixture::DSP_ReadPipeIfPossible(u32 channel, u32 /*peer*/, void* o
 Result ServiceFixture::ServiceFixture::DSP_ConvertProcessAddressFromDspDram(u32 dsp_address,
                                                                             u16** host_address) {
     *host_address = reinterpret_cast<u16*>(
-        (dsp_address << 1) + (reinterpret_cast<uintptr_t>(dsp->GetDspMemory().data()) + 0x40000u));
+        (dsp_address << 1) +
+        (reinterpret_cast<uintptr_t>(memory.GetDspMemory().data()) + 0x40000u));
     return ResultSuccess;
 }
 


### PR DESCRIPTION
Previously, the HLE and LLE dsp modules had their own DSP shared memory RAM. This PR moves the shared memory RAM to the memory subsystem, so that it is centralized.

This PR does not have any effect on perceived emulation, but it is needed in case a JIT is added to teakra eventually for faster LLE emulation.