### PR TITLE
audio_core: Add DSP sleep and wakeup functionality

### DIFF
--- a/src/audio_core/hle/aac_decoder.cpp
+++ b/src/audio_core/hle/aac_decoder.cpp
@@ -8,7 +8,7 @@
 namespace AudioCore::HLE {
 
 AACDecoder::AACDecoder(Memory::MemorySystem& memory) : memory(memory) {
-    OpenNewDecoder();
+    Reset();
 }
 
 AACDecoder::~AACDecoder() {
@@ -61,6 +61,10 @@ BinaryMessage AACDecoder::ProcessRequest(const BinaryMessage& request) {
                 },
         };
     }
+}
+
+void AACDecoder::Reset() {
+    OpenNewDecoder();
 }
 
 BinaryMessage AACDecoder::Decode(const BinaryMessage& request) {

--- a/src/audio_core/hle/aac_decoder.h
+++ b/src/audio_core/hle/aac_decoder.h
@@ -16,6 +16,8 @@ public:
     ~AACDecoder() override;
     BinaryMessage ProcessRequest(const BinaryMessage& request) override;
 
+    void Reset() override;
+
 private:
     BinaryMessage Decode(const BinaryMessage& request);
     bool OpenNewDecoder();

--- a/src/audio_core/hle/decoder.h
+++ b/src/audio_core/hle/decoder.h
@@ -1,4 +1,4 @@
-// Copyright 2018 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -137,6 +137,8 @@ class DecoderBase {
 public:
     virtual ~DecoderBase() = default;
     virtual BinaryMessage ProcessRequest(const BinaryMessage& request) = 0;
+
+    virtual void Reset() = 0;
 };
 
 } // namespace AudioCore::HLE

--- a/src/audio_core/hle/mixers.cpp
+++ b/src/audio_core/hle/mixers.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -13,6 +13,18 @@ namespace AudioCore::HLE {
 void Mixers::Reset() {
     current_frame.fill({});
     state = {};
+}
+
+void Mixers::Sleep() {
+    backup_state = state;
+    backup_frame = current_frame;
+}
+
+void Mixers::Wakeup() {
+    state = backup_state;
+    current_frame = backup_frame;
+    backup_state = {};
+    backup_frame.fill({});
 }
 
 DspStatus Mixers::Tick(DspConfiguration& config, const IntermediateMixSamples& read_samples,

--- a/src/audio_core/hle/shared_memory.h
+++ b/src/audio_core/hle/shared_memory.h
@@ -1,4 +1,4 @@
-// Copyright 2016 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -533,6 +533,7 @@ union DspMemory {
         u8 unused_2[0x8000];
     };
 };
+static_assert(sizeof(DspMemory) == 0x80000, "Incorrect DSP memory size");
 static_assert(offsetof(DspMemory, region_0) == region0_offset,
               "DSP region 0 is at the wrong offset");
 static_assert(offsetof(DspMemory, region_1) == region1_offset,

--- a/src/audio_core/hle/source.cpp
+++ b/src/audio_core/hle/source.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -42,6 +42,18 @@ void Source::MixInto(QuadFrame32& dest, std::size_t intermediate_mix_id) const {
 void Source::Reset() {
     current_frame.fill({});
     state = {};
+}
+
+void Source::Sleep() {
+    backup_frame = current_frame;
+    backup_state = state;
+}
+
+void Source::Wakeup() {
+    current_frame = backup_frame;
+    state = backup_state;
+    backup_frame.fill({});
+    backup_state = {};
 }
 
 void Source::SetMemory(Memory::MemorySystem& memory) {

--- a/src/audio_core/hle/source.h
+++ b/src/audio_core/hle/source.h
@@ -1,4 +1,4 @@
-// Copyright 2016 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -42,6 +42,9 @@ public:
     /// Resets internal state.
     void Reset();
 
+    void Sleep();
+    void Wakeup();
+
     /// Sets the memory system to read data from
     void SetMemory(Memory::MemorySystem& memory);
 
@@ -68,6 +71,7 @@ private:
     const std::size_t source_id;
     Memory::MemorySystem* memory_system{};
     StereoFrame16 current_frame;
+    StereoFrame16 backup_frame; // TODO(PabloMK7): Check if we actually need this
 
     using Format = SourceConfiguration::Configuration::Format;
     using InterpolationMode = SourceConfiguration::Configuration::InterpolationMode;
@@ -116,7 +120,7 @@ private:
         }
     };
 
-    struct {
+    struct SourceState {
 
         // State variables
 
@@ -179,8 +183,10 @@ private:
             ar & interpolation_mode;
         }
         friend class boost::serialization::access;
+    };
 
-    } state;
+    SourceState state;
+    SourceState backup_state;
 
     // Internal functions
 
@@ -197,6 +203,9 @@ private:
     template <class Archive>
     void serialize(Archive& ar, const unsigned int) {
         ar & state;
+        ar & backup_state;
+        ar & current_frame;
+        ar & backup_frame;
     }
     friend class boost::serialization::access;
 };


### PR DESCRIPTION
This PR implements the `Sleep` and `Wakeup` functionality in the HLE DSP implementation. This makes games not have their sound bugged when opening the home menu.

The implementation just saves all the DSP state to a backup, including the entire DSP memory, which very likely is not accurate. HW tests are needed to figure out exactly which state is saved and restored.

Furthermore, the `Initialize` call has been changed to leave the DSP in a consistent state, as it previously carried the configuration from the previous application.