### PR TITLE
qt: Fix incorrect system language detection

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -3959,14 +3959,35 @@ void GMainWindow::UpdateUITheme() {
 }
 
 void GMainWindow::LoadTranslation() {
+    bool loaded{false};
+
+    #ifdef _WIN32
+    // Set the language to the first option in "preferred languages" Windows' OS settings
+    if (UISettings::values.language.isEmpty()) {
+
+        const auto languages = QLocale::system().uiLanguages(QLocale::TagSeparator::Underscore);
+        for (const auto& lang : languages) {
+            // If the first language found is English, no need to install any translation
+            if (lang == QStringLiteral("en")) {
+                UISettings::values.language = lang;
+                return;
+            }
+            loaded = translator.load(lang, QStringLiteral(":/languages/"));
+            if (loaded) {
+                UISettings::values.language = lang;
+                break;
+            }
+        }
+    }
+    #endif
+
     // If the selected language is English, no need to install any translation
     if (UISettings::values.language == QStringLiteral("en")) {
         return;
     }
 
-    bool loaded;
 
-    if (UISettings::values.language.isEmpty()) {
+    if (UISettings::values.language.isEmpty() && !loaded) {
         // Use the system's default locale
         loaded = translator.load(QLocale::system(), {}, {}, QStringLiteral(":/languages/"));
     } else {

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -4085,10 +4085,8 @@ void GMainWindow::LoadTranslation() {
     const QString lang_en = QStringLiteral("en");
     const QString languages_dir = QStringLiteral(":/languages/");
 
-    #ifdef _WIN32
-    // Set the language to the first option in "preferred languages" Windows' OS settings
+    // Workaround for incorrect Qt system language detection
     if (UISettings::values.language.isEmpty()) {
-
         const auto languages = QLocale::system().uiLanguages(QLocale::TagSeparator::Underscore);
         for (const auto& lang : languages) {
             // If the first language found is English, no need to install any translation
@@ -4103,7 +4101,6 @@ void GMainWindow::LoadTranslation() {
             }
         }
     }
-    #endif
 
     // If the selected language is English, no need to install any translation
     if (UISettings::values.language == lang_en) {

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -4086,6 +4086,9 @@ void GMainWindow::LoadTranslation() {
     const QString languages_dir = QStringLiteral(":/languages/");
 
     // Workaround for incorrect Qt system language detection
+    // TODO: Allow the "<System>" option to actually be selected rather than overriding the
+    //       selected language option? Current behaviour is better than the issue it fixes,
+    //       but not ideal.
     if (UISettings::values.language.isEmpty()) {
         const auto languages = QLocale::system().uiLanguages(QLocale::TagSeparator::Underscore);
         for (const auto& lang : languages) {

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -4082,6 +4082,9 @@ void GMainWindow::UpdateUITheme() {
 void GMainWindow::LoadTranslation() {
     bool loaded{false};
 
+    const QString lang_en = QStringLiteral("en");
+    const QString languages_dir = QStringLiteral(":/languages/");
+
     #ifdef _WIN32
     // Set the language to the first option in "preferred languages" Windows' OS settings
     if (UISettings::values.language.isEmpty()) {
@@ -4089,11 +4092,11 @@ void GMainWindow::LoadTranslation() {
         const auto languages = QLocale::system().uiLanguages(QLocale::TagSeparator::Underscore);
         for (const auto& lang : languages) {
             // If the first language found is English, no need to install any translation
-            if (lang == QStringLiteral("en")) {
-                UISettings::values.language = lang;
+            if (lang == lang_en) {
+                UISettings::values.language = lang_en;
                 return;
             }
-            loaded = translator.load(lang, QStringLiteral(":/languages/"));
+            loaded = translator.load(lang, languages_dir);
             if (loaded) {
                 UISettings::values.language = lang;
                 break;
@@ -4103,23 +4106,23 @@ void GMainWindow::LoadTranslation() {
     #endif
 
     // If the selected language is English, no need to install any translation
-    if (UISettings::values.language == QStringLiteral("en")) {
+    if (UISettings::values.language == lang_en) {
         return;
     }
 
 
     if (UISettings::values.language.isEmpty() && !loaded) {
         // Use the system's default locale
-        loaded = translator.load(QLocale::system(), {}, {}, QStringLiteral(":/languages/"));
+        loaded = translator.load(QLocale::system(), {}, {}, languages_dir);
     } else {
         // Otherwise load from the specified file
-        loaded = translator.load(UISettings::values.language, QStringLiteral(":/languages/"));
+        loaded = translator.load(UISettings::values.language, languages_dir);
     }
 
     if (loaded) {
         qApp->installTranslator(&translator);
     } else {
-        UISettings::values.language = QStringLiteral("en");
+        UISettings::values.language = lang_en;
     }
 }
 

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -4080,14 +4080,35 @@ void GMainWindow::UpdateUITheme() {
 }
 
 void GMainWindow::LoadTranslation() {
+    bool loaded{false};
+
+    #ifdef _WIN32
+    // Set the language to the first option in "preferred languages" Windows' OS settings
+    if (UISettings::values.language.isEmpty()) {
+
+        const auto languages = QLocale::system().uiLanguages(QLocale::TagSeparator::Underscore);
+        for (const auto& lang : languages) {
+            // If the first language found is English, no need to install any translation
+            if (lang == QStringLiteral("en")) {
+                UISettings::values.language = lang;
+                return;
+            }
+            loaded = translator.load(lang, QStringLiteral(":/languages/"));
+            if (loaded) {
+                UISettings::values.language = lang;
+                break;
+            }
+        }
+    }
+    #endif
+
     // If the selected language is English, no need to install any translation
     if (UISettings::values.language == QStringLiteral("en")) {
         return;
     }
 
-    bool loaded;
 
-    if (UISettings::values.language.isEmpty()) {
+    if (UISettings::values.language.isEmpty() && !loaded) {
         // Use the system's default locale
         loaded = translator.load(QLocale::system(), {}, {}, QStringLiteral(":/languages/"));
     } else {

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -4080,7 +4080,7 @@ void GMainWindow::UpdateUITheme() {
 }
 
 void GMainWindow::LoadTranslation() {
-    bool loaded{false};
+    bool loaded = false;
 
     const QString lang_en = QStringLiteral("en");
     const QString languages_dir = QStringLiteral(":/languages/");

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -4110,7 +4110,6 @@ void GMainWindow::LoadTranslation() {
         return;
     }
 
-
     if (UISettings::values.language.isEmpty() && !loaded) {
         // Use the system's default locale
         loaded = translator.load(QLocale::system(), {}, {}, languages_dir);


### PR DESCRIPTION
May fix #242 

Needs testing for Windows 11. I can only test Windows 10.

The problem seems to be that `QLocale::system()` does not choose the system locale correctly from the list of preferred languages in Windows' language settings. This pull request manually loops through that list from `QLocale::system().uiLanguages()`, and because it is ordered in same way that the language preferences in Windows are ordered, the first language with a translation that it finds will be the most preferred language based on the user's ordering.

I am unsure as to the cause of this bug. I have a bit of a speculation:

- Notice how `QLocale::TagSeperator::Underscore` is passed in the patch's call to `QLocale::system().uiLanguages()`, well this was necessary because it appears the translation files use underscores, but the default is dashes. 

- `QLocale::system()` does not alter the underlying language list when passed to `translator.load()` resulting in the use of dashes instead of underscores, I assume this would cause translation files to be missed.

- Whether or not the above points are relevant, `QLocal::system()::language()` returns a language on my system that is NOT the selected system or most preferred language, and conspicuously also has an underscore separator instead of the default dash.

- I did not have debug symbols for Qt, so I can not check how it uses `uiLanguages()` or how it resolves what `QLocal::system()::language()` should be.

- `QTranslator::load()` notes in the documentation that when called with a `QLocale`, it will use the first translation file it finds in the search location (directory)

- Combined with above, `QCoreApplication::installTranslator()` may be connected, the documentation states that translations are searched for in the reverse order in which they were installed, and it appears that the order may be the reverse of `uiLanguages()`  afters the calls to `translator.load()`
