### PR TITLE
video_core/renderer_vulkan: Fix fb image view usage

### DIFF
--- a/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
@@ -1369,17 +1369,19 @@ vk::ImageView Surface::ImageView(u32 index) const noexcept {
 vk::ImageView Surface::FramebufferView() noexcept {
     is_framebuffer = true;
 
+    const u32 index = res_scale == 1 ? 0u : 1u;
+
     // If we already have a framebuffer-compatible view, return it
-    if (framebuffer_view) {
-        return framebuffer_view.get();
+    if (framebuffer_view[index]) {
+        return framebuffer_view[index].get();
     }
 
     // Create a new view with a single mip level for framebuffer compatibility
     // This is critical to avoid VUID-VkFramebufferCreateInfo-pAttachments-00883 validation errors
-    framebuffer_view = MakeFramebufferImageView(
+    framebuffer_view[index] = MakeFramebufferImageView(
         instance->GetDevice(), Image(), instance->GetTraits(pixel_format).native, Aspect(), 0);
 
-    return framebuffer_view.get();
+    return framebuffer_view[index].get();
 }
 
 vk::ImageView Surface::DepthView() noexcept {

--- a/src/video_core/renderer_vulkan/vk_texture_runtime.h
+++ b/src/video_core/renderer_vulkan/vk_texture_runtime.h
@@ -201,7 +201,7 @@ public:
     std::array<Handle, 3> handles{};
     std::array<vk::UniqueFramebuffer, 2> framebuffers{};
     Handle copy_handle;
-    vk::UniqueImageView framebuffer_view;
+    std::array<vk::UniqueImageView, 2> framebuffer_view;
     vk::UniqueImageView depth_view;
     vk::UniqueImageView stencil_view;
     vk::UniqueImageView storage_view;


### PR DESCRIPTION
Uses an array of two framebuffer image views, one for the original resolution and another for the scaled resolution. This fixes crashes introduced in #1116. This change was suggested by an anonymous contributor.

This PR is an amendment of another PR and should not be added to the changelog.