### PR TITLE
renderer_vulkan: Fix incorrect MaxTexelBufferElements return type

### DIFF
--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -229,7 +229,7 @@ public:
     }
 
     /// Returns the maximum supported elements in a texel buffer
-    u32 MaxTexelBufferElements() const {
+    u64 MaxTexelBufferElements() const {
         return properties.limits.maxTexelBufferElements;
     }
 


### PR DESCRIPTION
Closes #1530

A recent upstream change to Mesa changed the Vulkan texture limit to 1 << 29, and after this change, Azahar began consistently crashing when using the Vulkan renderer.

This crashing behaviour was due to the `TextureBufferSize` function in `vk_rasterizer.cpp` multiplying the u32 value returned from `MaxTexelBufferElements` by 8 to get 1 << 32. This value overflowed, rolling over to 0, and this incorrect overflowed value was then returned as the texture buffer size.

This is fixed by simply changing the return type of `MaxTexelBufferElements` to u64, preventing the overflow.

This fix was provided by an anonymous contributor.