### PR TITLE
core: Move plugin FB address ownership to MemorySystem

### DIFF
--- a/src/core/file_sys/plugin_3gx.cpp
+++ b/src/core/file_sys/plugin_3gx.cpp
@@ -290,7 +290,7 @@ Loader::ResultStatus FileSys::Plugin3GXLoader::Map(
     ASSERT(vma_heap.Succeeded());
     process.vm_manager.Reprotect(vma_heap.Unwrap(), Kernel::VMAPermission::ReadWriteExecute);
 
-    plg_ldr.SetPluginFBAddr(Memory::FCRAM_PADDR + fcram_offset + heap_offset);
+    kernel.memory.Plugin3GXFramebufferAddress() = Memory::FCRAM_PADDR + fcram_offset + heap_offset;
     plg_context.plugin_loaded = true;
     plg_context.plugin_process_id = process.process_id;
     plg_context.use_user_load_parameters = false;

--- a/src/core/hle/service/plgldr/plgldr.cpp
+++ b/src/core/hle/service/plgldr/plgldr.cpp
@@ -84,7 +84,6 @@ void PLG_LDR::PluginLoaderContext::serialize(Archive& ar, const unsigned int) {
     ar & exe_load_checksum;
     ar & load_exe_func;
     ar & load_exe_args;
-    ar & plugin_fb_addr;
 }
 SERIALIZE_IMPL(PLG_LDR::PluginLoaderContext)
 
@@ -167,6 +166,7 @@ void PLG_LDR::OnProcessExit(Kernel::Process& process, Kernel::KernelSystem& kern
         plgldr_context.plugin_loaded = false;
         plgldr_context.plugin_process_id = UINT32_MAX;
         plgldr_context.memory_changed_handle = 0;
+        kernel.memory.Plugin3GXFramebufferAddress() = 0;
         LOG_INFO(Service_PLGLDR, "Plugin unloaded successfully.");
     }
 }

--- a/src/core/hle/service/plgldr/plgldr.h
+++ b/src/core/hle/service/plgldr/plgldr.h
@@ -81,8 +81,6 @@ public:
         std::vector<u32> load_exe_func;
         u32_le load_exe_args[4] = {0};
 
-        PAddr plugin_fb_addr = 0;
-
         template <class Archive>
         void serialize(Archive& ar, const unsigned int);
         friend class boost::serialization::access;
@@ -113,12 +111,6 @@ public:
     }
     bool GetAllowGameChangeState() {
         return plgldr_context.allow_game_change;
-    }
-    void SetPluginFBAddr(PAddr addr) {
-        plgldr_context.plugin_fb_addr = addr;
-    }
-    PAddr GetPluginFBAddr() {
-        return plgldr_context.plugin_fb_addr;
     }
 
 private:

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -103,6 +103,8 @@ public:
     std::shared_ptr<BackingMem> n3ds_extra_ram_mem;
     std::shared_ptr<BackingMem> dsp_mem;
 
+    PAddr plugin_fb_address{};
+
     Impl(Core::System& system_);
 
     const u8* GetPtr(Region r) const {
@@ -262,12 +264,8 @@ public:
         if (addr >= VRAM_VADDR && addr < VRAM_VADDR_END) {
             return {vram_mem, addr - VRAM_VADDR};
         }
-        if (addr >= PLUGIN_3GX_FB_VADDR && addr < PLUGIN_3GX_FB_VADDR_END) {
-            auto plg_ldr = Service::PLGLDR::GetService(system);
-            if (plg_ldr) {
-                return {fcram_mem,
-                        addr - PLUGIN_3GX_FB_VADDR + plg_ldr->GetPluginFBAddr() - FCRAM_PADDR};
-            }
+        if (addr >= PLUGIN_3GX_FB_VADDR && addr < PLUGIN_3GX_FB_VADDR_END && plugin_fb_address) {
+            return {fcram_mem, addr - PLUGIN_3GX_FB_VADDR + plugin_fb_address - FCRAM_PADDR};
         }
 
         UNREACHABLE();
@@ -306,9 +304,8 @@ public:
         CheckRegion(LINEAR_HEAP_VADDR, LINEAR_HEAP_VADDR_END, FCRAM_PADDR);
         CheckRegion(NEW_LINEAR_HEAP_VADDR, NEW_LINEAR_HEAP_VADDR_END, FCRAM_PADDR);
         CheckRegion(VRAM_VADDR, VRAM_VADDR_END, VRAM_PADDR);
-        auto plg_ldr = Service::PLGLDR::GetService(system);
-        if (plg_ldr && plg_ldr->GetPluginFBAddr()) {
-            CheckRegion(PLUGIN_3GX_FB_VADDR, PLUGIN_3GX_FB_VADDR_END, plg_ldr->GetPluginFBAddr());
+        if (plugin_fb_address) {
+            CheckRegion(PLUGIN_3GX_FB_VADDR, PLUGIN_3GX_FB_VADDR_END, plugin_fb_address);
         }
     }
 
@@ -332,6 +329,7 @@ private:
         ar & vram_mem;
         ar & n3ds_extra_ram_mem;
         ar & dsp_mem;
+        ar & plugin_fb_address;
     }
 };
 
@@ -388,6 +386,10 @@ std::shared_ptr<PageTable> MemorySystem::GetCurrentPageTable() const {
 
 void MemorySystem::RasterizerFlushVirtualRegion(VAddr start, u32 size, FlushMode mode) {
     impl->RasterizerFlushVirtualRegion(start, size, mode);
+}
+
+PAddr& Memory::MemorySystem::Plugin3GXFramebufferAddress() {
+    return impl->plugin_fb_address;
 }
 
 void MemorySystem::MapPages(PageTable& page_table, u32 base, u32 size, MemoryRef memory,
@@ -700,12 +702,9 @@ std::vector<VAddr> MemorySystem::PhysicalToVirtualAddressForRasterizer(PAddr add
         return {addr - VRAM_PADDR + VRAM_VADDR};
     }
     // NOTE: Order matters here.
-    auto plg_ldr = Service::PLGLDR::GetService(impl->system);
-    if (plg_ldr) {
-        auto fb_addr = plg_ldr->GetPluginFBAddr();
-        if (addr >= fb_addr && addr < fb_addr + PLUGIN_3GX_FB_SIZE) {
-            return {addr - fb_addr + PLUGIN_3GX_FB_VADDR};
-        }
+    PAddr plg_fb_addr = Plugin3GXFramebufferAddress();
+    if (plg_fb_addr && addr >= plg_fb_addr && addr < plg_fb_addr + PLUGIN_3GX_FB_SIZE) {
+        return {addr - plg_fb_addr + PLUGIN_3GX_FB_VADDR};
     }
     if (addr >= FCRAM_PADDR && addr < FCRAM_PADDR_END) {
         return {addr - FCRAM_PADDR + LINEAR_HEAP_VADDR, addr - FCRAM_PADDR + NEW_LINEAR_HEAP_VADDR};

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -646,6 +646,9 @@ public:
 
     void RasterizerFlushVirtualRegion(VAddr start, u32 size, FlushMode mode);
 
+    /// Returns a reference to the framebuffer address of the currently loaded 3GX plugin.
+    PAddr& Plugin3GXFramebufferAddress();
+
 private:
     template <typename T>
     T Read(const std::shared_ptr<PageTable>& page_table, const VAddr vaddr);

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -57,11 +57,10 @@ PAddr GPU::VirtualToPhysicalAddress(VAddr addr) {
     if (addr >= Memory::NEW_LINEAR_HEAP_VADDR && addr <= Memory::NEW_LINEAR_HEAP_VADDR_END) {
         return addr - Memory::NEW_LINEAR_HEAP_VADDR + Memory::FCRAM_PADDR;
     }
-    if (addr >= Memory::PLUGIN_3GX_FB_VADDR && addr <= Memory::PLUGIN_3GX_FB_VADDR_END) {
-        auto plg_ldr = Service::PLGLDR::GetService(impl->system);
-        if (plg_ldr) {
-            return addr - Memory::PLUGIN_3GX_FB_VADDR + plg_ldr->GetPluginFBAddr();
-        }
+    PAddr plg_fb_addr;
+    if (addr >= Memory::PLUGIN_3GX_FB_VADDR && addr <= Memory::PLUGIN_3GX_FB_VADDR_END &&
+        (plg_fb_addr = impl->system.Memory().Plugin3GXFramebufferAddress())) {
+        return addr - Memory::PLUGIN_3GX_FB_VADDR + plg_fb_addr;
     }
 
     LOG_ERROR(HW_Memory, "Unknown virtual address @ 0x{:08X}", addr);


### PR DESCRIPTION
Moves the plugin framebuffer address ownership from the `plg:ldr` service to the memory system.

This way, there is no need to constantly get the reference to the plugin loader service every time the address is checked in hot code paths.

This change is minor performance update, but on it's own probably negligible.