### PR TITLE
video_core: Fix crash caused by malformed geo shaders

### DIFF
--- a/src/video_core/pica/pica_core.cpp
+++ b/src/video_core/pica/pica_core.cpp
@@ -342,7 +342,8 @@ void PicaCore::WriteInternalReg(u32 id, u32 value, u32 mask, bool& stop_requeste
         } else {
             vs_setup.program_code[offset] = value;
             vs_setup.MarkProgramCodeDirty();
-            if (!regs.internal.pipeline.gs_unit_exclusive_configuration) {
+            if (!regs.internal.pipeline.gs_unit_exclusive_configuration &&
+                regs.internal.pipeline.use_gs == PipelineRegs::UseGS::No) {
                 gs_setup.program_code[offset] = value;
                 gs_setup.MarkProgramCodeDirty();
             }
@@ -365,7 +366,8 @@ void PicaCore::WriteInternalReg(u32 id, u32 value, u32 mask, bool& stop_requeste
         } else {
             vs_setup.swizzle_data[offset] = value;
             vs_setup.MarkSwizzleDataDirty();
-            if (!regs.internal.pipeline.gs_unit_exclusive_configuration) {
+            if (!regs.internal.pipeline.gs_unit_exclusive_configuration &&
+                regs.internal.pipeline.use_gs == PipelineRegs::UseGS::No) {
                 gs_setup.swizzle_data[offset] = value;
                 gs_setup.MarkSwizzleDataDirty();
             }

--- a/src/video_core/shader/shader_interpreter.cpp
+++ b/src/video_core/shader/shader_interpreter.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -118,7 +118,21 @@ static void RunInterpreter(const ShaderSetup& setup, ShaderUnit& state,
         bool is_break = false;
         const u32 old_program_counter = program_counter;
 
-        const Instruction instr = {program_code[program_counter]};
+        // Always treat the last instruction of the program code as an
+        // end instruction. This fixes some games such as Thunder Blade
+        // or After Burner II which have malformed geo shaders without an
+        // end instruction crashing the emulator due to the program counter
+        // growing uncontrollably.
+        // TODO(PabloMK7): Find how real HW reacts to this, most likely the
+        // program counter wraps around after reaching the last instruction,
+        // but more testing is needed.
+        Instruction instr{};
+        if (program_counter < MAX_PROGRAM_CODE_LENGTH - 1) {
+            instr.hex = program_code[program_counter];
+        } else {
+            instr.opcode.Assign(OpCode::Id::END);
+        }
+
         const SwizzlePattern swizzle = {swizzle_data[instr.common.operand_desc_id]};
 
         Record<DebugDataRecord::CUR_INSTR>(debug_data, iteration, program_counter);

--- a/src/video_core/shader/shader_jit_a64_compiler.cpp
+++ b/src/video_core/shader/shader_jit_a64_compiler.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -899,7 +899,21 @@ void JitShader::Compile_NextInstr() {
 
     l(instruction_labels[program_counter]);
 
-    const Instruction instr = {(*program_code)[program_counter++]};
+    // Always treat the last instruction of the program code as an
+    // end instruction. This fixes some games such as Thunder Blade
+    // or After Burner II which have malformed geo shaders without an
+    // end instruction crashing the emulator due to the program counter
+    // growing uncontrollably.
+    // TODO(PabloMK7): Find how real HW reacts to this, most likely the
+    // program counter wraps around after reaching the last instruction,
+    // but more testing is needed.
+    Instruction instr{};
+    if (program_counter < MAX_PROGRAM_CODE_LENGTH - 1) {
+        instr.hex = (*program_code)[program_counter];
+    } else {
+        instr.opcode.Assign(OpCode::Id::END);
+    }
+    ++program_counter;
 
     const OpCode::Id opcode = instr.opcode.Value();
     const auto instr_func = instr_table[static_cast<std::size_t>(opcode)];


### PR DESCRIPTION
Fix a crash caused by the Program Counter in interpreted/jit shaders growing uncontrollably due to malformed shaders that have a missing end instruction, which would make the emulated program counter overflow and start reading garbage.

The issue has been fixed by forcing the last instruction of program memory to be an end instruction, however the proper real HW behaviour still needs to be figured out, most likely the PC just wraps around after reaching the end of the program memory.

Fixes crashes in 3D Thunder Blade II and 3D After Burner, but those games still present unplayable graphical glitches that will be fixed in the future.