### PR TITLE
android: Clean up long press dialog layout

### DIFF
--- a/src/android/app/src/main/res/layout/dialog_about_game.xml
+++ b/src/android/app/src/main/res/layout/dialog_about_game.xml
@@ -121,12 +121,13 @@
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/about_game_play"
                 style="@style/Widget.Material3.Button.Icon"
-                android:layout_width="0dp"
+                android:layout_width="142dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="3"
                 android:contentDescription="@string/play"
                 android:focusedByDefault="true"
                 android:text="@string/play"
+                android:textAlignment="center"
                 app:icon="@drawable/ic_play" />
 
             <com.google.android.material.button.MaterialButton
@@ -182,9 +183,18 @@
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/insert_cartridge_button"
                 style="@style/Widget.Material3.Button.TonalButton.Icon"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/compress_decompress"
+                style="@style/Widget.Material3.Button.TonalButton.Icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:contentDescription="@string/compress"
+                android:text="@string/compress" />
 
         </LinearLayout>
 
@@ -201,14 +211,6 @@
             app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/game_button_tray">
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/compress_decompress"
-                style="@style/Widget.Material3.Button.TonalButton.Icon"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:contentDescription="@string/compress"
-                android:text="@string/compress" />
 
         </LinearLayout>
 


### PR DESCRIPTION
Recent changes have made the about game dialog on Android look somewhat inconsistent. This PR moves the buttons into a more cohesive layout.

As this changes content which is currently only present on master, this PR shouldn't be noted in the changelog.

Before:
<img src=https://github.com/user-attachments/assets/1ce9c3f8-6a84-4b70-a59d-132881c891de width=300px />

After:
<img src=https://github.com/user-attachments/assets/f8dc9e78-e458-4a92-9643-e7686302a43a width=300px />
