### PR TITLE
Windows: Set process priority to above normal

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -319,6 +319,10 @@ GMainWindow::GMainWindow(Core::System& system_)
         }
     }
 
+#ifdef _WIN32
+    SetPriorityClass(GetCurrentProcess(), ABOVE_NORMAL_PRIORITY_CLASS);
+#endif
+
 #ifdef __unix__
     SetGamemodeEnabled(Settings::values.enable_gamemode.GetValue());
 #endif

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -396,6 +396,10 @@ GMainWindow::GMainWindow(Core::System& system_)
         }
     }
 
+#ifdef _WIN32
+    SetPriorityClass(GetCurrentProcess(), ABOVE_NORMAL_PRIORITY_CLASS);
+#endif
+
 #ifdef __unix__
     SetGamemodeEnabled(Settings::values.enable_gamemode.GetValue());
 #endif

--- a/src/citra_sdl/citra_sdl.cpp
+++ b/src/citra_sdl/citra_sdl.cpp
@@ -465,6 +465,10 @@ void LaunchSdlFrontend(int argc, char** argv) {
         }
     }
 
+#ifdef _WIN32
+    SetPriorityClass(GetCurrentProcess(), ABOVE_NORMAL_PRIORITY_CLASS);
+#endif
+
 #ifdef __unix__
     Common::Linux::StartGamemode();
 #endif


### PR DESCRIPTION
Sets [process priority class](https://learn.microsoft.com/en-us/windows/win32/procthread/scheduling-priorities) to above normal on Windows. Can prevent other applications (which are  usually set to normal by default) from interfering with Azahar and causing stutters. E.g OneDrive is normal and might suddenly decide it needs CPU time more than Azahar. It also provides a slight improvement in performance and consistency in cases where many applications are open and the CPU is under heavy load.