### PR TITLE
docker: Improve git tag/ commit hash integration

### DIFF
--- a/.ci/docker.sh
+++ b/.ci/docker.sh
@@ -1,4 +1,17 @@
-mkdir build
+#!/bin/bash -ex
 
-docker build -f docker/azahar-room/Dockerfile -t azahar-room .
-docker save azahar-room:latest > build/azahar-room.dockerimage
+GITREV="`git show -s --format='%h'`" || true
+
+if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+    TAG_NAME=$GITHUB_REF_NAME
+elif [[ -n $GITREV ]]; then
+    TAG_NAME=$GITREV
+else
+    TAG_NAME=unknown
+fi
+
+echo "Tag name is: $TAG_NAME"
+
+docker build -f docker/azahar-room/Dockerfile -t azahar-room:$TAG_NAME .
+mkdir -p build
+docker save azahar-room:$TAG_NAME > build/azahar-room-$TAG_NAME.dockerimage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -292,6 +292,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install tools
+        run: apk add bash
+      - name: Fix git ownership
+        run: git config --global --add safe.directory .
       - name: Build Docker image
         run: ./.ci/docker.sh
       - name: Move Docker image to artifacts directory


### PR DESCRIPTION
Closes #1601 
Closes #1606 

This PR allows the Docker image build process to use the current git tag/ commit hash in two ways, each of which addresses one of the above issues:

1. The current tag or commit hash is now automatically appended to the end of the image binary's filename.
2. The current tag or commit hash is now used as the Docker tag for the image.

If the current tag or commit hash cannot be determined, probably because the script is being run in a copy of the source code without the `.git` directory (which should never happen in CI), `unknown` is used in its place.