### PR TITLE
qt: Do not preload textures when custom textures are off

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -64,7 +64,7 @@ void EmuThread::run() {
     MicroProfileOnThreadCreate("EmuThread");
     const auto scope = core_context.Acquire();
 
-    if (Settings::values.preload_textures) {
+    if (Settings::values.custom_textures && Settings::values.preload_textures) {
         emit LoadProgress(VideoCore::LoadCallbackStage::Preload, 0, 0);
         system.CustomTexManager().PreloadTextures(
             stop_run, [this](VideoCore::LoadCallbackStage stage, std::size_t value,


### PR DESCRIPTION
Randomly, after closing my homebrew program, preload somehow enabled despite custom textures being off. Which then caused crashes when trying to start anything, should handle this special case, even if it shouldn't happen normally.