### PR TITLE
Qt: Exclude more logic if disabled

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -1517,8 +1517,9 @@ void GMainWindow::ShutdownGame() {
 
 #ifdef USE_DISCORD_PRESENCE
     discord_rpc->Pause();
-    emu_thread->RequestStop();
 #endif
+
+    emu_thread->RequestStop();
 
     // Release emu threads from any breakpoints
     // This belongs after RequestStop() and before wait() because if emulation stops on a GPU

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -1598,6 +1598,7 @@ void GMainWindow::ShutdownGame() {
     secondary_window->ReleaseRenderTarget();
 }
 
+#ifdef ENABLE_DEVELOPER_OPTIONS
 void GMainWindow::StartLaunchStressTest(const QString& game_path) {
     QThreadPool::globalInstance()->start([this, game_path] {
         do {
@@ -1607,6 +1608,7 @@ void GMainWindow::StartLaunchStressTest(const QString& game_path) {
         } while (emulation_running);
     });
 }
+#endif
 
 void GMainWindow::StoreRecentFile(const QString& filename) {
     UISettings::values.recent_files.prepend(filename);

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -60,7 +60,9 @@
 #include "citra_qt/debugger/profiler.h"
 #include "citra_qt/debugger/registers.h"
 #include "citra_qt/debugger/wait_tree.h"
+#ifdef USE_DISCORD_PRESENCE
 #include "citra_qt/discord.h"
+#endif
 #include "citra_qt/dumping/dumping_dialog.h"
 #include "citra_qt/game_list.h"
 #include "citra_qt/hotkeys.h"
@@ -341,8 +343,10 @@ GMainWindow::GMainWindow(Core::System& system_)
     default_theme_paths = QIcon::themeSearchPaths();
     UpdateUITheme();
 
+#ifdef USE_DISCORD_PRESENCE
     SetDiscordEnabled(UISettings::values.enable_discord_presence.GetValue());
     discord_rpc->Update();
+#endif
 
     play_time_manager = std::make_unique<PlayTime::PlayTimeManager>();
 
@@ -1511,8 +1515,10 @@ void GMainWindow::ShutdownGame() {
 
     AllowOSSleep();
 
+#ifdef USE_DISCORD_PRESENCE
     discord_rpc->Pause();
     emu_thread->RequestStop();
+#endif
 
     // Release emu threads from any breakpoints
     // This belongs after RequestStop() and before wait() because if emulation stops on a GPU
@@ -1539,8 +1545,9 @@ void GMainWindow::ShutdownGame() {
 
     OnCloseMovie();
 
+#ifdef USE_DISCORD_PRESENCE
     discord_rpc->Update();
-
+#endif
 #ifdef __unix__
     Common::Linux::StopGamemode();
 #endif
@@ -2476,8 +2483,9 @@ void GMainWindow::OnStartGame() {
     play_time_manager->SetProgramId(game_title_id);
     play_time_manager->Start();
 
+#ifdef USE_DISCORD_PRESENCE
     discord_rpc->Update();
-
+#endif
 #ifdef __unix__
     Common::Linux::StartGamemode();
 #endif
@@ -2801,7 +2809,9 @@ void GMainWindow::OnConfigure() {
     const int old_input_profile_index = Settings::values.current_input_profile_index;
     const auto old_input_profiles = Settings::values.input_profiles;
     const auto old_touch_from_button_maps = Settings::values.touch_from_button_maps;
+#ifdef USE_DISCORD_PRESENCE
     const bool old_discord_presence = UISettings::values.enable_discord_presence.GetValue();
+#endif
 #ifdef __unix__
     const bool old_gamemode = Settings::values.enable_gamemode.GetValue();
 #endif
@@ -2813,9 +2823,11 @@ void GMainWindow::OnConfigure() {
         if (UISettings::values.theme != old_theme) {
             UpdateUITheme();
         }
+#ifdef USE_DISCORD_PRESENCE
         if (UISettings::values.enable_discord_presence.GetValue() != old_discord_presence) {
             SetDiscordEnabled(UISettings::values.enable_discord_presence.GetValue());
         }
+#endif
 #ifdef __unix__
         if (Settings::values.enable_gamemode.GetValue() != old_gamemode) {
             SetGamemodeEnabled(Settings::values.enable_gamemode.GetValue());
@@ -4171,18 +4183,16 @@ void GMainWindow::RetranslateStatusBar() {
     multiplayer_state->retranslateUi();
 }
 
-void GMainWindow::SetDiscordEnabled([[maybe_unused]] bool state) {
 #ifdef USE_DISCORD_PRESENCE
+void GMainWindow::SetDiscordEnabled([[maybe_unused]] bool state) {
     if (state) {
         discord_rpc = std::make_unique<DiscordRPC::DiscordImpl>(system);
     } else {
         discord_rpc = std::make_unique<DiscordRPC::NullImpl>();
     }
-#else
-    discord_rpc = std::make_unique<DiscordRPC::NullImpl>();
-#endif
     discord_rpc->Update();
 }
+#endif
 
 #ifdef __unix__
 void GMainWindow::SetGamemodeEnabled(bool state) {

--- a/src/citra_qt/citra_qt.h
+++ b/src/citra_qt/citra_qt.h
@@ -312,7 +312,9 @@ private slots:
 #endif
     void OnSwitchDiskResources(VideoCore::LoadCallbackStage stage, std::size_t value,
                                std::size_t total);
+#ifdef ENABLE_DEVELOPER_OPTIONS
     void StartLaunchStressTest(const QString& game_path);
+#endif
 
 private:
     Q_INVOKABLE void OnMoviePlaybackCompleted();

--- a/src/citra_qt/citra_qt.h
+++ b/src/citra_qt/citra_qt.h
@@ -66,9 +66,11 @@ namespace Camera {
 class QtMultimediaCameraHandlerFactory;
 }
 
+#ifdef USE_DISCORD_PRESENCE
 namespace DiscordRPC {
 class DiscordInterface;
 }
+#endif
 
 namespace PlayTime {
 class PlayTimeManager;
@@ -107,7 +109,9 @@ public:
 
     GameList* game_list;
     std::unique_ptr<PlayTime::PlayTimeManager> play_time_manager;
+#ifdef USE_DISCORD_PRESENCE
     std::unique_ptr<DiscordRPC::DiscordInterface> discord_rpc;
+#endif
 
     bool DropAction(QDropEvent* event);
     void AcceptDropEvent(QDropEvent* event);
@@ -168,7 +172,9 @@ private:
     void BootGame(const QString& filename);
     void ShutdownGame();
 
+#ifdef USE_DISCORD_PRESENCE
     void SetDiscordEnabled(bool state);
+#endif
     void LoadAmiibo(const QString& filename);
 
     /**
@@ -436,8 +442,8 @@ private:
 
     std::shared_ptr<Camera::QtMultimediaCameraHandlerFactory> qt_cameras;
 
-    // Prompt shown when update check succeeds
 #ifdef ENABLE_QT_UPDATE_CHECKER
+    // Prompt shown when update check succeeds
     QFuture<QString> update_future;
     QFutureWatcher<QString> update_watcher;
 #endif

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -566,8 +566,12 @@ void QtConfig::ReadMiscellaneousValues() {
 
     ReadBasicSetting(Settings::values.log_filter);
     ReadBasicSetting(Settings::values.log_regex_filter);
+#ifdef __unix__
     ReadBasicSetting(Settings::values.enable_gamemode);
+#endif
+#ifdef ENABLE_QT_UPDATE_CHECKER
     ReadBasicSetting(UISettings::values.check_for_update_on_start);
+#endif
 
     qt_config->endGroup();
 }
@@ -810,7 +814,9 @@ void QtConfig::ReadUIValues() {
         UISettings::values.theme =
             ReadSetting(QStringLiteral("theme"), QString::fromUtf8(UISettings::themes[0].second))
                 .toString();
+#ifdef USE_DISCORD_PRESENCE
         ReadBasicSetting(UISettings::values.enable_discord_presence);
+#endif
         ReadBasicSetting(UISettings::values.screenshot_resolution_factor);
 
         ReadUILayoutValues();
@@ -1137,9 +1143,12 @@ void QtConfig::SaveMiscellaneousValues() {
 
     WriteBasicSetting(Settings::values.log_filter);
     WriteBasicSetting(Settings::values.log_regex_filter);
+#ifdef __unix__
     WriteBasicSetting(Settings::values.enable_gamemode);
+#endif
+#ifdef ENABLE_QT_UPDATE_CHECKER
     WriteBasicSetting(UISettings::values.check_for_update_on_start);
-
+#endif
     qt_config->endGroup();
 }
 
@@ -1328,7 +1337,9 @@ void QtConfig::SaveUIValues() {
     if (global) {
         WriteSetting(QStringLiteral("theme"), UISettings::values.theme,
                      QString::fromUtf8(UISettings::themes[0].second));
+#ifdef USE_DISCORD_PRESENCE
         WriteBasicSetting(UISettings::values.enable_discord_presence);
+#endif
         WriteBasicSetting(UISettings::values.screenshot_resolution_factor);
 
         SaveUILayoutValues();

--- a/src/citra_qt/configuration/configure_general.cpp
+++ b/src/citra_qt/configuration/configure_general.cpp
@@ -90,7 +90,7 @@ void ConfigureGeneral::SetConfiguration() {
         ui->toggle_background_mute->setChecked(
             UISettings::values.mute_when_in_background.GetValue());
         ui->toggle_hide_mouse->setChecked(UISettings::values.hide_mouse.GetValue());
-#ifdef USE_DISCORD_PRESENCE
+#ifdef ENABLE_QT_UPDATE_CHECKER
         ui->toggle_update_checker->setChecked(
             UISettings::values.check_for_update_on_start.GetValue());
 #endif
@@ -180,7 +180,7 @@ void ConfigureGeneral::ApplyConfiguration() {
         UISettings::values.pause_when_in_background = ui->toggle_background_pause->isChecked();
         UISettings::values.mute_when_in_background = ui->toggle_background_mute->isChecked();
         UISettings::values.hide_mouse = ui->toggle_hide_mouse->isChecked();
-#ifdef USE_DISCORD_PRESENCE
+#ifdef ENABLE_QT_UPDATE_CHECKER
         UISettings::values.check_for_update_on_start = ui->toggle_update_checker->isChecked();
 #endif
 #ifdef __unix__

--- a/src/citra_qt/configuration/configure_general.cpp
+++ b/src/citra_qt/configuration/configure_general.cpp
@@ -90,8 +90,10 @@ void ConfigureGeneral::SetConfiguration() {
         ui->toggle_background_mute->setChecked(
             UISettings::values.mute_when_in_background.GetValue());
         ui->toggle_hide_mouse->setChecked(UISettings::values.hide_mouse.GetValue());
+#ifdef USE_DISCORD_PRESENCE
         ui->toggle_update_checker->setChecked(
             UISettings::values.check_for_update_on_start.GetValue());
+#endif
 #ifdef __unix__
         ui->toggle_gamemode->setChecked(Settings::values.enable_gamemode.GetValue());
 #endif
@@ -178,7 +180,9 @@ void ConfigureGeneral::ApplyConfiguration() {
         UISettings::values.pause_when_in_background = ui->toggle_background_pause->isChecked();
         UISettings::values.mute_when_in_background = ui->toggle_background_mute->isChecked();
         UISettings::values.hide_mouse = ui->toggle_hide_mouse->isChecked();
+#ifdef USE_DISCORD_PRESENCE
         UISettings::values.check_for_update_on_start = ui->toggle_update_checker->isChecked();
+#endif
 #ifdef __unix__
         Settings::values.enable_gamemode = ui->toggle_gamemode->isChecked();
 #endif

--- a/src/citra_qt/configuration/configure_web.cpp
+++ b/src/citra_qt/configuration/configure_web.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/citra_qt/configuration/configure_web.cpp
+++ b/src/citra_qt/configuration/configure_web.cpp
@@ -23,12 +23,15 @@ ConfigureWeb::ConfigureWeb(QWidget* parent)
 ConfigureWeb::~ConfigureWeb() = default;
 
 void ConfigureWeb::SetConfiguration() {
-
+#ifdef USE_DISCORD_PRESENCE
     ui->toggle_discordrpc->setChecked(UISettings::values.enable_discord_presence.GetValue());
+#endif
 }
 
 void ConfigureWeb::ApplyConfiguration() {
+#ifdef USE_DISCORD_PRESENCE
     UISettings::values.enable_discord_presence = ui->toggle_discordrpc->isChecked();
+#endif
 }
 
 void ConfigureWeb::RetranslateUI() {

--- a/src/citra_qt/configuration/configure_web.h
+++ b/src/citra_qt/configuration/configure_web.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <memory>
-#include <QFutureWatcher>
 #include <QWidget>
 
 namespace Ui {

--- a/src/citra_qt/configuration/configure_web.h
+++ b/src/citra_qt/configuration/configure_web.h
@@ -1,4 +1,4 @@
-// Copyright 2017 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/citra_qt/game_list.h
+++ b/src/citra_qt/game_list.h
@@ -107,7 +107,9 @@ signals:
     void AddDirectory();
     void ShowList(bool show);
     void PopulatingCompleted();
+#ifdef ENABLE_DEVELOPER_OPTIONS
     void StartingLaunchStressTest(const QString& game_path);
+#endif
 
 private slots:
     void OnItemExpanded(const QModelIndex& item);

--- a/src/citra_qt/uisettings.h
+++ b/src/citra_qt/uisettings.h
@@ -83,12 +83,16 @@ struct Values {
     Settings::Setting<bool> pause_when_in_background{false, "pauseWhenInBackground"};
     Settings::Setting<bool> mute_when_in_background{false, "muteWhenInBackground"};
     Settings::Setting<bool> hide_mouse{false, "hideInactiveMouse"};
+#ifdef ENABLE_QT_UPDATE_CHECKER
     Settings::Setting<bool> check_for_update_on_start{true, "check_for_update_on_start"};
+#endif
 
     Settings::Setting<std::string> inserted_cartridge{"", "inserted_cartridge"};
 
+#ifdef USE_DISCORD_PRESENCE
     // Discord RPC
     Settings::Setting<bool> enable_discord_presence{true, "enable_discord_presence"};
+#endif
 
     // Game List
     Settings::Setting<GameListIconSize> game_list_icon_size{GameListIconSize::LargeIcon,


### PR DESCRIPTION
Exclude more logic for Discord RPC, update checker, Linux gamemode and stress test if disabled at compile time, so that less dead code gets shipped in those cases. Also removes an unused include.