### PR TITLE
Fix previous cheats not being cleaned up when a game has no corresponding cheats file

### DIFF
--- a/src/core/cheats/cheats.cpp
+++ b/src/core/cheats/cheats.cpp
@@ -91,10 +91,6 @@ void CheatEngine::LoadCheatFile(u64 title_id) {
         FileUtil::CreateDir(cheat_dir);
     }
 
-    if (!FileUtil::Exists(filepath)) {
-        return;
-    }
-
     auto gateway_cheats = GatewayCheat::LoadFile(filepath);
     {
         std::unique_lock lock{cheats_list_mutex};

--- a/src/core/cheats/gateway_cheat.cpp
+++ b/src/core/cheats/gateway_cheat.cpp
@@ -487,6 +487,10 @@ std::string GatewayCheat::ToString() const {
 std::vector<std::shared_ptr<CheatBase>> GatewayCheat::LoadFile(const std::string& filepath) {
     std::vector<std::shared_ptr<CheatBase>> cheats;
 
+    if (!FileUtil::Exists(filepath)) {
+        return cheats;
+    }
+
     boost::iostreams::stream<boost::iostreams::file_descriptor_source> file;
     FileUtil::OpenFStream<std::ios_base::in>(file, filepath);
     if (!file.is_open()) {


### PR DESCRIPTION
When game properties are opened or the game is launched, its cheats are loaded from the corrisponding .txt file in cheats folder.
However, when the game has no cheats file, the file loading logic was skipped entirely, causing any previously loaded cheats not to be cleared inside `CheatEngine`.
The most visible consequence of this is the bug reported in #937, however the stale cheats would have remained applied even after booting a game that had no cheats, with the potential of causing glitches due to mismatched cheats.

To fix this, I've moved the cheats file existence check from `CheatEngine::LoadCheatFile` to `GatewayCheat::LoadFile`, which seemed the most sensible location to me since it makes the behavior consistent to what happens when the cheat file cannot be opened (see the `if (!file.is_open())` check a few lines below the added lines).

The fix was tested and confirmed working as intended on Windows.