### PR TITLE
Remove old CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,0 @@
-**The Contributor's Guide has moved to [the wiki](https://github.com/citra-emu/citra/wiki/Contributing).**


### PR DESCRIPTION
It appears to be a remnant of the Citra era, as it points to a wiki page that doesn't exist anymore.
Removing it will help reduce confusion for new contributors :)