### PR TITLE
DirectoryInitialization.kt: Switch to getFilesDir for internalUserPath

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/DirectoryInitialization.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/DirectoryInitialization.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/DirectoryInitialization.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/DirectoryInitialization.kt
@@ -28,8 +28,8 @@ object DirectoryInitialization {
     @Volatile
     private var directoryState: DirectoryInitializationState? = null
     var userPath: String? = null
-    val internalUserPath
-        get() = CitraApplication.appContext.getExternalFilesDir(null)!!.canonicalPath
+    val internalUserPath: String
+        get() = CitraApplication.appContext.filesDir.canonicalPath
     private val isCitraDirectoryInitializationRunning = AtomicBoolean(false)
 
     val context: Context get() = CitraApplication.appContext


### PR DESCRIPTION
Should close #1576

On certain Android systems, the result of `getExternalFilesDir` can be null. It's unclear to me under what circumstances this can happen, as I have never experienced this on any of my devices, but users have reported crashes caused by this issue.

To my understanding, we can use `getFilesDir`, which can never be null, as a drop-in replacement.

I have successfully tested this across 3 different devices with existing Azahar setups, and @DavidRGriswold has also successfully tested this change.

This fix was based on a code snippet provided by @MissingxLink in the aforementioned issue.