### PR TITLE
Attempt to fix macOS crashes in 2124

### DIFF
--- a/src/citra_meta/main.cpp
+++ b/src/citra_meta/main.cpp
@@ -4,6 +4,9 @@
 
 #include <iostream>
 
+#include "common/detached_tasks.h"
+#include "common/scope_exit.h"
+
 #ifdef ENABLE_QT
 #include "citra_qt/citra_qt.h"
 #endif
@@ -69,6 +72,9 @@ static bool CheckAndReportSSE42() {
 #endif
 
 int main(int argc, char* argv[]) {
+    Common::DetachedTasks detached_tasks;
+    SCOPE_EXIT({ detached_tasks.WaitForAllTasks(); });
+
 #if CITRA_HAS_SSE42
     if (!CheckAndReportSSE42()) {
         return 1;
@@ -84,8 +90,7 @@ int main(int argc, char* argv[]) {
     }
 
     if (launch_room) {
-        LaunchRoom(argc, argv, true);
-        return 0;
+        return LaunchRoom(argc, argv, true);
     }
 #endif
 
@@ -98,13 +103,12 @@ int main(int argc, char* argv[]) {
     }
 
     if (!no_gui) {
-        LaunchQtFrontend(argc, argv);
-        return 0;
+        return LaunchQtFrontend(argc, argv);
     }
 #endif
 
 #if ENABLE_SDL2_FRONTEND
-    LaunchSdlFrontend(argc, argv);
+    return LaunchSdlFrontend(argc, argv);
 #else
     std::cout << "Cannot use SDL frontend as it was disabled at compile time. Exiting."
               << std::endl;

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -80,7 +80,6 @@
 #include "citra_qt/util/util.h"
 #include "common/arch.h"
 #include "common/common_paths.h"
-#include "common/detached_tasks.h"
 #include "common/dynamic_library/dynamic_library.h"
 #include "common/file_util.h"
 #include "common/literals.h"
@@ -4240,13 +4239,11 @@ static Qt::HighDpiScaleFactorRoundingPolicy GetHighDpiRoundingPolicy() {
 #endif
 }
 
-void LaunchQtFrontend(int argc, char* argv[]) {
+int LaunchQtFrontend(int argc, char* argv[]) {
 #ifdef __APPLE__
     // Ensure that the linker doesn't optimize qt_swizzle.mm out of existence.
     QtSwizzle::Dummy();
 #endif
-
-    Common::DetachedTasks detached_tasks;
 
 #if MICROPROFILE_ENABLED
     MicroProfileOnThreadCreate("Frontend");
@@ -4317,6 +4314,5 @@ void LaunchQtFrontend(int argc, char* argv[]) {
                      &GMainWindow::OnAppFocusStateChanged);
 
     int result = app.exec();
-    detached_tasks.WaitForAllTasks();
-    exit(result);
+    return result;
 }

--- a/src/citra_qt/citra_qt.h
+++ b/src/citra_qt/citra_qt.h
@@ -90,7 +90,7 @@ namespace Service::FS {
 enum class MediaType : u32;
 }
 
-void LaunchQtFrontend(int argc, char* argv[]);
+int LaunchQtFrontend(int argc, char* argv[]);
 
 class GMainWindow : public QMainWindow {
     Q_OBJECT

--- a/src/citra_room/citra_room.cpp
+++ b/src/citra_room/citra_room.cpp
@@ -19,7 +19,6 @@
 
 #include "common/common_paths.h"
 #include "common/common_types.h"
-#include "common/detached_tasks.h"
 #include "common/file_util.h"
 #include "common/logging/backend.h"
 #include "common/logging/log.h"
@@ -160,8 +159,7 @@ static void InitializeLogging(const std::string& log_file) {
 }
 
 /// Application entry point
-void LaunchRoom(int argc, char** argv, bool called_by_option) {
-    Common::DetachedTasks detached_tasks;
+int LaunchRoom(int argc, char** argv, bool called_by_option) {
     int option_index = 0;
     char* endarg;
 
@@ -251,20 +249,20 @@ void LaunchRoom(int argc, char** argv, bool called_by_option) {
                 break;
             case 'h':
                 PrintHelp(argv[0]);
-                exit(0);
+                return 0;
             case 'v':
                 PrintVersion();
-                exit(0);
+                return 0;
             case 'e':
                 PrintRemovedOptionWarning(argv[0], "--enable-citra-mods/-e");
-                exit(255);
+                return 255;
             case 'g':
                 PrintRemovedOptionWarning(argv[0], "--preferred-game/-g");
-                exit(255);
+                return 255;
             case 0:
                 if (strcmp(long_options[option_index].name, "preferred-game-id") == 0) {
                     PrintRemovedOptionWarning(argv[0], "--preferred-game-id");
-                    exit(255);
+                    return 255;
                 }
             }
         }
@@ -273,12 +271,12 @@ void LaunchRoom(int argc, char** argv, bool called_by_option) {
     if (room_name.empty()) {
         std::cout << "room name is empty!\n\n";
         PrintHelp(argv[0]);
-        exit(-1);
+        return -1;
     }
     if (preferred_game.empty()) {
         std::cout << "preferred application is empty!\n\n";
         PrintHelp(argv[0]);
-        exit(-1);
+        return -1;
     }
     if (preferred_game_id == 0) {
         std::cout
@@ -289,12 +287,12 @@ void LaunchRoom(int argc, char** argv, bool called_by_option) {
         std::cout << "max_members needs to be in the range 2 - "
                   << Network::MaxConcurrentConnections << "!\n\n";
         PrintHelp(argv[0]);
-        exit(-1);
+        return -1;
     }
     if (port > 65535) {
         std::cout << "port needs to be in the range 0 - 65535!\n\n";
         PrintHelp(argv[0]);
-        exit(-1);
+        return -1;
     }
     if (ban_list_file.empty()) {
         std::cout << "Ban list file not set!\nThis should get set to load and save room ban "
@@ -351,7 +349,7 @@ void LaunchRoom(int argc, char** argv, bool called_by_option) {
         if (!room->Create(room_name, room_description, "", port, password, max_members, username,
                           preferred_game, preferred_game_id, std::move(verify_backend), ban_list)) {
             std::cout << "Failed to create room: \n\n";
-            exit(-1);
+            return -1;
         }
         std::cout << "Room is open. Close with Q+Enter...\n\n";
         auto announce_session = std::make_unique<Network::AnnounceMultiplayerSession>();
@@ -377,5 +375,5 @@ void LaunchRoom(int argc, char** argv, bool called_by_option) {
         room->Destroy();
     }
     Network::Shutdown();
-    detached_tasks.WaitForAllTasks();
+    return 0;
 }

--- a/src/citra_room/citra_room.h
+++ b/src/citra_room/citra_room.h
@@ -4,4 +4,4 @@
 
 #pragma once
 
-void LaunchRoom(int argc, char** argv, bool called_by_option);
+int LaunchRoom(int argc, char** argv, bool called_by_option);

--- a/src/citra_room_standalone/citra_room_standalone.cpp
+++ b/src/citra_room_standalone/citra_room_standalone.cpp
@@ -3,7 +3,12 @@
 // Refer to the license.txt file included.
 
 #include "citra_room/citra_room.h"
+#include "common/detached_tasks.h"
+#include "common/scope_exit.h"
 
 int main(int argc, char* argv[]) {
+    Common::DetachedTasks detached_tasks;
+    SCOPE_EXIT({ detached_tasks.WaitForAllTasks(); });
+
     LaunchRoom(argc, argv, false);
 }

--- a/src/citra_sdl/citra_sdl.h
+++ b/src/citra_sdl/citra_sdl.h
@@ -1,7 +1,7 @@
-// Copyright Citra Emulator Project / Lime3DS Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
 #pragma once
 
-void LaunchSdlFrontend(int argc, char** argv);
+int LaunchSdlFrontend(int argc, char** argv);

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -51,6 +51,8 @@ public:
     virtual void EnableForStacktrace() = 0;
 
     virtual void Flush() = 0;
+
+    virtual void Close() = 0;
 };
 
 /**
@@ -70,6 +72,10 @@ public:
 
     void Flush() override {
         std::fflush(stderr);
+    }
+
+    void Close() override {
+        enabled = false;
     }
 
     void EnableForStacktrace() override {
@@ -130,6 +136,11 @@ public:
         file->Flush();
     }
 
+    void Close() override {
+        file->Close();
+        enabled = false;
+    }
+
     void EnableForStacktrace() override {
         enabled = true;
         bytes_written = 0;
@@ -158,6 +169,8 @@ public:
 
     void Flush() override {}
 
+    void Close() override {}
+
     void EnableForStacktrace() override {}
 };
 
@@ -177,11 +190,14 @@ public:
 
     void Flush() override {}
 
+    void Close() override {}
+
     void EnableForStacktrace() override {}
 };
 #endif
 
 bool initialization_in_progress_suppress_logging = true;
+bool logging_initialized = false;
 
 #ifdef CITRA_LINUX_GCC_BACKTRACE
 [[noreturn]] void SleepForever() {
@@ -216,6 +232,7 @@ public:
         instance = std::unique_ptr<Impl, decltype(&Deleter)>(
             new Impl(fmt::format("{}{}", log_dir, log_file), filter), Deleter);
         initialization_in_progress_suppress_logging = false;
+        logging_initialized = true;
     }
 
     static void Start() {
@@ -258,8 +275,8 @@ public:
         if (!filter.CheckMessage(log_class, log_level)) {
             return;
         }
-        Entry new_entry =
-            CreateEntry(log_class, log_level, filename, line_num, function, std::move(message));
+        Entry new_entry = CreateEntry(log_class, log_level, filename, line_num, function,
+                                      std::move(message), time_origin);
         if (!regex_filter.empty() &&
             !boost::regex_search(FormatLogMessage(new_entry), regex_filter)) {
             return;
@@ -272,6 +289,24 @@ public:
         } else {
             message_queue.EmplaceWait(new_entry);
         }
+    }
+
+    static Entry CreateEntry(Class log_class, Level log_level, const char* filename,
+                             unsigned int line_nr, const char* function, std::string&& message,
+                             const std::chrono::steady_clock::time_point& time_origin) {
+        using std::chrono::duration_cast;
+        using std::chrono::microseconds;
+        using std::chrono::steady_clock;
+
+        return {
+            .timestamp = duration_cast<microseconds>(steady_clock::now() - time_origin),
+            .log_class = log_class,
+            .log_level = log_level,
+            .filename = filename,
+            .line_num = line_nr,
+            .function = function,
+            .message = std::move(message),
+        };
     }
 
 private:
@@ -348,6 +383,8 @@ private:
             };
             while (!stop_token.stop_requested()) {
                 message_queue.PopWait(entry, stop_token);
+                // Only write the log if something was actually popped (entry.filename != nullptr)
+                // (for example, when the stop token is signaled).
                 if (entry.filename != nullptr) {
                     write_logs();
                 }
@@ -367,24 +404,10 @@ private:
             backend_thread.join();
         }
 
-        ForEachBackend([](Backend& backend) { backend.Flush(); });
-    }
-
-    Entry CreateEntry(Class log_class, Level log_level, const char* filename, unsigned int line_nr,
-                      const char* function, std::string&& message) const {
-        using std::chrono::duration_cast;
-        using std::chrono::microseconds;
-        using std::chrono::steady_clock;
-
-        return {
-            .timestamp = duration_cast<microseconds>(steady_clock::now() - time_origin),
-            .log_class = log_class,
-            .log_level = log_level,
-            .filename = filename,
-            .line_num = line_nr,
-            .function = function,
-            .message = std::move(message),
-        };
+        ForEachBackend([](Backend& backend) {
+            backend.Flush();
+            backend.Close();
+        });
     }
 
     void ForEachBackend(auto lambda) {
@@ -485,9 +508,19 @@ void SetColorConsoleBackendEnabled(bool enabled) {
 void FmtLogMessageImpl(Class log_class, Level log_level, const char* filename,
                        unsigned int line_num, const char* function, fmt::string_view format,
                        const fmt::format_args& args) {
-    if (!initialization_in_progress_suppress_logging) {
+    if (initialization_in_progress_suppress_logging) [[unlikely]] {
+        return;
+    }
+
+    if (logging_initialized) [[likely]] {
         Impl::Instance().PushEntry(log_class, log_level, filename, line_num, function,
                                    fmt::vformat(format, args));
+    } else {
+        // In the rare case that logging occurs before initialization, write the
+        // message to stderr to preserve useful debug information.
+        Entry new_entry = Impl::CreateEntry(log_class, log_level, filename, line_num, function,
+                                            fmt::vformat(format, args), {});
+        PrintMessage(new_entry);
     }
 }
 } // namespace Common::Log


### PR DESCRIPTION
This PR adds two changes:
- Move the `DetachedTasks` singleton constructor from the individual projects (citra_qt, citra_sdl and citra_room) to the citra_meta project. This allows `DetachedTasks` to be constructed as soon as possible. Also changed all `exit()` calls to a `return` statement so that the `DetachedTasks::WaitForAllTasks()` method has a chance to be called. This change also allows the destructors in the scopes that previously called `exit()` to run.
In #1637, an user suggested the issue happening inside the `DetachedTasks` constructor, but this is very strange because logs cannot be produced at this point yet (not initialized), so there is no way the user could have seen the log. It may be possible the user somehow ran `LaunchQtFrontend` twice through the debugger. It is unclear if this change will fix the problem, but it's worth having it anyways.
- Add a fallback to print logs to `stderr` if the logging system was not yet initialized. This helps getting information in case an `ASSERT` triggers before logging initialization. Also, close the file as soon as the logging is stopped to flush any remaining contents and free the file.