### PR TITLE
cmake: Upgrade bundled Qt to 6.9.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,7 +310,7 @@ find_package(Threads REQUIRED)
 
 if (ENABLE_QT)
     if (NOT USE_SYSTEM_QT)
-        download_qt(6.9.2)
+        download_qt(6.9.3)
     endif()
 
     find_package(Qt6 REQUIRED COMPONENTS Widgets Multimedia Concurrent)


### PR DESCRIPTION
As a simple bugfix/maintenance update, this should be safe to upgrade to from 6.9.2.