### PR TITLE
cmake: Fix build info sometimes not generating correctly

### DIFF
--- a/CMakeModules/GenerateBuildInfo.cmake
+++ b/CMakeModules/GenerateBuildInfo.cmake
@@ -1,49 +1,51 @@
-# Gets a UTC timstamp and sets the provided variable to it
-function(get_timestamp _var)
-    string(TIMESTAMP timestamp UTC)
-    set(${_var} "${timestamp}" PARENT_SCOPE)
-endfunction()
-get_timestamp(BUILD_DATE)
+macro(generate_build_info)
+    # Gets a UTC timstamp and sets the provided variable to it
+    function(get_timestamp _var)
+        string(TIMESTAMP timestamp UTC)
+        set(${_var} "${timestamp}" PARENT_SCOPE)
+    endfunction()
+    get_timestamp(BUILD_DATE)
 
-list(APPEND CMAKE_MODULE_PATH "${SRC_DIR}/externals/cmake-modules")
+    list(APPEND CMAKE_MODULE_PATH "${SRC_DIR}/externals/cmake-modules")
 
-if (EXISTS "${SRC_DIR}/.git/objects")
-    # Find the package here with the known path so that the GetGit commands can find it as well
-    find_package(Git QUIET PATHS "${GIT_EXECUTABLE}")
+    if (EXISTS "${SRC_DIR}/.git/objects")
+        # Find the package here with the known path so that the GetGit commands can find it as well
+        find_package(Git QUIET PATHS "${GIT_EXECUTABLE}")
 
-    # only use Git to check revision info when source is obtained via Git
-    include(GetGitRevisionDescription)
-    get_git_head_revision(GIT_REF_SPEC GIT_REV)
-    git_describe(GIT_DESC --always --long --dirty)
-    git_branch_name(GIT_BRANCH)
-elseif (EXISTS "${SRC_DIR}/GIT-COMMIT" AND EXISTS "${SRC_DIR}/GIT-TAG")
-    # unified source archive
-    file(READ "${SRC_DIR}/GIT-COMMIT" GIT_REV_RAW LIMIT 64)
-    string(STRIP "${GIT_REV_RAW}" GIT_REV)
-    string(SUBSTRING "${GIT_REV_RAW}" 0 9 GIT_DESC)
-    set(GIT_BRANCH "HEAD")
-else()
-    # self-packed archive?
-    set(GIT_REV "UNKNOWN")
-    set(GIT_DESC "UNKNOWN")
-    set(GIT_BRANCH "UNKNOWN")
-endif()
-string(SUBSTRING "${GIT_REV}" 0 7 GIT_SHORT_REV)
-
-# Set build version
-set(REPO_NAME "")
-set(BUILD_VERSION "0")
-set(BUILD_FULLNAME "${GIT_SHORT_REV}")
-if (DEFINED ENV{CI} AND DEFINED ENV{GITHUB_ACTIONS})
-    if ($ENV{GITHUB_REF_TYPE} STREQUAL "tag")
-        set(GIT_TAG $ENV{GITHUB_REF_NAME})
+        # only use Git to check revision info when source is obtained via Git
+        include(GetGitRevisionDescription)
+        get_git_head_revision(GIT_REF_SPEC GIT_REV)
+        git_describe(GIT_DESC --always --long --dirty)
+        git_branch_name(GIT_BRANCH)
+    elseif (EXISTS "${SRC_DIR}/GIT-COMMIT" AND EXISTS "${SRC_DIR}/GIT-TAG")
+        # unified source archive
+        file(READ "${SRC_DIR}/GIT-COMMIT" GIT_REV_RAW LIMIT 64)
+        string(STRIP "${GIT_REV_RAW}" GIT_REV)
+        string(SUBSTRING "${GIT_REV_RAW}" 0 9 GIT_DESC)
+        set(GIT_BRANCH "HEAD")
+    else()
+        # self-packed archive?
+        set(GIT_REV "UNKNOWN")
+        set(GIT_DESC "UNKNOWN")
+        set(GIT_BRANCH "UNKNOWN")
     endif()
-elseif (EXISTS "${SRC_DIR}/GIT-COMMIT" AND EXISTS "${SRC_DIR}/GIT-TAG")
-    file(READ "${SRC_DIR}/GIT-TAG" GIT_TAG)
-    string(STRIP ${GIT_TAG} GIT_TAG)
-endif()
+    string(SUBSTRING "${GIT_REV}" 0 7 GIT_SHORT_REV)
 
-if (DEFINED GIT_TAG AND NOT "${GIT_TAG}" STREQUAL "unknown")
-    set(BUILD_VERSION "${GIT_TAG}")
-    set(BUILD_FULLNAME "${BUILD_VERSION}")
-endif()
+    # Set build version
+    set(REPO_NAME "")
+    set(BUILD_VERSION "0")
+    set(BUILD_FULLNAME "${GIT_SHORT_REV}")
+    if (DEFINED ENV{CI} AND DEFINED ENV{GITHUB_ACTIONS})
+        if ($ENV{GITHUB_REF_TYPE} STREQUAL "tag")
+            set(GIT_TAG $ENV{GITHUB_REF_NAME})
+        endif()
+    elseif (EXISTS "${SRC_DIR}/GIT-COMMIT" AND EXISTS "${SRC_DIR}/GIT-TAG")
+        file(READ "${SRC_DIR}/GIT-TAG" GIT_TAG)
+        string(STRIP ${GIT_TAG} GIT_TAG)
+    endif()
+
+    if (DEFINED GIT_TAG AND NOT "${GIT_TAG}" STREQUAL "unknown")
+        set(BUILD_VERSION "${GIT_TAG}")
+        set(BUILD_FULLNAME "${BUILD_VERSION}")
+    endif()
+endmacro()

--- a/CMakeModules/GenerateSCMRev.cmake
+++ b/CMakeModules/GenerateSCMRev.cmake
@@ -1,5 +1,6 @@
 list(APPEND CMAKE_MODULE_PATH "${SRC_DIR}/CMakeModules")
 include(GenerateBuildInfo)
+generate_build_info()
 
 # The variable SRC_DIR must be passed into the script (since it uses the current build directory for all values of CMAKE_*_DIR)
 set(VIDEO_CORE "${SRC_DIR}/src/video_core")

--- a/src/citra_meta/CMakeLists.txt
+++ b/src/citra_meta/CMakeLists.txt
@@ -17,6 +17,8 @@ if (APPLE)
 
     # Define app bundle metadata.
     include(GenerateBuildInfo)
+    set(SRC_DIR "${PROJECT_SOURCE_DIR}")
+    generate_build_info()
     set_target_properties(citra_meta PROPERTIES
         MACOSX_BUNDLE TRUE
         MACOSX_BUNDLE_INFO_PLIST "${DIST_DIR}/Info.plist.in"


### PR DESCRIPTION
Sometimes, when building locally, the build info which is supposed to be generated by CMake will just not generate, returning "UNKNOWN" instead. I'm not sure what exactly causes this, but simply putting the code into a macro made the issue go away on my end.

I suspect that the issue was somehow related to how CMake code included with `include` is scoped.