### PR TITLE
citra_meta: search for Qt6::GuiPrivate before using it

### DIFF
--- a/src/citra_meta/CMakeLists.txt
+++ b/src/citra_meta/CMakeLists.txt
@@ -63,6 +63,7 @@ if (ENABLE_QT AND UNIX AND NOT APPLE)
 endif()
 
 if (ENABLE_QT AND APPLE)
+    find_package(Qt6 REQUIRED COMPONENTS GuiPrivate)
     target_link_libraries(citra_meta PRIVATE Qt6::GuiPrivate)
 endif()
 


### PR DESCRIPTION
Otherwise, the configuration on darwin fails for me with the following error:

```
CMake Error at src/citra_meta/CMakeLists.txt:64 (target_link_libraries):
  Target "citra_meta" links to:

    Qt6::GuiPrivate

  but the target was not found.
```