### PR TITLE
android: Fix desynced default value for `use_vsync` setting

### DIFF
--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -515,7 +515,11 @@ struct Values {
     SwitchableSetting<bool> use_hw_shader{true, "use_hw_shader"};
     SwitchableSetting<bool> use_disk_shader_cache{true, "use_disk_shader_cache"};
     SwitchableSetting<bool> shaders_accurate_mul{true, "shaders_accurate_mul"};
+#ifdef ANDROID // TODO: Fuck this -OS
+    SwitchableSetting<bool> use_vsync{false, "use_vsync"};
+#else
     SwitchableSetting<bool> use_vsync{true, "use_vsync"};
+#endif
     Setting<bool> use_shader_jit{true, "use_shader_jit"};
     SwitchableSetting<u32, true> resolution_factor{1, 0, 10, "resolution_factor"};
     SwitchableSetting<double, true> frame_limit{100, 0, 1000, "frame_limit"};


### PR DESCRIPTION
Prior to this change, there was a mismatch between the default value of the `use_vsync` setting key in settings.h and the equivalent setting in BooleanSetting.kt. The former had the default incorrectly set to true, and the latter had it set to false, as it should be.

This resulted in a situation where, when the `use_vsync` setting hasn't been altered since installation, the setting displays as being disabled in the settings, but is actually enabled internally.