### PR TITLE
qt: Implement Update Channel setting

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -173,11 +173,20 @@ void GMainWindow::ShowCommandOutput(std::string title, std::string message) {
 #endif
 }
 
-bool IsPrerelease() {
+bool IsPrereleaseBuild() {
     return ((strstr(Common::g_build_fullname, "alpha") != NULL) ||
             (strstr(Common::g_build_fullname, "beta") != NULL) ||
             (strstr(Common::g_build_fullname, "rc") != NULL));
 }
+
+#ifdef ENABLE_QT_UPDATE_CHECKER
+bool ShouldCheckForPrereleaseUpdates() {
+    const bool update_channel = UISettings::values.update_check_channel.GetValue();
+    const bool using_prerelease_channel =
+        (update_channel == UISettings::UpdateCheckChannels::PRERELEASE);
+    return (IsPrereleaseBuild() || using_prerelease_channel);
+}
+#endif
 
 GMainWindow::GMainWindow(Core::System& system_)
     : ui{std::make_unique<Ui::MainWindow>()}, system{system_}, movie{system.Movie()},
@@ -410,7 +419,8 @@ GMainWindow::GMainWindow(Core::System& system_)
     if (UISettings::values.check_for_update_on_start) {
         update_future = QtConcurrent::run([]() -> QString {
             const std::optional<std::string> latest_release_tag =
-                UpdateChecker::GetLatestRelease(IsPrerelease());
+                UpdateChecker::GetLatestRelease(ShouldCheckForPrereleaseUpdates());
+
             if (latest_release_tag && latest_release_tag.value() != Common::g_build_fullname) {
                 return QString::fromStdString(latest_release_tag.value());
             }
@@ -4072,7 +4082,7 @@ void GMainWindow::OnEmulatorUpdateAvailable() {
     update_prompt.exec();
     if (update_prompt.button(QMessageBox::Yes) == update_prompt.clickedButton()) {
         std::string update_page_url;
-        if (IsPrerelease()) {
+        if (ShouldCheckForPrereleaseUpdates()) {
             update_page_url = "https://github.com/azahar-emu/azahar/releases";
         } else {
             update_page_url = "https://azahar-emu.org/pages/download/";

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -571,6 +571,7 @@ void QtConfig::ReadMiscellaneousValues() {
 #endif
 #ifdef ENABLE_QT_UPDATE_CHECKER
     ReadBasicSetting(UISettings::values.check_for_update_on_start);
+    ReadBasicSetting(UISettings::values.update_check_channel);
 #endif
 
     qt_config->endGroup();
@@ -1148,6 +1149,7 @@ void QtConfig::SaveMiscellaneousValues() {
 #endif
 #ifdef ENABLE_QT_UPDATE_CHECKER
     WriteBasicSetting(UISettings::values.check_for_update_on_start);
+    WriteBasicSetting(UISettings::values.update_check_channel);
 #endif
     qt_config->endGroup();
 }

--- a/src/citra_qt/configuration/configure_general.cpp
+++ b/src/citra_qt/configuration/configure_general.cpp
@@ -44,7 +44,7 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
     ui->toggle_gamemode->setVisible(false);
 #endif
 #ifndef ENABLE_QT_UPDATE_CHECKER
-    ui->toggle_update_checker->setVisible(false);
+    ui->updates_group->setVisible(false);
 #endif
 
     SetupPerGameUI();
@@ -93,6 +93,8 @@ void ConfigureGeneral::SetConfiguration() {
 #ifdef ENABLE_QT_UPDATE_CHECKER
         ui->toggle_update_checker->setChecked(
             UISettings::values.check_for_update_on_start.GetValue());
+        ui->update_channel_combobox->setCurrentIndex(
+            UISettings::values.update_check_channel.GetValue());
 #endif
 #ifdef __unix__
         ui->toggle_gamemode->setChecked(Settings::values.enable_gamemode.GetValue());
@@ -182,6 +184,7 @@ void ConfigureGeneral::ApplyConfiguration() {
         UISettings::values.hide_mouse = ui->toggle_hide_mouse->isChecked();
 #ifdef ENABLE_QT_UPDATE_CHECKER
         UISettings::values.check_for_update_on_start = ui->toggle_update_checker->isChecked();
+        UISettings::values.update_check_channel = ui->update_channel_combobox->currentIndex();
 #endif
 #ifdef __unix__
         Settings::values.enable_gamemode = ui->toggle_gamemode->isChecked();
@@ -215,5 +218,5 @@ void ConfigureGeneral::SetupPerGameUI() {
     ui->general_group->setVisible(false);
     ui->button_reset_defaults->setVisible(false);
     ui->toggle_gamemode->setVisible(false);
-    ui->toggle_update_checker->setVisible(false);
+    ui->updates_group->setVisible(false);
 }

--- a/src/citra_qt/configuration/configure_general.ui
+++ b/src/citra_qt/configuration/configure_general.ui
@@ -17,6 +17,43 @@
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>
+      <widget class="QGroupBox" name="updates_group">
+       <property name="title">
+        <string>Updates</string>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <item row="0" column="0">
+         <widget class="QCheckBox" name="toggle_update_checker">
+          <property name="text">
+           <string>Check for updates</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="update_channel_label">
+          <property name="text">
+           <string>Update Channel</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QComboBox" name="update_channel_combobox">
+          <item>
+           <property name="text">
+            <string>Stable</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Prerelease</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
       <widget class="QGroupBox" name="general_group">
        <property name="title">
         <string>General</string>
@@ -54,13 +91,6 @@
          <widget class="QCheckBox" name="toggle_gamemode">
           <property name="text">
            <string>Enable Gamemode</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="toggle_update_checker">
-          <property name="text">
-           <string>Check for updates</string>
           </property>
          </widget>
         </item>
@@ -315,7 +345,6 @@
   <tabstop>toggle_check_exit</tabstop>
   <tabstop>toggle_background_pause</tabstop>
   <tabstop>toggle_hide_mouse</tabstop>
-  <tabstop>toggle_update_checker</tabstop>
   <tabstop>button_reset_defaults</tabstop>
  </tabstops>
  <resources/>

--- a/src/citra_qt/uisettings.h
+++ b/src/citra_qt/uisettings.h
@@ -59,6 +59,12 @@ enum class GameListText : s32 {
     ListEnd,       ///< Keep this at the end of the enum.
 };
 
+class UpdateCheckChannels {
+public:
+    static constexpr int STABLE = 0;
+    static constexpr int PRERELEASE = 1;
+};
+
 struct Values {
     QByteArray geometry;
     QByteArray state;
@@ -85,6 +91,8 @@ struct Values {
     Settings::Setting<bool> hide_mouse{false, "hideInactiveMouse"};
 #ifdef ENABLE_QT_UPDATE_CHECKER
     Settings::Setting<bool> check_for_update_on_start{true, "check_for_update_on_start"};
+    Settings::Setting<int> update_check_channel{UpdateCheckChannels::STABLE,
+                                                "update_check_channel"};
 #endif
 
     Settings::Setting<std::string> inserted_cartridge{"", "inserted_cartridge"};


### PR DESCRIPTION
Previously the kind of update check which was run by the emulator was determined by what kind of build was currently installed. If the user was using a stable build, the emulator would only check for stable updates, but if a prerelease build was installed, it would also check for prereleases.

This PR adds a new setting in the general section of the configuration menu named "Update Channel". This allows users to select between "Stable" (default) and "Prerelease". These options mirror the previous stable and prerelease update behaviour, but now in user-configurable form:
<br><br>
<img width="600" alt="Screenshot 2026-01-21 at 00 12 09" src="https://github.com/user-attachments/assets/6dc4c90c-44ad-4559-b88a-422c16a306fb" />
<br><br>
On prerelease builds, the update channel can still be changed, but will be ignored in favour of always checking for newer prereleases to ensure that critical fixes can be rolled out. It's still important to still allow the update channel to be changed however, as the setting also dictates the behaviour of the update check after a user updates *from* a prerelease build *to* a stable build.

The rationale behind this change is to encourage increased adoption of the prerelease builds, as there has been a lack of community pre-release testing in recent releases which has caused high-severity bugs to make their way into a stable release.

This feature has been locally verified to work correctly, so review should mostly focus on code quality.