### PR TITLE
qt: Workaround for Qt directoryChanged event spam on macOS

### DIFF
--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -1119,7 +1119,7 @@ void GameList::RefreshGameDirectory() {
         return;
     }
 
-    const auto time_now = std::chrono::system_clock::now();
+    const auto time_now = std::chrono::steady_clock::now();
 
     // Max of 1 refresh every 1 second.
     if (time_last_refresh + std::chrono::seconds(1) > time_now) {

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -1113,12 +1113,20 @@ const QStringList GameList::supported_file_extensions = {
 };
 
 void GameList::RefreshGameDirectory() {
-
     // Do not scan directories when the system is powered on, it will be
     // repopulated on shutdown anyways.
     if (Core::System::GetInstance().IsPoweredOn()) {
         return;
     }
+
+    const auto time_now = std::chrono::system_clock::now();
+
+    // Max of 1 refresh every 1 second.
+    if (time_last_refresh + std::chrono::seconds(1) > time_now) {
+        return;
+    }
+
+    time_last_refresh = time_now;
 
     if (!UISettings::values.game_dirs.isEmpty() && current_worker != nullptr) {
         LOG_INFO(Frontend, "Change detected in the applications directory. Reloading game list.");

--- a/src/citra_qt/game_list.h
+++ b/src/citra_qt/game_list.h
@@ -154,7 +154,7 @@ private:
 
     const PlayTime::PlayTimeManager& play_time_manager;
 
-    std::chrono::time_point<std::chrono::system_clock> time_last_refresh;
+    std::chrono::time_point<std::chrono::steady_clock> time_last_refresh;
 };
 
 class GameListPlaceholder : public QWidget {

--- a/src/citra_qt/game_list.h
+++ b/src/citra_qt/game_list.h
@@ -153,6 +153,8 @@ private:
     friend class GameListSearchField;
 
     const PlayTime::PlayTimeManager& play_time_manager;
+
+    std::chrono::time_point<std::chrono::system_clock> time_last_refresh;
 };
 
 class GameListPlaceholder : public QWidget {


### PR DESCRIPTION
Closes #1662
Closes #1656

On macOS, a suspected Qt bug or some other anomaly is causing the `directoryChanged` event to re-fire when the directory hasn't actually been altered. This is triggered by `watcher` being altered in `GameList::DonePopulating`, causing an infinite loop where either the entire frontend would hang when opening or the game list would begin to violently flicker as the list refreshed itself as fast as it can.

I was only able to replicate this issue by using an application directory with at least 4 applications within it. Additionally, the bug wasn't consistent, sometimes requiring several re-launches for the issue to be seen.

This issue has been addressed by limiting the application directory to one refresh per second. If additional refreshes are attempted in this timeframe, they are ignored. This prevents the aforementioned infinite loop or hang from occurring, as after the second attempted refresh in the loop is performed, it is cancelled, allowing the application continue as normal.

In the future, the behaviour described above should be investigated, and if determined to be a Qt bug, should be reported upstream.