### PR TITLE
Bug Fix: Retroid Second Screen on Odin 2

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/display/SecondaryDisplay.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/display/SecondaryDisplay.kt
@@ -50,7 +50,7 @@ class SecondaryDisplay(val context: Context) : DisplayManager.DisplayListener {
         val currentDisplayId = context.display.displayId
         val displays = dm.displays
         val presDisplays = dm.getDisplays(DisplayManager.DISPLAY_CATEGORY_PRESENTATION);
-        return displays.firstOrNull {
+        val extDisplays = displays.filter {
             val isPresentable = presDisplays.any { pd -> pd.displayId == it.displayId }
             val isNotDefaultOrPresentable = it.displayId != Display.DEFAULT_DISPLAY || isPresentable
             isNotDefaultOrPresentable &&
@@ -59,6 +59,10 @@ class SecondaryDisplay(val context: Context) : DisplayManager.DisplayListener {
                     it.state != Display.STATE_OFF &&
                     it.isValid
         }
+        // if there is a display called Built-In Display or Built-In Screen, prioritize the OTHER screen
+        val selected = extDisplays.firstOrNull { ! it.name.contains("Built",true) }
+            ?: extDisplays.firstOrNull()
+        return selected
     }
 
     fun updateDisplay() {


### PR DESCRIPTION
Fixes #1660 

When using the Retroid launcher on the odin 2 with the Retroid Pocket screen attachment, a virtual display called Built-In Screen is created, I assume for the purpose of better control over mirroring. Because this is created earlier than when the display is actually plugged in, it becomes the "first" external display, so Azahar was incorrectly displaying to that instead of the real external DP display.

This was solved in a different fork by excluding any display called "Built-In Screen", but that caused issues with other devices that give that name to the ACTUAL second display.

This code instead makes the choice of finding all potential second displays, then *prioritizing* displays with a name that does not contain the word "Built", but will fall back on one with the word "Built" fi needed.

#1385 provides a more flexible solution by offering the user the option to select *which* external display to use, but I will still update the PR to use this logic to pick the default value.
