### PR TITLE
Mention in the tooltip that Async Presentation (Vulkan) adds 1 frame of input lag

### DIFF
--- a/src/citra_qt/configuration/configure_graphics.ui
+++ b/src/citra_qt/configuration/configure_graphics.ui
@@ -234,7 +234,7 @@
       <item>
        <widget class="QCheckBox" name="toggle_async_present">
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Perform presentation on separate threads. Improves performance when using Vulkan in most applications.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Perform presentation on separate threads. Improves performance when using Vulkan in most applications. Adds ~1 frame of input lag.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
          <string>Enable async presentation</string>


### PR DESCRIPTION
This adds the mention in the tooltip that Async Presentation (Vulkan) adds 1 frame of input lag. I've added the description in all the languages. I could only verify in english & french. For the rest, I had to use ChatGPT :p.

Closes https://github.com/azahar-emu/azahar/issues/1595