### PR TITLE
Fix accurate multiplication setting loading

### DIFF
--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -269,6 +269,8 @@ static Core::System::ResultStatus RunCitra(const std::string& filepath) {
 
     LoadDiskCacheProgress(VideoCore::LoadCallbackStage::Prepare, 0, 0);
 
+    system.GPU().ApplyPerProgramSettings(program_id);
+
     std::unique_ptr<Frontend::GraphicsContext> cpu_context;
     system.GPU().Renderer().Rasterizer()->LoadDefaultDiskResources(stop_run,
                                                                    &LoadDiskCacheProgress);

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -18,6 +18,7 @@
 #include "core/3ds.h"
 #include "core/core.h"
 #include "core/frontend/framebuffer_layout.h"
+#include "core/loader/loader.h"
 #include "core/perf_stats.h"
 #include "input_common/keyboard.h"
 #include "input_common/main.h"
@@ -77,6 +78,10 @@ void EmuThread::run() {
         });
 
     emit LoadProgress(VideoCore::LoadCallbackStage::Prepare, 0, 0);
+
+    u64 program_id{};
+    system.GetAppLoader().ReadProgramId(program_id);
+    system.GPU().ApplyPerProgramSettings(program_id);
 
     system.GPU().Renderer().Rasterizer()->LoadDefaultDiskResources(
         stop_run, [this](VideoCore::LoadCallbackStage stage, std::size_t value, std::size_t total) {

--- a/src/citra_sdl/citra_sdl.cpp
+++ b/src/citra_sdl/citra_sdl.cpp
@@ -474,6 +474,10 @@ int LaunchSdlFrontend(int argc, char** argv) {
         }
     });
 
+    u64 program_id{};
+    system.GetAppLoader().ReadProgramId(program_id);
+    system.GPU().ApplyPerProgramSettings(program_id);
+
     std::atomic_bool stop_run;
     system.GPU().Renderer().Rasterizer()->LoadDefaultDiskResources(
         stop_run, [](VideoCore::LoadCallbackStage stage, std::size_t value, std::size_t total) {

--- a/src/common/hacks/hack_list.cpp
+++ b/src/common/hacks/hack_list.cpp
@@ -55,6 +55,12 @@ HackManager hack_manager = {
                      0x00040000001D1400, // USA
                      0x00040000001D1500, // EUR
                      0x00040000001CA900, // JPN
+
+                     // Mario & Luigi: Paper Jam
+                     0x0004000000132600, // JPN
+                     0x0004000000132700, // USA
+                     0x0004000000132800, // EUR
+                     0x000400000018A100, // EUR (Demo)
                  },
          }},
 

--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -693,6 +693,7 @@ Result GSP_GPU::AcquireGpuRight(const Kernel::HLERequestContext& ctx,
             Common::Hacks::HackAllowMode::DISALLOW) != Common::Hacks::HackAllowMode::DISALLOW;
 
     auto& gpu = system.GPU();
+    gpu.ApplyPerProgramSettings(process->codeset->program_id);
     gpu.GetRightEyeDisabler().SetEnabled(right_eye_disable_allow);
     gpu.PicaCore().vs_setup.requires_fixup = requires_shader_fixup;
     gpu.PicaCore().gs_setup.requires_fixup = requires_shader_fixup;

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -311,7 +311,7 @@ GraphicsDebugger& GPU::Debugger() {
     return impl->gpu_debugger;
 }
 
-void GPU::ReportLoadingProgramID(u64 program_ID) {
+void GPU::ApplyPerProgramSettings(u64 program_ID) {
     auto hack = Common::Hacks::hack_manager.GetHack(
         Common::Hacks::HackType::ACCURATE_MULTIPLICATION, program_ID);
     bool use_accurate_mul = Settings::values.shaders_accurate_mul.GetValue();

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -94,7 +94,7 @@ public:
         return *right_eye_disabler;
     }
 
-    void ReportLoadingProgramID(u64 program_ID);
+    void ApplyPerProgramSettings(u64 program_ID);
 
 private:
     void SubmitCmdList(u32 index);


### PR DESCRIPTION
This PR adds two changes:
- Adds Mario & Luigi: Paper Jam to the list of applications that need accurate multiplication forced to prevent major graphical issues.
- Fixes accurate multiplication setting loading:
    - When launching an application from the home menu, the code that forces accurate multiplication was not called, causing applications that need the setting forced not having it forced. The fix is to run the code on GPU right acquire, just before the shader cache is switched. (NOTE: This change allows the accurate multiplication setting to change mid-emulation, which had never been allowed before. It shouldn't have any side effect as it is done right before the shader cache is switched, but if new issues appear then we should investigate this PR as the origin.)
    - When loading a savestate, the logic that enables accurate multiplication was not called at all. This caused the setting to always become disabled as soon as a savestate was loaded no matter what, with no way to re-enable it until the emulation was restarted.