### PR TITLE
Fix visual glitches and custom textures not loading after restoring a savestate

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -894,6 +894,10 @@ void System::serialize(Archive& ar, const unsigned int file_version) {
         timing->UnlockEventQueue();
         cheat_engine.Connect(cheats_pid);
 
+        if (Settings::values.custom_textures) {
+            custom_tex_manager->FindCustomTextures();
+        }
+
         // Re-register gpu callback, because gsp service changed after service_manager got
         // serialized
         auto gsp = service_manager->GetService<Service::GSP::GSP_GPU>("gsp::Gpu");
@@ -902,6 +906,7 @@ void System::serialize(Archive& ar, const unsigned int file_version) {
 
         // Apply per program settings and switch the shader cache to the title running when the
         // savestate was created.
+        // TODO(PabloMK7): Find better way to obtain the program ID.
         const u32 thread_id = gsp->GetActiveClientThreadId();
         if (thread_id != std::numeric_limits<u32>::max()) {
             const auto thread = kernel->GetThreadByID(thread_id);

--- a/src/video_core/pica/dirty_regs.h
+++ b/src/video_core/pica/dirty_regs.h
@@ -16,6 +16,10 @@ union DirtyRegs {
         qwords[reg_id >> 6] |= 1ULL << (reg_id & 0x3f);
     }
 
+    void SetAllDirty() {
+        qwords.fill(UINT64_MAX);
+    }
+
     void Reset() {
         qwords.fill(0ULL);
     }

--- a/src/video_core/pica/pica_core.cpp
+++ b/src/video_core/pica/pica_core.cpp
@@ -35,6 +35,7 @@ PicaCore::PicaCore(Memory::MemorySystem& memory_, std::shared_ptr<DebugContext> 
       geometry_pipeline{regs.internal, gs_unit, gs_setup},
       shader_engine{CreateEngine(Settings::values.use_shader_jit.GetValue())} {
     InitializeRegs();
+    dirty_regs.SetAllDirty();
 
     const auto submit_vertex = [this](const AttributeBuffer& buffer) {
         const auto add_triangle = [this](const OutputVertex& v0, const OutputVertex& v1,

--- a/src/video_core/pica/pica_core.h
+++ b/src/video_core/pica/pica_core.h
@@ -185,6 +185,9 @@ public:
         template <class Archive>
         void serialize(Archive& ar, const u32 file_version) {
             ar& boost::serialization::make_binary_object(this, sizeof(ProcTex));
+            if (Archive::is_loading::value) {
+                table_dirty = TableAllDirty;
+            }
         }
     };
 
@@ -225,6 +228,9 @@ public:
         template <class Archive>
         void serialize(Archive& ar, const u32 file_version) {
             ar& boost::serialization::make_binary_object(this, sizeof(Lighting));
+            if (Archive::is_loading::value) {
+                lut_dirty = LutAllDirty;
+            }
         }
     };
 
@@ -253,6 +259,9 @@ public:
         template <class Archive>
         void serialize(Archive& ar, const u32 file_version) {
             ar& boost::serialization::make_binary_object(this, sizeof(Fog));
+            if (Archive::is_loading::value) {
+                lut_dirty = true;
+            }
         }
     };
 
@@ -285,6 +294,9 @@ private:
         ar & geometry_pipeline;
         ar & primitive_assembler;
         ar & cmd_list;
+        if (Archive::is_loading::value) {
+            dirty_regs.SetAllDirty();
+        }
     }
 
 public:

--- a/src/video_core/pica/shader_setup.h
+++ b/src/video_core/pica/shader_setup.h
@@ -168,6 +168,9 @@ private:
         ar & swizzle_data_hash;
         ar & requires_fixup;
         ar & has_fixup;
+        if (Archive::is_loading::value) {
+            uniforms_dirty = true;
+        }
     }
 };
 


### PR DESCRIPTION
Fixes #1280, #487 

This PR includes two fixes:
- Fix a regression introduced in #1059 (since 2122) that caused graphics to momentarily break just after loading a savestate. This was happening because the PICA regs were not marked as dirty, so the renderer backend was not updating its state.
- Fix a long standing issue where custom textures would revert back to normal after loading a savestate. The fix was completely proposed by @makemeunsee in #1280.

Thanks to @makemeunsee for pointing me out in the right direction with their comments! I actually suspected the regs not being marked as dirty was the issue, but it was confirmed with their fixes!