### PR TITLE
Android:Update language for clarity and use UP instead of DOWN on axis mapping

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/InputBindingSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/InputBindingSetting.kt
@@ -255,7 +255,9 @@ class InputBindingSetting(
         } else {
             buttonCode
         }
-        writeAxisMapping(motionRange.axis, button, axisDir == '-')
+        // use UP (-) to map vertical, but use RIGHT (+) to map horizontal
+        val inverted = if (isHorizontalOrientation()) axisDir == '-' else axisDir == '+'
+        writeAxisMapping(motionRange.axis, button, inverted)
         val uiString = "${device.name}: Axis ${motionRange.axis}" + axisDir
         value = uiString
     }

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -130,8 +130,8 @@
     <string name="controller_dpad_axis_description">Some controllers may not be able to map their D-pad as an axis. If that\'s the case, use the D-Pad (buttons) section.</string>
     <string name="controller_dpad_button">D-Pad (Button)</string>
     <string name="controller_dpad_button_description">Only map the D-pad to these if you\'re facing issues with the D-Pad (Axis) button mappings.</string>
-    <string name="controller_axis_vertical">Up/Down Axis</string>
-    <string name="controller_axis_horizontal">Left/Right Axis</string>
+    <string name="controller_axis_vertical">Vertical Axis</string>
+    <string name="controller_axis_horizontal">Horizontal Axis</string>
     <string name="direction_up">Up</string>
     <string name="direction_down">Down</string>
     <string name="direction_left">Left</string>
@@ -140,8 +140,8 @@
     <string name="input_dialog_description">Press or move an input.</string>
     <string name="input_binding">Input Binding</string>
     <string name="input_binding_description">Press or move an input to bind it to %1$s.</string>
-    <string name="input_binding_description_vertical_axis">Move your joystick down</string>
-    <string name="input_binding_description_horizontal_axis">Move your joystick right</string>
+    <string name="input_binding_description_vertical_axis">Press UP on your joystick.</string>
+    <string name="input_binding_description_horizontal_axis">Press RIGHT on your joystick.</string>
     <string name="button_a" translatable="false">A</string>
     <string name="button_b" translatable="false">B</string>
     <string name="button_select" translatable="false">SELECT</string>


### PR DESCRIPTION
Improvement on axis mapping to make it less likely users will accidentally use the wrong direction when mapping axis on Android, now that the information is saved.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d4a3eb6f-e577-43d3-96cd-8d56185f3ee4" />

