### PR TITLE
[BAD] ci: Only build appimage-wayland for tagged jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,11 +38,14 @@ jobs:
       CCACHE_SLOPPINESS: time_macros
       OS: linux
       TARGET: ${{ matrix.target }}
+      SHOULD_RUN: ${{ (matrix.target != 'appimage-wayland' || github.ref_type == 'tag') }}
     steps:
       - uses: actions/checkout@v4
+        if: ${{ env.SHOULD_RUN == 'true' }}
         with:
           submodules: recursive
       - name: Set up cache
+        if: ${{ env.SHOULD_RUN == 'true' }}
         uses: actions/cache@v4
         with:
           path: ${{ env.CCACHE_DIR }}
@@ -50,18 +53,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.target }}-
       - name: Build
+        if: ${{ env.SHOULD_RUN == 'true' }}
         run: ./.ci/linux.sh
       - name: Move AppImage to artifacts directory
-        if: ${{ contains(matrix.target, 'appimage') }}
+        if: ${{ contains(matrix.target, 'appimage') && env.SHOULD_RUN == 'true' }}
         run: |
           mkdir -p artifacts
           mv build/bundle/*.AppImage artifacts/
       - name: Rename AppImage
-        if: ${{ matrix.target == 'appimage-wayland' }}
+        if: ${{ matrix.target == 'appimage-wayland' && env.SHOULD_RUN == 'true' }}
         run: |
           mv artifacts/azahar.AppImage artifacts/azahar-wayland.AppImage
       - name: Upload
-        if: ${{ contains(matrix.target, 'appimage') }}
+        if: ${{ contains(matrix.target, 'appimage') && env.SHOULD_RUN == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.OS }}-${{ env.TARGET }}


### PR DESCRIPTION
This is to reduce stress on the CI/CD build queue and cache
