### PR TITLE
qt: Rename Per-Application Speed and change shortcut to CTRL+U

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -827,7 +827,7 @@ void GMainWindow::InitializeHotkeys() {
             ToggleFullscreen();
         }
     });
-    connect_shortcut(QStringLiteral("Toggle Per-Application Speed"), [&] {
+    connect_shortcut(QStringLiteral("Toggle Framerate Limit"), [&] {
         if (!hotkey_registry
                  .GetKeySequence(QStringLiteral("Main Window"), QStringLiteral("Toggle Turbo Mode"))
                  .isEmpty()) {

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -88,7 +88,7 @@ const std::array<UISettings::Shortcut, 38> QtConfig::default_hotkeys {{
      {QStringLiteral("Toggle Custom Textures"),   QStringLiteral("Main Window"), {QStringLiteral("F7"),     Qt::ApplicationShortcut}},
      {QStringLiteral("Toggle Filter Bar"),        QStringLiteral("Main Window"), {QStringLiteral("Ctrl+F"), Qt::WindowShortcut}},
      {QStringLiteral("Toggle Frame Advancing"),   QStringLiteral("Main Window"), {QStringLiteral("Ctrl+A"), Qt::ApplicationShortcut}},
-     {QStringLiteral("Toggle Per-Application Speed"),  QStringLiteral("Main Window"), {QStringLiteral("Ctrl+Z"), Qt::ApplicationShortcut}},
+     {QStringLiteral("Toggle Framerate Limit"),   QStringLiteral("Main Window"), {QStringLiteral("Ctrl+U"), Qt::ApplicationShortcut}},
      {QStringLiteral("Toggle Screen Layout"),     QStringLiteral("Main Window"), {QStringLiteral("F10"),    Qt::WindowShortcut}},
      {QStringLiteral("Toggle Status Bar"),        QStringLiteral("Main Window"), {QStringLiteral("Ctrl+S"), Qt::WindowShortcut}},
      {QStringLiteral("Toggle Texture Dumping"),   QStringLiteral("Main Window"), {QStringLiteral(""),       Qt::ApplicationShortcut}},

--- a/src/citra_qt/configuration/configure_hotkeys.cpp
+++ b/src/citra_qt/configuration/configure_hotkeys.cpp
@@ -98,16 +98,16 @@ void ConfigureHotkeys::Configure(QModelIndex index) {
     }
     const auto [key_sequence_used, used_action] = IsUsedKey(key_sequence);
 
-    // Check for turbo/per-game speed conflict. Needed to prevent the user from binding both hotkeys
-    // to the same action. Which cuases problems resetting the frame limit.to the inititla value.
+    // Check for turbo/framerate limit conflict. Needed to prevent the user from binding both
+    // hotkeys to the same action, which causes problems when resetting the frame limit to the
+    // initital value
     const QString current_action =
         model->data(model->index(index.row(), 0, index.parent())).toString();
     const bool is_turbo = current_action == tr("Toggle Turbo Mode");
-    const bool is_per_game = current_action == tr("Toggle Per-Application Speed");
+    const bool is_frame_limit = current_action == tr("Toggle Framerate Limit");
 
-    if (is_turbo || is_per_game) {
-        QString other_action =
-            is_turbo ? tr("Toggle Per-Application Speed") : tr("Toggle Turbo Mode");
+    if (is_turbo || is_frame_limit) {
+        QString other_action = is_turbo ? tr("Toggle Framerate Limit") : tr("Toggle Turbo Mode");
         QKeySequence other_sequence;
 
         for (int r = 0; r < model->rowCount(); ++r) {
@@ -124,7 +124,7 @@ void ConfigureHotkeys::Configure(QModelIndex index) {
         // Show warning if either hotkey is already set
         if (!key_sequence.isEmpty() && !other_sequence.isEmpty()) {
             QMessageBox::warning(this, tr("Conflicting Key Sequence"),
-                                 tr("The per-application speed and turbo speed hotkeys cannot be "
+                                 tr("The frame limit and turbo speed hotkeys cannot be "
                                     "bound at the same time."));
             return;
         }


### PR DESCRIPTION
Rename "Toggle Per-Application Speed" shortcut option to "Toggle Framerate Limit", in order to more accurately describe what it does and change shortcut to CTRL/CMD+U. Matches yuzu and its forks, and similar is common among other emulators