### PR TITLE
video_core: vulkan: Only store hashes in shader cache maps

### DIFF
--- a/src/common/hash.h
+++ b/src/common/hash.h
@@ -99,4 +99,38 @@ struct HashableStruct {
     }
 };
 
+/// Helper struct that provides a hashable string with basic string API
+template <typename Hasher = HashAlgo64::XXH3>
+struct HashableString {
+    std::string value;
+
+    HashableString() = default;
+    HashableString(const std::string& s) : value(s) {}
+    HashableString(std::string&& s) noexcept : value(std::move(s)) {}
+
+    std::size_t Hash() const noexcept {
+        return ComputeHash64<Hasher>(value.data(), value.size());
+    }
+
+    bool empty() const noexcept {
+        return value.empty();
+    }
+
+    std::size_t size() const noexcept {
+        return value.size();
+    }
+
+    const char* data() const noexcept {
+        return value.data();
+    }
+
+    operator std::string_view() const noexcept {
+        return value;
+    }
+
+    operator std::string&&() && noexcept {
+        return std::move(value);
+    }
+};
+
 } // namespace Common

--- a/src/common/hash.h
+++ b/src/common/hash.h
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <cstring>
+#include <string>
 #include <xxhash.h>
 #include "cityhash.h"
 #include "common/common_types.h"

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.h
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.h
@@ -135,10 +135,11 @@ private:
 
     std::array<u64, MAX_SHADER_STAGES> shader_hashes;
     std::array<Shader*, MAX_SHADER_STAGES> current_shaders;
-    std::unordered_map<Pica::Shader::Generator::PicaVSConfig, Shader*> programmable_vertex_map;
-    std::unordered_map<std::string, Shader> programmable_vertex_cache;
-    std::unordered_map<Pica::Shader::Generator::PicaFixedGSConfig, Shader> fixed_geometry_shaders;
-    std::unordered_map<Pica::Shader::FSConfig, Shader> fragment_shaders;
+
+    std::unordered_map<size_t, Shader*> programmable_vertex_map;
+    std::unordered_map<size_t, Shader> programmable_vertex_cache;
+    std::unordered_map<size_t, Shader> fixed_geometry_shaders;
+    std::unordered_map<size_t, Shader> fragment_shaders;
     Shader trivial_vertex_shader;
 
     u64 current_program_id{0};


### PR DESCRIPTION
This changes how the shaders are kept track of in the vulkan renderer. Instead of using the whole object as a key, only its hash is used. This way we prevent a copy of the object being stored in memory, which is never actually used.

Slight memory usage reduction while using the vulkan renderer.