### PR TITLE
qt: Fixed some setting tooltips not having automatic line breaks

### DIFF
--- a/src/citra_qt/configuration/configure_audio.ui
+++ b/src/citra_qt/configuration/configure_audio.ui
@@ -88,7 +88,7 @@
       <item>
        <widget class="QCheckBox" name="toggle_audio_stretching">
         <property name="toolTip">
-         <string>This post-processing effect adjusts audio speed to match emulation speed and helps prevent audio stutter. This however increases audio latency.</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This post-processing effect adjusts audio speed to match emulation speed and helps prevent audio stutter. This however increases audio latency.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
          <string>Enable audio stretching</string>
@@ -98,7 +98,7 @@
       <item>
        <widget class="QCheckBox" name="toggle_realtime_audio">
         <property name="toolTip">
-         <string>Scales audio playback speed to account for drops in emulation framerate. This means that audio will play at full speed even while the application framerate is low. May cause audio desync issues.</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Scales audio playback speed to account for drops in emulation framerate. This means that audio will play at full speed even while the application framerate is low. May cause audio desync issues.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
          <string>Enable realtime audio</string>

--- a/src/citra_qt/configuration/configure_camera.ui
+++ b/src/citra_qt/configuration/configure_camera.ui
@@ -127,7 +127,7 @@
         <item>
          <widget class="QLabel" name="image_source_label">
           <property name="toolTip">
-           <string>Select where the image of the emulated camera comes from. It may be an image or a real camera.</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select where the image of the emulated camera comes from. It may be an image or a real camera.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="text">
            <string>Camera Image Source</string>
@@ -137,7 +137,7 @@
         <item>
          <widget class="QComboBox" name="image_source">
           <property name="toolTip">
-           <string>Select where the image of the emulated camera comes from. It may be an image or a real camera.</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select where the image of the emulated camera comes from. It may be an image or a real camera.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <item>
            <property name="text">

--- a/src/citra_qt/configuration/configure_graphics.ui
+++ b/src/citra_qt/configuration/configure_graphics.ui
@@ -310,7 +310,7 @@
       <item>
        <widget class="QCheckBox" name="toggle_vsync">
         <property name="toolTip">
-         <string>VSync prevents the screen from tearing, but some graphics cards have lower performance with VSync enabled. Keep it enabled if you don't notice a performance difference.</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;VSync prevents the screen from tearing, but some graphics cards have lower performance with VSync enabled. Keep it enabled if you don't notice a performance difference.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
          <string>Enable VSync</string>

--- a/src/citra_qt/configuration/configure_storage.ui
+++ b/src/citra_qt/configuration/configure_storage.ui
@@ -187,7 +187,7 @@
              <string>Compress installed CIA content</string>
             </property>
             <property name="toolTip">
-              <string>Compresses the content of CIA files when installed to the emulated SD card. Only affects CIA content which is installed while the setting is enabled.</string>
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Compresses the content of CIA files when installed to the emulated SD card. Only affects CIA content which is installed while the setting is enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Without the HTML tags included in this PR and previously present for other setting tooltips, Qt doesn't automatically add any line breaks to the setting tooltip. This resulted in tooltips which are very long and unpleasant to read.