### PR TITLE
Add "Enable display refresh rate detection" setting on desktop

### DIFF
--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -698,6 +698,7 @@ void QtConfig::ReadRendererValues() {
     ReadGlobalSetting(Settings::values.shaders_accurate_mul);
     ReadGlobalSetting(Settings::values.use_disk_shader_cache);
     ReadGlobalSetting(Settings::values.use_vsync);
+    ReadGlobalSetting(Settings::values.use_display_refresh_rate_detection);
     ReadGlobalSetting(Settings::values.resolution_factor);
     ReadGlobalSetting(Settings::values.frame_limit);
     ReadGlobalSetting(Settings::values.turbo_limit);
@@ -1238,6 +1239,7 @@ void QtConfig::SaveRendererValues() {
     WriteGlobalSetting(Settings::values.shaders_accurate_mul);
     WriteGlobalSetting(Settings::values.use_disk_shader_cache);
     WriteGlobalSetting(Settings::values.use_vsync);
+    WriteGlobalSetting(Settings::values.use_display_refresh_rate_detection);
     WriteGlobalSetting(Settings::values.resolution_factor);
     WriteGlobalSetting(Settings::values.frame_limit);
     WriteGlobalSetting(Settings::values.turbo_limit);

--- a/src/citra_qt/configuration/configure_graphics.cpp
+++ b/src/citra_qt/configuration/configure_graphics.cpp
@@ -21,9 +21,10 @@ ConfigureGraphics::ConfigureGraphics(QString gl_renderer, std::span<const QStrin
 
     ui->graphics_api_combo->setEnabled(!is_powered_on);
     ui->physical_device_combo->setEnabled(!is_powered_on);
+    ui->toggle_accurate_mul->setEnabled(!is_powered_on);
     ui->toggle_async_shaders->setEnabled(!is_powered_on);
     ui->toggle_async_present->setEnabled(!is_powered_on);
-    ui->toggle_accurate_mul->setEnabled(!is_powered_on);
+    ui->toggle_display_refresh_rate_detection->setEnabled(!is_powered_on);
     // Set the index to -1 to ensure the below lambda is called with setCurrentIndex
     ui->graphics_api_combo->setCurrentIndex(-1);
 
@@ -150,6 +151,8 @@ void ConfigureGraphics::SetConfiguration() {
 
     if (Settings::IsConfiguringGlobal()) {
         ui->toggle_shader_jit->setChecked(Settings::values.use_shader_jit.GetValue());
+        ui->toggle_display_refresh_rate_detection->setChecked(
+            Settings::values.use_display_refresh_rate_detection.GetValue());
     }
 }
 
@@ -182,6 +185,8 @@ void ConfigureGraphics::ApplyConfiguration() {
 
     if (Settings::IsConfiguringGlobal()) {
         Settings::values.use_shader_jit = ui->toggle_shader_jit->isChecked();
+        Settings::values.use_display_refresh_rate_detection =
+            ui->toggle_display_refresh_rate_detection->isChecked();
     }
 }
 
@@ -216,6 +221,7 @@ void ConfigureGraphics::SetupPerGameUI() {
     });
 
     ui->toggle_shader_jit->setVisible(false);
+    ui->toggle_display_refresh_rate_detection->setVisible(false);
 
     ConfigurationShared::SetColoredComboBox(
         ui->graphics_api_combo, ui->graphics_api_group,

--- a/src/citra_qt/configuration/configure_graphics.h
+++ b/src/citra_qt/configuration/configure_graphics.h
@@ -39,6 +39,7 @@ private:
     ConfigurationShared::CheckState shaders_accurate_mul;
     ConfigurationShared::CheckState use_disk_shader_cache;
     ConfigurationShared::CheckState use_vsync;
+    ConfigurationShared::CheckState use_display_refresh_rate_detection;
     ConfigurationShared::CheckState async_shader_compilation;
     ConfigurationShared::CheckState async_presentation;
     ConfigurationShared::CheckState spirv_shader_gen;

--- a/src/citra_qt/configuration/configure_graphics.ui
+++ b/src/citra_qt/configuration/configure_graphics.ui
@@ -318,6 +318,16 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="toggle_display_refresh_rate_detection">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When enabled, this setting detects when the refresh rate of the screen is below that of the 3DS, and when it is, disables VSync automatically to avoid emulation speed being forced below 100%.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Enable display refresh rate detection</string>
+        </property>
+       </widget>
+      </item>
+      <item>
         <widget class="QWidget" name="delay_render_layout" native="true">
           <layout class="QHBoxLayout" name="delay_render_layout_inner">
             <property name="leftMargin">

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -520,6 +520,8 @@ struct Values {
 #else
     SwitchableSetting<bool> use_vsync{true, "use_vsync"};
 #endif
+    SwitchableSetting<bool> use_display_refresh_rate_detection{
+        true, "use_display_refresh_rate_detection"};
     Setting<bool> use_shader_jit{true, "use_shader_jit"};
     SwitchableSetting<u32, true> resolution_factor{1, 0, 10, "resolution_factor"};
     SwitchableSetting<double, true> frame_limit{100, 0, 1000, "frame_limit"};

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -60,6 +60,10 @@ constexpr static std::array<vk::DescriptorSetLayoutBinding, 1> PRESENT_BINDINGS 
 
 namespace {
 static bool IsLowRefreshRate() {
+    if (!Settings::values.use_display_refresh_rate_detection) {
+        LOG_INFO(Render_Vulkan, "Refresh rate detection is currently disabled via settings");
+        return false;
+    }
 #if defined(__APPLE__) || defined(ENABLE_SDL2)
 #ifdef __APPLE__
     // Apple's low power mode sometimes limits applications to 30fps without changing the refresh


### PR DESCRIPTION
Closes #1509

The setting is enabled by default, which reflects the current behaviour without this PR, but this detection can now be disabled by unchecking the setting as a workaround for edge cases where this kind of behaviour isn't desired.

This setting could easily be added on Android as well, but as far as I know there is zero use-case for a setting like this on an Android device, so it hasn't been included in this PR.