### PR TITLE
common: Add NATVIS to BitField class for better VS debugging

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -68,6 +68,7 @@ add_library(citra_common STATIC
     detached_tasks.cpp
     detached_tasks.h
     bit_field.h
+    bit_field.natvis
     bit_set.h
     bounded_threadsafe_queue.h
     cityhash.cpp

--- a/src/common/bit_field.natvis
+++ b/src/common/bit_field.natvis
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright Citra Emulator Project / Azahar Emulator Project -->
+<!-- Licensed under GPLv2 or any later version -->
+<!-- Refer to the license.txt file included. -->
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="BitField&lt;*,*,*,*&gt;">
+    <DisplayString>
+      {((unsigned long long)storage &gt;&gt; $T1) &amp; (((unsigned long long)1 &lt;&lt; $T2) - 1)}
+    </DisplayString>
+    <Expand>
+      <Item Name="UnsignedValue">
+        ((unsigned long long)storage &gt;&gt; $T1) &amp; (((unsigned long long)1 &lt;&lt; $T2) - 1)
+      </Item>
+      <Item Name="SignedValue">
+        (long long)((((unsigned long long)storage &gt;&gt; $T1) &amp; ((1ULL &lt;&lt; $T2)-1)) &amp; (1ULL &lt;&lt; ($T2-1))
+        ? -((1ULL &lt;&lt; $T2) - (((unsigned long long)storage &gt;&gt; $T1) &amp; ((1ULL &lt;&lt; $T2)-1)))
+        : (((unsigned long long)storage &gt;&gt; $T1) &amp; ((1ULL &lt;&lt; $T2)-1)))
+      </Item>
+      <Item Name="Position">
+        $T1
+      </Item>
+      <Item Name="Bits">
+        $T2
+      </Item>
+      <Item Name="RawStorage">storage</Item>
+    </Expand>
+  </Type>
+</AutoVisualizer>


### PR DESCRIPTION
This adds a `.natvis` file that tells Visual Studio how to display `BitField` objects while debugging on MSVC builds. Other build environments will just ignore the file.

Previously, all `BitField` objects in unions would just display as `{storage=value}` with the same value, without considering the bit shift and mask. Now, they display their intended value, both signed and unsigned, as well as the bit position and mask:

<img width="405" height="423" alt="image" src="https://github.com/user-attachments/assets/f6026027-a14f-45df-9342-e50a61edaca8" />

This makes debugging easier in Visual Studio, whenever `BitField` objects are involved.

