### PR TITLE
Windows: Fix game shortcut character corruption

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -1918,7 +1918,9 @@ bool GMainWindow::CreateShortcutLink(const std::filesystem::path& shortcut_path,
         LOG_ERROR(Frontend, "Failed to get IPersistFile interface");
         return false;
     }
-    hres = persist_file->Save(std::filesystem::path{shortcut_path / (name + ".lnk")}.c_str(), TRUE);
+    hres = persist_file->Save(
+        std::filesystem::path{shortcut_path / (Common::UTF8ToUTF16W(name) + L".lnk")}.c_str(),
+        TRUE);
     if (FAILED(hres)) {
         LOG_ERROR(Frontend, "Failed to save shortcut");
         return false;


### PR DESCRIPTION
When using the game shortcut creation feature on Windows, special characters like the é in Pokémon would end up corrupted in the resulting shortcut. Additionally, Japanese names made the creation fail entirely. This fixes that by ensuring that names are properly converted to Windows filesystem's expected UTF16 format