### PR TITLE
common/cpu_detect: Remove FMA4 detection

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -396,7 +396,7 @@ GMainWindow::GMainWindow(Core::System& system_)
         } else if (caps.avx2) {
             cpu_string += '2';
         }
-        if (caps.fma || caps.fma4) {
+        if (caps.fma) {
             cpu_string += " | FMA";
         }
     }

--- a/src/common/x64/cpu_detect.cpp
+++ b/src/common/x64/cpu_detect.cpp
@@ -1,7 +1,10 @@
-// Copyright 2013 Dolphin Emulator Project / 2015 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+// Copyright 2013 Dolphin Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
 #include "common/arch.h"
 #if CITRA_ARCH(x86_64)
 
@@ -129,13 +132,6 @@ static CPUCaps Detect() {
         std::memcpy(caps.cpu_string + 16, cpu_id, sizeof(cpu_id));
         __cpuid(cpu_id, 0x80000004);
         std::memcpy(caps.cpu_string + 32, cpu_id, sizeof(cpu_id));
-    }
-
-    if (max_ex_fn >= 0x80000001) {
-        // Check for more features
-        __cpuid(cpu_id, 0x80000001);
-        if ((cpu_id[2] >> 16) & 1)
-            caps.fma4 = true;
     }
 
     return caps;

--- a/src/common/x64/cpu_detect.h
+++ b/src/common/x64/cpu_detect.h
@@ -1,7 +1,10 @@
-// Copyright 2013 Dolphin Emulator Project / 2015 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+// Copyright 2013 Dolphin Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
 #pragma once
 
 #include "common/arch.h"
@@ -25,7 +28,6 @@ struct CPUCaps {
     bool bmi1;
     bool bmi2;
     bool fma;
-    bool fma4;
     bool aes;
 };
 


### PR DESCRIPTION
Removes detection and logging for FMA4, an AMD exclusive extension that is no longer supported on newer processors and was unused here
