### PR TITLE
video_core: Fixes to vulkan disk shader cache

### DIFF
--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -302,6 +302,7 @@ public:
 
     virtual bool Close();
 
+    /// Returns the amount of T items read
     template <typename T>
     std::size_t ReadArray(T* data, std::size_t length) {
         static_assert(std::is_trivially_copyable_v<T>,
@@ -314,16 +315,18 @@ public:
         return items_read;
     }
 
+    /// Returns the amount of bytes read
     template <typename T>
     std::size_t ReadAtArray(T* data, std::size_t length, std::size_t offset) {
         static_assert(std::is_trivially_copyable_v<T>,
                       "Given array does not consist of trivially copyable objects");
 
-        std::size_t items_read = ReadAtImpl(data, length, sizeof(T), offset);
-        if (items_read != length)
+        const size_t bytes = length * sizeof(T);
+        std::size_t size_read = ReadAtImpl(data, bytes, offset);
+        if (size_read != bytes)
             m_good = false;
 
-        return items_read;
+        return size_read;
     }
 
     template <typename T>
@@ -466,8 +469,7 @@ protected:
     virtual bool Open();
 
     virtual std::size_t ReadImpl(void* data, std::size_t length, std::size_t data_size);
-    virtual std::size_t ReadAtImpl(void* data, std::size_t length, std::size_t data_size,
-                                   std::size_t offset);
+    virtual std::size_t ReadAtImpl(void* data, std::size_t byte_count, std::size_t offset);
     virtual std::size_t WriteImpl(const void* data, std::size_t length, std::size_t data_size);
 
     virtual bool SeekImpl(s64 off, int origin);
@@ -520,8 +522,7 @@ private:
     std::unique_ptr<CryptoIOFileImpl> impl;
 
     std::size_t ReadImpl(void* data, std::size_t length, std::size_t data_size) override;
-    std::size_t ReadAtImpl(void* data, std::size_t length, std::size_t data_size,
-                           std::size_t offset) override;
+    std::size_t ReadAtImpl(void* data, std::size_t byte_count, std::size_t offset) override;
     std::size_t WriteImpl(const void* data, std::size_t length, std::size_t data_size) override;
 
     bool SeekImpl(s64 off, int origin) override;

--- a/src/common/zstd_compression.cpp
+++ b/src/common/zstd_compression.cpp
@@ -357,8 +357,7 @@ std::size_t Z3DSWriteIOFile::ReadImpl(void* data, std::size_t length, std::size_
     return 0;
 }
 
-std::size_t Z3DSWriteIOFile::ReadAtImpl(void* data, std::size_t length, std::size_t data_size,
-                                        std::size_t offset) {
+std::size_t Z3DSWriteIOFile::ReadAtImpl(void* data, std::size_t byte_count, std::size_t offset) {
     // Stubbed
     UNIMPLEMENTED();
     return 0;
@@ -619,12 +618,12 @@ bool Z3DSReadIOFile::Open() {
 }
 
 std::size_t Z3DSReadIOFile::ReadImpl(void* data, std::size_t length, std::size_t data_size) {
-    return impl->Read(data, length * data_size);
+    size_t res = impl->Read(data, length * data_size);
+    return res == std::numeric_limits<size_t>::max() ? res : (res / data_size);
 }
 
-std::size_t Z3DSReadIOFile::ReadAtImpl(void* data, std::size_t length, std::size_t data_size,
-                                       std::size_t offset) {
-    return impl->ReadAt(data, length * data_size, offset);
+std::size_t Z3DSReadIOFile::ReadAtImpl(void* data, std::size_t byte_count, std::size_t offset) {
+    return impl->ReadAt(data, byte_count, offset);
 }
 
 std::size_t Z3DSReadIOFile::WriteImpl(const void* data, std::size_t length, std::size_t data_size) {

--- a/src/common/zstd_compression.h
+++ b/src/common/zstd_compression.h
@@ -183,8 +183,7 @@ private:
     bool Open() override;
 
     std::size_t ReadImpl(void* data, std::size_t length, std::size_t data_size) override;
-    std::size_t ReadAtImpl(void* data, std::size_t length, std::size_t data_size,
-                           std::size_t offset) override;
+    std::size_t ReadAtImpl(void* data, std::size_t byte_count, std::size_t offset) override;
     std::size_t WriteImpl(const void* data, std::size_t length, std::size_t data_size) override;
 
     bool SeekImpl(s64 off, int origin) override;
@@ -250,8 +249,7 @@ private:
     bool Open() override;
 
     std::size_t ReadImpl(void* data, std::size_t length, std::size_t data_size) override;
-    std::size_t ReadAtImpl(void* data, std::size_t length, std::size_t data_size,
-                           std::size_t offset) override;
+    std::size_t ReadAtImpl(void* data, std::size_t byte_count, std::size_t offset) override;
     std::size_t WriteImpl(const void* data, std::size_t length, std::size_t data_size) override;
 
     bool SeekImpl(s64 off, int origin) override;

--- a/src/core/file_sys/ncch_container.cpp
+++ b/src/core/file_sys/ncch_container.cpp
@@ -168,7 +168,6 @@ Loader::ResultStatus NCCHContainer::LoadHeader() {
             ASSERT(Loader::MakeMagic('N', 'C', 'S', 'D') == ncsd_header.magic);
             ASSERT(partition < 8);
             ncch_offset = ncsd_header.partitions[partition].offset * kBlockSize;
-            LOG_ERROR(Service_FS, "{}", ncch_offset);
             file->Seek(ncch_offset, SEEK_SET);
             file->ReadBytes(&ncch_header, sizeof(NCCH_Header));
         }

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.h
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.h
@@ -58,15 +58,13 @@ public:
         offsets[binding] = offset;
     }
 
-    /// Loads the pipeline cache stored to disk
-    void LoadPipelineDiskCache(const std::atomic_bool& stop_loading = std::atomic_bool{false},
-                               const VideoCore::DiskResourceLoadCallback& callback = {});
+    /// Loads the driver pipeline cache and the disk shader cache
+    void LoadCache(const std::atomic_bool& stop_loading = std::atomic_bool{false},
+                   const VideoCore::DiskResourceLoadCallback& callback = {});
 
-    void LoadDiskCache(const std::atomic_bool& stop_loading = std::atomic_bool{false},
-                       const VideoCore::DiskResourceLoadCallback& callback = {});
-
-    /// Stores the generated pipeline cache to disk
-    void SaveDiskCache();
+    /// Switches the driver pipeline cache and the shader disk cache to the specified title
+    void SwitchCache(u64 title_id, const std::atomic_bool& stop_loading = std::atomic_bool{false},
+                     const VideoCore::DiskResourceLoadCallback& callback = {});
 
     /// Binds a pipeline using the provided information
     bool BindPipeline(PipelineInfo& info, bool wait_built = false);
@@ -90,11 +88,6 @@ public:
     /// Binds a fragment shader generated from PICA state
     void UseFragmentShader(const Pica::RegsInternal& regs, const Pica::Shader::UserConfig& user);
 
-    /// Switches the shader disk cache to the specified title
-    void SwitchPipelineCache(u64 title_id,
-                             const std::atomic_bool& stop_loading = std::atomic_bool{false},
-                             const VideoCore::DiskResourceLoadCallback& callback = {});
-
     /// Gets the current program ID
     u64 GetProgramID() const {
         return current_program_id;
@@ -110,6 +103,17 @@ public:
 
 private:
     friend ShaderDiskCache;
+
+    /// Loads the driver pipeline cache
+    void LoadDriverPipelineDiskCache(const std::atomic_bool& stop_loading = std::atomic_bool{false},
+                                     const VideoCore::DiskResourceLoadCallback& callback = {});
+
+    /// Stores the generated pipeline cache
+    void SaveDriverPipelineDiskCache();
+
+    /// Loads the shader disk cache
+    void LoadDiskCache(const std::atomic_bool& stop_loading = std::atomic_bool{false},
+                       const VideoCore::DiskResourceLoadCallback& callback = {});
 
     /// Switches the disk cache at runtime to use a different title ID
     void SwitchDiskCache(u64 title_id, const std::atomic_bool& stop_loading,
@@ -140,7 +144,7 @@ private:
     DescriptorUpdateQueue& update_queue;
 
     Pica::Shader::Profile profile{};
-    vk::UniquePipelineCache pipeline_cache;
+    vk::UniquePipelineCache driver_pipeline_cache;
     vk::UniquePipelineLayout pipeline_layout;
     std::size_t num_worker_threads;
     Common::ThreadWorker workers;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -152,10 +152,13 @@ void RasterizerVulkan::LoadDefaultDiskResources(
         program_id = 0;
     }
 
+    if (callback) {
+        callback(VideoCore::LoadCallbackStage::Prepare, 0, 0, "");
+    }
+
     pipeline_cache.SetProgramID(program_id);
     pipeline_cache.SetAccurateMul(accurate_mul);
-    pipeline_cache.LoadPipelineDiskCache(stop_loading, callback);
-    pipeline_cache.LoadDiskCache(stop_loading, callback);
+    pipeline_cache.LoadCache(stop_loading, callback);
 
     if (callback) {
         callback(VideoCore::LoadCallbackStage::Complete, 0, 0, "");
@@ -985,8 +988,17 @@ void RasterizerVulkan::UploadUniforms(bool accelerate_draw) {
 
 void RasterizerVulkan::SwitchDiskResources(u64 title_id) {
     std::atomic_bool stop_loading = false;
+
+    if (switch_disk_resources_callback) {
+        switch_disk_resources_callback(VideoCore::LoadCallbackStage::Prepare, 0, 0, "");
+    }
+
     pipeline_cache.SetAccurateMul(accurate_mul);
-    pipeline_cache.SwitchPipelineCache(title_id, stop_loading, switch_disk_resources_callback);
+    pipeline_cache.SwitchCache(title_id, stop_loading, switch_disk_resources_callback);
+
+    if (switch_disk_resources_callback) {
+        switch_disk_resources_callback(VideoCore::LoadCallbackStage::Complete, 0, 0, "");
+    }
 }
 
 } // namespace Vulkan


### PR DESCRIPTION
Fixed the following:

- Made the vulkan shader cache respect the "use disk shader cache" option.
- Fixed some logic errors that could cause the cache files to break.
- Refactored some code related to disk cache handling.
- Fixed a long standing issue in FileUtil where ReadAtArray would incorrectly set the `m_good` flag to false.
- Removed a debug log in `ncch_container.cpp` that made it into the master branch.

The first 3 points can be considered an amendments to #1725 