### PR TITLE
Fix segfault when resetting default settings

### DIFF
--- a/src/citra_qt/configuration/configure_general.cpp
+++ b/src/citra_qt/configuration/configure_general.cpp
@@ -163,7 +163,7 @@ void ConfigureGeneral::ResetDefaults() {
 
     FileUtil::Delete(FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) + "qt-config.ini");
     FileUtil::DeleteDirRecursively(FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) + "custom");
-    std::exit(0);
+    qApp->quit();
 }
 
 void ConfigureGeneral::ApplyConfiguration() {


### PR DESCRIPTION
I noticed that the app segfaults when resetting the default settings:
[Screencast_20260217_084934.webm](https://github.com/user-attachments/assets/92c1fd77-32a5-4983-9fb7-9c12483f2d44)
