### PR TITLE
common/cpu_detect: Remove SSE/SSE2 detection

### DIFF
--- a/src/common/x64/cpu_detect.cpp
+++ b/src/common/x64/cpu_detect.cpp
@@ -80,10 +80,6 @@ static CPUCaps Detect() {
     if (max_std_fn >= 1) {
         __cpuid(cpu_id, 0x00000001);
 
-        if ((cpu_id[3] >> 25) & 1)
-            caps.sse = true;
-        if ((cpu_id[3] >> 26) & 1)
-            caps.sse2 = true;
         if ((cpu_id[2]) & 1)
             caps.sse3 = true;
         if ((cpu_id[2] >> 9) & 1)

--- a/src/common/x64/cpu_detect.h
+++ b/src/common/x64/cpu_detect.h
@@ -16,8 +16,6 @@ namespace Common {
 struct CPUCaps {
     char cpu_string[0x21];
     char brand_string[0x41];
-    bool sse;
-    bool sse2;
     bool sse3;
     bool ssse3;
     bool sse4_1;


### PR DESCRIPTION
Also remove detection for the SSE/SSE2 extensions, as they are unused and always true for x64 (they come from a time where Dolphin had x32 builds)