### PR TITLE
Allow ABI filter override via abiFilters Gradle property

### DIFF
--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -20,7 +20,9 @@ plugins {
  * next 680 years.
  */
 val autoVersion = (((System.currentTimeMillis() / 1000) - 1451606400) / 10).toInt()
-val abiFilter = listOf("arm64-v8a", "x86_64")
+val abiFilter = (project.findProperty("abiFilters") as String?)
+    ?.split(",")?.map { it.trim() }
+    ?: listOf("arm64-v8a", "x86_64")
 
 val downloadedJniLibsPath = "${layout.buildDirectory.get().asFile.path}/downloadedJniLibs"
 


### PR DESCRIPTION
edit: apparently I don't know how to set the target to my own fork. please disregard

---

> [!note]
> merging for my fork first, testing in other branches. might make a PR against origin after tested and proven
---

## Summary

- Make the Android ABI filter configurable via a Gradle property, allowing developers to build for a single architecture during local development instead of compiling for all supported ABIs

### Usage

Build for a specific ABI by passing -PabiFilters:

```
./gradlew assembleVanillaRelWithDebInfo -PabiFilters=arm64-v8a
```

Multiple ABIs can be comma-separated:

```
./gradlew assembleVanillaRelWithDebInfo -PabiFilters=arm64-v8a,x86_64
```

Omitting the property preserves the existing default behavior (arm64-v8a, x86_64).

Invalid ABI values fail fast with a clear error:

```
Invalid ABI filter(s): [armv7]. Valid values: [armeabi-v7a, arm64-v8a, x86, x86_64]
```

### Why

Building both arm64-v8a and x86_64 native libraries is the most expensive part of the Android build. When deploying to a physical device during development, only one ABI is needed. This cuts native compilation roughly in half for local iteration.
