### PR TITLE
Add justfile for Android builds and configurable ABI filtering in Gradle

### DIFF
--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -20,7 +20,16 @@ plugins {
  * next 680 years.
  */
 val autoVersion = (((System.currentTimeMillis() / 1000) - 1451606400) / 10).toInt()
-val abiFilter = listOf("arm64-v8a", "x86_64")
+val validAbis = setOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
+val abiFilter =
+    (project.findProperty("abiFilters") as String?)
+        ?.split(",")
+        ?.map { it.trim() }
+        ?.also { filters ->
+            val invalid = filters.filterNot { it in validAbis }
+            require(invalid.isEmpty()) { "Invalid ABI filter(s): $invalid. Valid values: $validAbis" }
+        }
+        ?: listOf("arm64-v8a", "x86_64")
 
 val downloadedJniLibsPath = "${layout.buildDirectory.get().asFile.path}/downloadedJniLibs"
 

--- a/src/android/justfile
+++ b/src/android/justfile
@@ -1,0 +1,57 @@
+# Default build: vanilla flavor, relWithDebInfo type (project default)
+apk_path := "app/build/outputs/apk/vanilla/relWithDebInfo/app-vanilla-relWithDebInfo.apk"
+debug_apk_path := "app/build/outputs/apk/vanilla/debug/app-vanilla-debug.apk"
+
+# Detect connected device ABI for single-arch builds
+device_abi := `adb shell getprop ro.product.cpu.abi 2>/dev/null || true`
+abi_filter := if device_abi != "" { "-PabiFilters=" + device_abi } else { "" }
+
+# List available commands
+default:
+    @just --list
+
+alias help := default
+
+# Build targeting connected device's ABI when available, full build otherwise
+[group('build')]
+build:
+    ./gradlew assembleVanillaRelWithDebInfo {{ abi_filter }}
+
+# Debug build targeting connected device's ABI when available
+[group('build')]
+build-debug:
+    ./gradlew assembleVanillaDebug {{ abi_filter }}
+
+# Build and copy timestamped APK to out/
+[group('build')]
+generate-apk: build
+    #!/usr/bin/env sh
+    mkdir -p out
+    timestamp=$(date +%Y%m%d-%H%M)
+    cp {{ apk_path }} out/azahar-${timestamp}.apk
+    echo "APK copied to out/azahar-${timestamp}.apk"
+
+# Build and install to connected device
+[group('device')]
+install: build
+    adb install -r -t {{ apk_path }}
+
+# Build and install debug variant to connected device
+[group('device')]
+install-debug: build-debug
+    adb install -r -t {{ debug_apk_path }}
+
+# Stop gradle daemons
+[group('maintenance')]
+stop:
+    ./gradlew --stop
+
+# Remove all build artifacts
+[group('maintenance')]
+clean:
+    ./gradlew clean
+
+# Full refresh: stop daemons, clean build artifacts, rebuild from scratch
+[group('maintenance')]
+refresh: stop clean
+    ./gradlew assembleVanillaRelWithDebInfo


### PR DESCRIPTION
## Summary

- Make the Android ABI filter configurable via a Gradle property, allowing developers to build for a single architecture during local development instead of compiling for all supported ABIs
- Add a justfile with grouped build, device, and maintenance commands that auto-detects the connected device's ABI for single-arch builds

### Usage

Build for a specific ABI by passing -PabiFilters:

```
./gradlew assembleVanillaRelWithDebInfo -PabiFilters=arm64-v8a
```

Multiple ABIs can be comma-separated:

```
./gradlew assembleVanillaRelWithDebInfo -PabiFilters=arm64-v8a,x86_64
```

Omitting the property preserves the existing default behavior (arm64-v8a, x86_64).

Invalid ABI values fail fast with a clear error:

```
Invalid ABI filter(s): [armv7]. Valid values: [armeabi-v7a, arm64-v8a, x86, x86_64]
```

The justfile wraps these commands with device ABI auto-detection. Run `just` to see available commands:

```
❯ just
Available recipes:
    default       # List available commands [alias: help]

    [build]
    build         # Build targeting connected device's ABI when available, full build otherwise
    build-debug   # Debug build targeting connected device's ABI when available
    generate-apk  # Build and copy timestamped APK to out/

    [device]
    install       # Build and install to connected device
    install-debug # Build and install debug variant to connected device

    [maintenance]
    clean         # Remove all build artifacts
    refresh       # Full refresh: stop daemons, clean build artifacts, rebuild from scratch
    stop          # Stop gradle daemons
```

### Why

Building both arm64-v8a and x86_64 native libraries is the most expensive part of the Android build. When deploying to a physical device during development, only one ABI is needed. This cuts native compilation roughly in half for local iteration.