### PR TITLE
Qt: Improve update checker system to prevent downgrades #1749

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -189,7 +189,12 @@ static bool ShouldCheckForPrereleaseUpdates() {
 
 static int GetMajorVersion(const std::string& version) {
     size_t dot = version.find('.');
-    return std::stoi(version.substr(0, dot));
+    try {
+        return std::stoi(version.substr(0, dot));
+    } catch (...) {
+        return 0;
+    }
+    
 }
 #endif
 

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -180,7 +180,7 @@ bool IsPrereleaseBuild() {
 }
 
 #ifdef ENABLE_QT_UPDATE_CHECKER
-bool ShouldCheckForPrereleaseUpdates() {
+static bool ShouldCheckForPrereleaseUpdates() {
     const bool update_channel = UISettings::values.update_check_channel.GetValue();
     const bool using_prerelease_channel =
         (update_channel == UISettings::UpdateCheckChannels::PRERELEASE);
@@ -426,15 +426,10 @@ GMainWindow::GMainWindow(Core::System& system_)
             const std::optional<std::string> latest_release_tag =
                 UpdateChecker::GetLatestRelease(ShouldCheckForPrereleaseUpdates());
 
-            if (latest_release_tag) {
-                const int latest_version = GetMajorVersion(latest_release_tag.value());
-                const int current_version = GetMajorVersion(Common::g_build_fullname);
-
-                if (latest_version > current_version) {
-                    return QString::fromStdString(latest_release_tag.value());
-                } else if ((latest_version == current_version) &&
-                           (latest_release_tag &&
-                            latest_release_tag.value() != Common::g_build_fullname)) {
+            if (latest_release_tag && latest_release_tag.value() != Common::g_build_fullname) {
+                const int latest_major_version = GetMajorVersion(latest_release_tag.value());
+                const int current_major_version = GetMajorVersion(Common::g_build_fullname);
+                if (current_major_version <= latest_major_version) {
                     return QString::fromStdString(latest_release_tag.value());
                 }
             }

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -194,7 +194,6 @@ static int GetMajorVersion(const std::string& version) {
     } catch (...) {
         return 0;
     }
-    
 }
 #endif
 


### PR DESCRIPTION
Improve update checker system to prevent downgrades. Closes #1749

If the pre-release channel is selected, the major version from the latest update is now extracted and compared the current installed version. It will only ask for updates if the new major version is higher or matches, and if the latter, then checks if there are suffix differences via the old method (e.g. allowing 2125-rc1 to upgrade to 2125-rc2), but preventing downgrades. Best way I could think of solving this and should be able to handle all edge cases

Did a quick test on my repository and seemed fine, but recommend proper testing on your end