### PR TITLE
video_core: Do not spam file IO when reading vulkan shader disk cache

### DIFF
--- a/src/video_core/renderer_vulkan/vk_shader_disk_cache.h
+++ b/src/video_core/renderer_vulkan/vk_shader_disk_cache.h
@@ -292,9 +292,14 @@ private:
         bool SwitchMode(CacheOpMode mode);
 
     private:
+        bool ReadFromFileCached(void* dst, size_t absolute_pos, size_t size);
+
         CacheOpMode curr_mode = CacheOpMode::NONE;
         std::string filepath;
         FileUtil::IOFile file{};
+        size_t file_size;
+        size_t cached_file_data_start{};
+        std::vector<u8> cached_file_data;
         std::atomic<size_t> next_entry_id = SIZE_MAX;
         Common::ThreadWorker append_worker{1, "Disk Shader Cache Append Worker"};
     };


### PR DESCRIPTION
Previously, when processing the vulkan shader disk cache, each cache entry read was translated into a single file read operation. For large cache files with thousands of entries, this was not efficient, so read the file data to memory in chunks of `MAX_ENTRY_SIZE` instead.

This is an amendment of #1725 