### PR TITLE
citra-meta: Use dedicated GPU by default on AMD

### DIFF
--- a/src/citra_meta/main.cpp
+++ b/src/citra_meta/main.cpp
@@ -20,8 +20,10 @@
 
 #ifdef _WIN32
 extern "C" {
-// tells Nvidia drivers to use the dedicated GPU by default on laptops with switchable graphics
+// tells Nvidia and AMD drivers to use the dedicated GPU by default on laptops with switchable
+// graphics
 __declspec(dllexport) unsigned long NvOptimusEnablement = 0x00000001;
+__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
 }
 #endif
 


### PR DESCRIPTION
Tell AMD drivers on Windows to use the dedicated GPU by default, if both iGPU and dGPU are available. Ensures highest performance and matches the Nvidia side. Something I found while inspecting Eden code