### PR TITLE
video_core: Apply texture filter to color surfaces

### DIFF
--- a/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
@@ -922,7 +922,8 @@ void Surface::Upload(const VideoCore::BufferTextureCopy& upload,
             .src_rect = upload.texture_rect,
             .dst_rect = upload.texture_rect * res_scale,
         };
-        if (type != SurfaceType::Texture || !runtime->blit_helper.Filter(*this, blit)) {
+        if ((type != SurfaceType::Color && type != SurfaceType::Texture) ||
+            !runtime->blit_helper.Filter(*this, blit)) {
             BlitScale(blit, true);
         }
     }


### PR DESCRIPTION
Apply texture filter to surfaces marked as `Color` too. Previously it was only being applied to surfaces marked as `Texture`. Fixes filtering not applying to some textures.

Closes #1777 