### PR TITLE
Fix UI freeze on macOS game-list population

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -432,9 +432,6 @@ GMainWindow::GMainWindow(Core::System& system_)
     }
 #endif
 
-    game_list->LoadCompatibilityList();
-    game_list->PopulateAsync(UISettings::values.game_dirs);
-
     mouse_hide_timer.setInterval(default_mouse_timeout);
     connect(&mouse_hide_timer, &QTimer::timeout, this, &GMainWindow::HideMouseCursor);
     connect(ui->menubar, &QMenuBar::hovered, this, &GMainWindow::OnMouseActivity);
@@ -3736,6 +3733,11 @@ void GMainWindow::mousePressEvent([[maybe_unused]] QMouseEvent* event) {
 
 void GMainWindow::mouseReleaseEvent([[maybe_unused]] QMouseEvent* event) {
     OnMouseActivity();
+}
+
+void GMainWindow::showEvent([[maybe_unused]] QShowEvent* event) {
+    game_list->LoadCompatibilityList();
+    game_list->PopulateAsync(UISettings::values.game_dirs);
 }
 
 void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string details) {

--- a/src/citra_qt/citra_qt.h
+++ b/src/citra_qt/citra_qt.h
@@ -461,6 +461,7 @@ protected:
     void mouseMoveEvent(QMouseEvent* event) override;
     void mousePressEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
+    void showEvent(QShowEvent* event) override;
 };
 
 class GApplicationEventFilter : public QObject {


### PR DESCRIPTION
it seems like the initial call to `GameList::PopulateAsync` in the window constructor is too early in the app life-cycle and doesn't run asynchronously, or Qt is using macOS API in an esoteric way, or maybe it's something else entirely.

Moving the list population to happen before the window is shown instead appears to fix the issue.