### PR TITLE
artic_base_client: Fix high cpu usage

### DIFF
--- a/src/network/artic_base/artic_base_client.cpp
+++ b/src/network/artic_base/artic_base_client.cpp
@@ -606,6 +606,7 @@ bool Client::Read(SocketHolder sockFD, void* buffer, size_t size,
             if (GET_ERRNO == ERRNO(EWOULDBLOCK) &&
                 (timeout == std::chrono::nanoseconds(0) ||
                  std::chrono::steady_clock::now() - before < timeout)) {
+                std::this_thread::sleep_for(100us);
                 continue;
             }
             read_bytes = 0;
@@ -630,6 +631,7 @@ bool Client::Write(SocketHolder sockFD, const void* buffer, size_t size,
             if (GET_ERRNO == ERRNO(EWOULDBLOCK) &&
                 (timeout == std::chrono::nanoseconds(0) ||
                  std::chrono::steady_clock::now() - before < timeout)) {
+                std::this_thread::sleep_for(100us);
                 continue;
             }
             write_bytes = 0;


### PR DESCRIPTION
Fixes high CPU usage (azahar-emu#1788) by adding a small sleep to the Client::Read and Client::Write methods

I've decided to also apply the proposed fix to the Client::Write method as it's similar, even though it would probably not cause problems during runtime, probably just small spikes at most.