### PR TITLE
android: Fully use raw FS access on vanilla builds

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
@@ -698,7 +698,7 @@ object NativeLibrary {
 
         val dirSep = "/"
 
-        val pathSegment = uri.lastPathSegment!!
+        val pathSegment = uri.lastPathSegment ?: return ""
         val virtualPath = pathSegment.substringAfter(":")
 
         if (pathSegment.startsWith("primary:")) { // User directory is located in primary storage
@@ -723,7 +723,8 @@ object NativeLibrary {
     fun getUserDirectory(): String {
         val preferences: SharedPreferences =
             PreferenceManager.getDefaultSharedPreferences(CitraApplication.appContext)
-        return getNativePath(preferences.getString("CITRA_DIRECTORY", "")!!.toUri())
+        val userDirectoryUri = preferences.getString("CITRA_DIRECTORY", "")!!.toUri()
+        return getNativePath(userDirectoryUri)
     }
 
     @Keep

--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
@@ -230,6 +230,8 @@ object NativeLibrary {
     external fun playTimeManagerGetPlayTime(titleId: Long): Long
     external fun playTimeManagerGetCurrentTitleId(): Long
 
+    external fun uninstallTitle(titleId: Long): Boolean
+
     private var coreErrorAlertResult = false
     private val coreErrorAlertLock = Object()
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
@@ -25,6 +25,7 @@ import androidx.fragment.app.DialogFragment
 import androidx.preference.PreferenceManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.citra.citra_emu.activities.EmulationActivity
+import org.citra.citra_emu.model.Game
 import org.citra.citra_emu.utils.BuildUtil
 import org.citra.citra_emu.utils.FileUtil
 import org.citra.citra_emu.utils.Log
@@ -132,7 +133,27 @@ object NativeLibrary {
      * If not set, it auto-detects a location
      */
     external fun setUserDirectory(directory: String)
-    external fun getInstalledGamePaths(): Array<String?>
+
+    data class InstalledGame(
+        val path: String,
+        val mediaType: Game.MediaType
+    )
+    fun getInstalledGamePaths(): Array<InstalledGame> {
+        val games = getInstalledGamePathsImpl()
+
+        return games.mapNotNull { entry ->
+            entry?.let {
+                val sep = it.lastIndexOf('|')
+                if (sep == -1) return@mapNotNull null
+
+                val path = it.substring(0, sep)
+                val mediaType = Game.MediaType.fromInt(it.substring(sep + 1).toInt())
+
+                InstalledGame(path, mediaType!!)
+            }
+        }.toTypedArray()
+    }
+    private external fun getInstalledGamePathsImpl(): Array<String?>
 
     // Create the config.ini file.
     external fun createConfigFile()
@@ -230,7 +251,10 @@ object NativeLibrary {
     external fun playTimeManagerGetPlayTime(titleId: Long): Long
     external fun playTimeManagerGetCurrentTitleId(): Long
 
-    external fun uninstallTitle(titleId: Long): Boolean
+    private external fun uninstallTitle(titleId: Long, mediaType: Int): Boolean
+    fun uninstallTitle(titleId: Long, mediaType: Game.MediaType): Boolean {
+        return uninstallTitle(titleId, mediaType.value)
+    }
 
     private var coreErrorAlertResult = false
     private val coreErrorAlertLock = Object()

--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
@@ -693,34 +693,37 @@ object NativeLibrary {
 
     @Keep
     @JvmStatic
-    fun getUserDirectory(uriOverride: Uri? = null): String {
+    fun getNativePath(uri: Uri): String {
         BuildUtil.assertNotGooglePlay()
 
-        val preferences: SharedPreferences =
-            PreferenceManager.getDefaultSharedPreferences(CitraApplication.appContext)
-
         val dirSep = "/"
-        val udUri = uriOverride ?:
-                    preferences.getString("CITRA_DIRECTORY", "")!!.toUri()
-        val udPathSegment = udUri.lastPathSegment!!
-        val udVirtualPath = udPathSegment.substringAfter(":")
 
-        if (udPathSegment.startsWith("primary:")) { // User directory is located in primary storage
+        val pathSegment = uri.lastPathSegment!!
+        val virtualPath = pathSegment.substringAfter(":")
+
+        if (pathSegment.startsWith("primary:")) { // User directory is located in primary storage
             val primaryStoragePath = Environment.getExternalStorageDirectory().absolutePath
-            return primaryStoragePath + dirSep + udVirtualPath + dirSep
+            return primaryStoragePath + dirSep + virtualPath + dirSep
         } else { // User directory probably located on a removable storage device
-            val storageIdString = udPathSegment.substringBefore(":")
-            val udRemovablePath = RemovableStorageHelper.getRemovableStoragePath(storageIdString)
+            val storageIdString = pathSegment.substringBefore(":")
+            val removablePath = RemovableStorageHelper.getRemovableStoragePath(storageIdString)
 
-            if (udRemovablePath == null) {
+            if (removablePath == null) {
                 android.util.Log.e("NativeLibrary",
-                    "Unknown mount location for storage device '$storageIdString' (URI: $udUri)"
+                    "Unknown mount location for storage device '$storageIdString' (URI: $uri)"
                 )
                 return ""
             }
-            return udRemovablePath + dirSep + udVirtualPath + dirSep
+            return removablePath + dirSep + virtualPath
         }
+    }
 
+    @Keep
+    @JvmStatic
+    fun getUserDirectory(): String {
+        val preferences: SharedPreferences =
+            PreferenceManager.getDefaultSharedPreferences(CitraApplication.appContext)
+        return getNativePath(preferences.getString("CITRA_DIRECTORY", "")!!.toUri())
     }
 
     @Keep

--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
@@ -698,6 +698,11 @@ object NativeLibrary {
 
         val dirSep = "/"
 
+        val uriString = uri.toString()
+        if (!uriString.contains(":")) { // These raw URIs happen when generating the game list. Why?
+            return uriString
+        }
+
         val pathSegment = uri.lastPathSegment ?: return ""
         val virtualPath = pathSegment.substringAfter(":")
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
@@ -256,6 +256,8 @@ object NativeLibrary {
         return uninstallTitle(titleId, mediaType.value)
     }
 
+    external fun nativeFileExists(path: String): Boolean
+
     private var coreErrorAlertResult = false
     private val coreErrorAlertLock = Object()
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
@@ -703,7 +703,7 @@ object NativeLibrary {
 
         if (pathSegment.startsWith("primary:")) { // User directory is located in primary storage
             val primaryStoragePath = Environment.getExternalStorageDirectory().absolutePath
-            return primaryStoragePath + dirSep + virtualPath + dirSep
+            return primaryStoragePath + dirSep + virtualPath
         } else { // User directory probably located on a removable storage device
             val storageIdString = pathSegment.substringBefore(":")
             val removablePath = RemovableStorageHelper.getRemovableStoragePath(storageIdString)

--- a/src/android/app/src/main/java/org/citra/citra_emu/adapters/GameAdapter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/adapters/GameAdapter.kt
@@ -323,14 +323,16 @@ class GameAdapter(
             }
         }
 
+        val titleId = game.titleId
+        val dlcTitleId = titleId or 0x8C00000000L
+        val updateTitleId = titleId or 0xE00000000L
+
         popup.setOnMenuItemClickListener { menuItem ->
             val uninstallAction: () -> Unit = {
                 when (menuItem.itemId) {
-                    R.id.game_context_uninstall -> CitraApplication.documentsTree.deleteDocument(dirs.gameDir)
-                    R.id.game_context_uninstall_dlc -> FileUtil.deleteDocument(CitraApplication.documentsTree.folderUriHelper(dirs.dlcDir)
-                        .toString())
-                    R.id.game_context_uninstall_updates -> FileUtil.deleteDocument(CitraApplication.documentsTree.folderUriHelper(dirs.updatesDir)
-                        .toString())
+                    R.id.game_context_uninstall -> NativeLibrary.uninstallTitle(titleId)
+                    R.id.game_context_uninstall_dlc -> NativeLibrary.uninstallTitle(dlcTitleId)
+                    R.id.game_context_uninstall_updates -> NativeLibrary.uninstallTitle(updateTitleId)
                 }
                 ViewModelProvider(activity)[GamesViewModel::class.java].reloadGames(true)
                 bottomSheetDialog.dismiss()

--- a/src/android/app/src/main/java/org/citra/citra_emu/adapters/GameAdapter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/adapters/GameAdapter.kt
@@ -136,7 +136,7 @@ class GameAdapter(
         val holder = view.tag as GameViewHolder
         gameExists(holder)
 
-        if (holder.game.titleId == 0L) {
+        if (!holder.game.valid) {
             MaterialAlertDialogBuilder(context)
                 .setTitle(R.string.properties)
                 .setMessage(R.string.properties_not_loaded)
@@ -558,7 +558,9 @@ class GameAdapter(
 
     private class DiffCallback : DiffUtil.ItemCallback<Game>() {
         override fun areItemsTheSame(oldItem: Game, newItem: Game): Boolean {
-            return oldItem.titleId == newItem.titleId
+            // The title is taken into account to support 3DSX, which all have the titleID 0.
+            // This only works now because we always return the English title, adjust if that changes.
+            return oldItem.titleId == newItem.titleId && oldItem.title == newItem.title
         }
 
         override fun areContentsTheSame(oldItem: Game, newItem: Game): Boolean {

--- a/src/android/app/src/main/java/org/citra/citra_emu/adapters/GameAdapter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/adapters/GameAdapter.kt
@@ -54,8 +54,10 @@ import org.citra.citra_emu.databinding.DialogShortcutBinding
 import org.citra.citra_emu.features.cheats.ui.CheatsFragmentDirections
 import org.citra.citra_emu.fragments.IndeterminateProgressDialogFragment
 import org.citra.citra_emu.model.Game
+import org.citra.citra_emu.utils.BuildUtil
 import org.citra.citra_emu.utils.FileUtil
 import org.citra.citra_emu.utils.GameIconUtils
+import org.citra.citra_emu.utils.Log
 import org.citra.citra_emu.viewmodel.GamesViewModel
 
 class GameAdapter(
@@ -153,12 +155,21 @@ class GameAdapter(
         if (holder.game.isInstalled) {
             return true
         }
-
-        val gameExists = DocumentFile.fromSingleUri(
-            CitraApplication.appContext,
-            Uri.parse(holder.game.path)
-        )?.exists() == true
+        val path = holder.game.path
+        val pathUri = path.toUri()
+        var gameExists: Boolean
+        if (BuildUtil.isGooglePlayBuild || FileUtil.isNativePath(path)) {
+            gameExists =
+                DocumentFile.fromSingleUri(
+                    CitraApplication.appContext,
+                    pathUri
+                )?.exists() == true
+        } else {
+            val nativePath = NativeLibrary.getNativePath(pathUri)
+            gameExists = NativeLibrary.nativeFileExists(nativePath)
+        }
         return if (!gameExists) {
+            Log.error("[GameAdapter] ROM file does not exist: $path")
             Toast.makeText(
                 CitraApplication.appContext,
                 R.string.loader_error_file_not_found,

--- a/src/android/app/src/main/java/org/citra/citra_emu/adapters/GameAdapter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/adapters/GameAdapter.kt
@@ -330,9 +330,9 @@ class GameAdapter(
         popup.setOnMenuItemClickListener { menuItem ->
             val uninstallAction: () -> Unit = {
                 when (menuItem.itemId) {
-                    R.id.game_context_uninstall -> NativeLibrary.uninstallTitle(titleId)
-                    R.id.game_context_uninstall_dlc -> NativeLibrary.uninstallTitle(dlcTitleId)
-                    R.id.game_context_uninstall_updates -> NativeLibrary.uninstallTitle(updateTitleId)
+                    R.id.game_context_uninstall -> NativeLibrary.uninstallTitle(titleId, game.mediaType)
+                    R.id.game_context_uninstall_dlc -> NativeLibrary.uninstallTitle(dlcTitleId, Game.MediaType.SDMC)
+                    R.id.game_context_uninstall_updates -> NativeLibrary.uninstallTitle(updateTitleId, Game.MediaType.SDMC)
                 }
                 ViewModelProvider(activity)[GamesViewModel::class.java].reloadGames(true)
                 bottomSheetDialog.dismiss()

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
@@ -133,14 +133,16 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
         var intentGame: Game? = null
         if (intentUri != null) {
             intentGame = if (Game.extensions.contains(FileUtil.getExtension(intentUri))) {
-                GameHelper.getGame(intentUri, isInstalled = false, addedToLibrary = false)
+                // isInstalled, addedToLibrary and mediaType do not matter here
+                GameHelper.getGame(intentUri, isInstalled = false, addedToLibrary = false, mediaType = Game.MediaType.GAME_CARD)
             } else {
                 null
             }
         } else if (oldIntentInfo.first != null) {
             val gameUri = Uri.parse(oldIntentInfo.first)
             intentGame = if (Game.extensions.contains(FileUtil.getExtension(gameUri))) {
-                GameHelper.getGame(gameUri, isInstalled = false, addedToLibrary = false)
+                // isInstalled, addedToLibrary and mediaType do not matter here
+                GameHelper.getGame(gameUri, isInstalled = false, addedToLibrary = false, mediaType = Game.MediaType.GAME_CARD)
             } else {
                 null
             }

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
@@ -567,7 +567,7 @@ class SetupFragment : Fragment() {
         }
 
         if (!BuildUtil.isGooglePlayBuild) {
-            if (NativeLibrary.getUserDirectory(result) == "") {
+            if (NativeLibrary.getNativePath(result) == "") {
                 SelectUserDirectoryDialogFragment.newInstance(
                     mainActivity,
                     R.string.invalid_selection,

--- a/src/android/app/src/main/java/org/citra/citra_emu/model/Game.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/model/Game.kt
@@ -16,6 +16,7 @@ import org.citra.citra_emu.activities.EmulationActivity
 @Parcelize
 @Serializable
 class Game(
+    val valid: Boolean = false,
     val title: String = "",
     val description: String = "",
     val path: String = "",

--- a/src/android/app/src/main/java/org/citra/citra_emu/model/Game.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/model/Game.kt
@@ -20,6 +20,7 @@ class Game(
     val description: String = "",
     val path: String = "",
     val titleId: Long = 0L,
+    val mediaType: MediaType = MediaType.GAME_CARD,
     val company: String = "",
     val regions: String = "",
     val isInstalled: Boolean = false,
@@ -58,8 +59,21 @@ class Game(
         result = 31 * result + regions.hashCode()
         result = 31 * result + path.hashCode()
         result = 31 * result + titleId.hashCode()
+        result = 31 * result + mediaType.hashCode()
         result = 31 * result + company.hashCode()
         return result
+    }
+
+    enum class MediaType(val value: Int) {
+        NAND(0),
+        SDMC(1),
+        GAME_CARD(2);
+
+        companion object {
+            fun fromInt(value: Int): MediaType? {
+                return MediaType.entries.find { it.value == value }
+            }
+        }
     }
 
     companion object {

--- a/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
@@ -367,7 +367,7 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
             }
 
             if (!BuildUtil.isGooglePlayBuild) {
-                if (NativeLibrary.getUserDirectory(result) == "") {
+                if (NativeLibrary.getNativePath(result) == "") {
                     SelectUserDirectoryDialogFragment.newInstance(
                         this,
                         R.string.invalid_selection,

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/CiaInstallWorker.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/CiaInstallWorker.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -12,9 +12,11 @@ import androidx.core.app.NotificationCompat
 import androidx.work.ForegroundInfo
 import androidx.work.Worker
 import androidx.work.WorkerParameters
+import org.citra.citra_emu.NativeLibrary
 import org.citra.citra_emu.NativeLibrary.InstallStatus
 import org.citra.citra_emu.R
 import org.citra.citra_emu.utils.FileUtil.getFilename
+import androidx.core.net.toUri
 
 class CiaInstallWorker(
     val context: Context,
@@ -131,7 +133,7 @@ class CiaInstallWorker(
         installProgressBuilder.setOngoing(true)
         setProgressCallback(100, 0)
         selectedFiles.forEachIndexed { i, file ->
-            val filename = getFilename(Uri.parse(file))
+            val filename = getFilename(file.toUri())
             installProgressBuilder.setContentText(
                 context.getString(
                     R.string.cia_install_notification_installing,
@@ -140,7 +142,13 @@ class CiaInstallWorker(
                     selectedFiles.size
                 )
             )
-            val res = installCIA(file)
+            var fileFinal: String
+            if (BuildUtil.isGooglePlayBuild) {
+                fileFinal = file
+            } else {
+                fileFinal = "!" + NativeLibrary.getNativePath(file.toUri())
+            }
+            val res = installCIA(fileFinal)
             notifyInstallStatus(filename, res)
         }
         notificationManager.cancel(PROGRESS_NOTIFICATION_ID)

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/DocumentsTree.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/DocumentsTree.kt
@@ -10,6 +10,8 @@ import androidx.core.net.toUri
 import androidx.documentfile.provider.DocumentFile
 import org.citra.citra_emu.CitraApplication
 import org.citra.citra_emu.model.CheapDocument
+import org.citra.citra_emu.utils.BuildUtil
+import java.io.IOException
 import java.net.URLDecoder
 import java.nio.file.Paths
 import java.util.StringTokenizer
@@ -261,6 +263,17 @@ class DocumentsTree {
 
     @Synchronized
     private fun resolvePath(filepath: String): DocumentsNode? {
+        if (!BuildUtil.isGooglePlayBuild) {
+            var isLegalPath = false
+            kotlinDirectoryAccessWhitelist.forEach {
+                if (filepath.startsWith(it)) {
+                    isLegalPath = true
+                }
+            }
+            if (!isLegalPath) {
+                throw IOException("Attempted to resolve forbidden path: " + filepath)
+            }
+        }
         root ?: return null
         val tokens = StringTokenizer(filepath, DELIMITER, false)
         var iterator = root
@@ -352,5 +365,10 @@ class DocumentsTree {
 
     companion object {
         const val DELIMITER = "/"
+        val kotlinDirectoryAccessWhitelist = arrayOf(
+            "/config/",
+            "/log/",
+            "/gpu_drivers/",
+        )
     }
 }

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/DocumentsTree.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/DocumentsTree.kt
@@ -77,8 +77,9 @@ class DocumentsTree {
 
     @Synchronized
     fun getFilename(filepath: String): String {
-        val node = resolvePath(filepath) ?: return ""
-        return node.name
+        val components = filepath.split(DELIMITER).filter { it.isNotEmpty() }
+        val filename = components.last()
+        return filename
     }
 
     @Synchronized

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/GameHelper.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/GameHelper.kt
@@ -70,7 +70,15 @@ object GameHelper {
 
     fun getGame(uri: Uri, isInstalled: Boolean, addedToLibrary: Boolean): Game {
         val filePath = uri.toString()
-        var gameInfo: GameInfo? = GameInfo(filePath)
+        var nativePath: String? = null
+        var gameInfo: GameInfo?
+        if (BuildUtil.isGooglePlayBuild || FileUtil.isNativePath(filePath)) {
+            gameInfo = GameInfo(filePath)
+        } else {
+            nativePath = "!" + NativeLibrary.getNativePath(uri);
+            gameInfo = GameInfo(nativePath)
+        }
+
 
         if (gameInfo?.isValid() == false) {
             gameInfo = null
@@ -81,7 +89,11 @@ object GameHelper {
         val newGame = Game(
             (gameInfo?.getTitle() ?: FileUtil.getFilename(uri)).replace("[\\t\\n\\r]+".toRegex(), " "),
             filePath.replace("\n", " "),
-            filePath,
+            if (BuildUtil.isGooglePlayBuild || FileUtil.isNativePath(filePath)) {
+                filePath
+            } else {
+                nativePath!!
+            },
             gameInfo?.getTitleID() ?: 0,
             gameInfo?.getCompany() ?: "",
             if (isEncrypted) { CitraApplication.appContext.getString(R.string.unsupported_encrypted) } else { gameInfo?.getRegions() ?: "" },

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/GameHelper.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/GameHelper.kt
@@ -32,7 +32,7 @@ object GameHelper {
 
         addGamesRecursive(games, FileUtil.listFiles(gamesUri), 3)
         NativeLibrary.getInstalledGamePaths().forEach {
-            games.add(getGame(Uri.parse(it), isInstalled = true, addedToLibrary = true))
+            games.add(getGame(Uri.parse(it.path), isInstalled = true, addedToLibrary = true, it.mediaType))
         }
 
         // Cache list of games found on disk
@@ -62,13 +62,13 @@ object GameHelper {
                 addGamesRecursive(games, FileUtil.listFiles(it.uri), depth - 1)
             } else {
                 if (Game.allExtensions.contains(FileUtil.getExtension(it.uri))) {
-                    games.add(getGame(it.uri, isInstalled = false, addedToLibrary = true))
+                    games.add(getGame(it.uri, isInstalled = false, addedToLibrary = true, Game.MediaType.GAME_CARD))
                 }
             }
         }
     }
 
-    fun getGame(uri: Uri, isInstalled: Boolean, addedToLibrary: Boolean): Game {
+    fun getGame(uri: Uri, isInstalled: Boolean, addedToLibrary: Boolean, mediaType: Game.MediaType): Game {
         val filePath = uri.toString()
         var nativePath: String? = null
         var gameInfo: GameInfo?
@@ -95,6 +95,7 @@ object GameHelper {
                 nativePath!!
             },
             gameInfo?.getTitleID() ?: 0,
+            mediaType,
             gameInfo?.getCompany() ?: "",
             if (isEncrypted) { CitraApplication.appContext.getString(R.string.unsupported_encrypted) } else { gameInfo?.getRegions() ?: "" },
             isInstalled,

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/GameHelper.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/GameHelper.kt
@@ -79,14 +79,15 @@ object GameHelper {
             gameInfo = GameInfo(nativePath)
         }
 
-
-        if (gameInfo?.isValid() == false) {
+        val valid = gameInfo.isValid()
+        if (!valid) {
             gameInfo = null
         }
 
         val isEncrypted = gameInfo?.isEncrypted() == true
 
         val newGame = Game(
+            valid,
             (gameInfo?.getTitle() ?: FileUtil.getFilename(uri)).replace("[\\t\\n\\r]+".toRegex(), " "),
             filePath.replace("\n", " "),
             if (BuildUtil.isGooglePlayBuild || FileUtil.isNativePath(filePath)) {

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -1124,4 +1124,10 @@ jboolean Java_org_citra_citra_1emu_NativeLibrary_uninstallTitle(JNIEnv* env, job
     return true;
 }
 
+jboolean Java_org_citra_citra_1emu_NativeLibrary_nativeFileExists(JNIEnv* env, jobject obj,
+                                                                  jstring j_path) {
+    const auto path = GetJString(env, j_path);
+    return FileUtil::Exists(path);
+}
+
 } // extern "C"

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -1107,4 +1107,17 @@ void Java_org_citra_citra_1emu_NativeLibrary_setInsertedCartridge(JNIEnv* env, j
     inserted_cartridge = GetJString(env, path);
 }
 
+jboolean Java_org_citra_citra_1emu_NativeLibrary_uninstallTitle(JNIEnv* env, jobject obj,
+                                                                jlong j_titleid) {
+    const auto titleid = static_cast<long long>(env, j_titleid);
+    // TODO: Don't hard-code to SDMC? (CBA to pass a value from Kotlin at the moment) -OS
+    const auto result = Service::AM::UninstallProgram(Service::FS::MediaType::SDMC, titleid);
+    if (result.IsError()) {
+        LOG_ERROR(Frontend, "Failed to uninstall '{}': 0x{:08X}", std::to_string(titleid),
+                  result.raw);
+        return false;
+    }
+    return true;
+}
+
 } // extern "C"

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -652,34 +652,38 @@ void Java_org_citra_citra_1emu_NativeLibrary_setUserDirectory(JNIEnv* env,
     FileUtil::SetCurrentDir(GetJString(env, j_directory));
 }
 
-jobjectArray Java_org_citra_citra_1emu_NativeLibrary_getInstalledGamePaths(
+jobjectArray Java_org_citra_citra_1emu_NativeLibrary_getInstalledGamePathsImpl(
     JNIEnv* env, [[maybe_unused]] jclass clazz) {
     std::vector<std::string> games;
-    const FileUtil::DirectoryEntryCallable ScanDir =
-        [&games, &ScanDir](u64*, const std::string& directory, const std::string& virtual_name) {
-            std::string path = directory + virtual_name;
-            if (FileUtil::IsDirectory(path)) {
-                path += '/';
-                FileUtil::ForeachDirectoryEntry(nullptr, path, ScanDir);
-            } else {
-                if (!FileUtil::Exists(path))
-                    return false;
-                auto loader = Loader::GetLoader(path);
-                if (loader) {
-                    bool executable{};
-                    const Loader::ResultStatus result = loader->IsExecutable(executable);
-                    if (Loader::ResultStatus::Success == result && executable) {
-                        games.emplace_back(path);
-                    }
+    Service::FS::MediaType media_type;
+    const FileUtil::DirectoryEntryCallable ScanDir = [&games, &ScanDir, &media_type](
+                                                         u64*, const std::string& directory,
+                                                         const std::string& virtual_name) {
+        std::string path = directory + virtual_name;
+        if (FileUtil::IsDirectory(path)) {
+            path += '/';
+            FileUtil::ForeachDirectoryEntry(nullptr, path, ScanDir);
+        } else {
+            if (!FileUtil::Exists(path))
+                return false;
+            auto loader = Loader::GetLoader(path);
+            if (loader) {
+                bool executable{};
+                const Loader::ResultStatus result = loader->IsExecutable(executable);
+                if (Loader::ResultStatus::Success == result && executable) {
+                    games.emplace_back(path + "|" + std::to_string(static_cast<int>(media_type)));
                 }
             }
-            return true;
-        };
+        }
+        return true;
+    };
+    media_type = Service::FS::MediaType::SDMC;
     ScanDir(nullptr, "",
             FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir) +
                 "Nintendo "
                 "3DS/00000000000000000000000000000000/"
                 "00000000000000000000000000000000/title/00040000");
+    media_type = Service::FS::MediaType::NAND;
     ScanDir(nullptr, "",
             FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) +
                 "00000000000000000000000000000000/title/00040010");
@@ -1108,10 +1112,10 @@ void Java_org_citra_citra_1emu_NativeLibrary_setInsertedCartridge(JNIEnv* env, j
 }
 
 jboolean Java_org_citra_citra_1emu_NativeLibrary_uninstallTitle(JNIEnv* env, jobject obj,
-                                                                jlong j_titleid) {
-    const auto titleid = static_cast<long long>(env, j_titleid);
-    // TODO: Don't hard-code to SDMC? (CBA to pass a value from Kotlin at the moment) -OS
-    const auto result = Service::AM::UninstallProgram(Service::FS::MediaType::SDMC, titleid);
+                                                                jlong j_titleid, jint j_mediatype) {
+    const auto titleid = static_cast<u64>(j_titleid);
+    const auto result =
+        Service::AM::UninstallProgram(static_cast<Service::FS::MediaType>(j_mediatype), titleid);
     if (result.IsError()) {
         LOG_ERROR(Frontend, "Failed to uninstall '{}': 0x{:08X}", std::to_string(titleid),
                   result.raw);

--- a/src/common/android_storage.cpp
+++ b/src/common/android_storage.cpp
@@ -293,6 +293,18 @@ bool MoveAndRenameFile(const std::string& src_full_path, const std::string& dest
     return result;
 }
 
+std::string TranslateFilePath(const std::string& filepath) {
+    std::optional<std::string> userDirLocation = GetUserDirectory();
+    if (userDirLocation) {
+        return *userDirLocation + filepath;
+    }
+    return "";
+}
+
+bool CanUseRawFS() {
+    return AndroidStorage::GetBuildFlavor() != AndroidBuildFlavors::GOOGLEPLAY;
+}
+
 #define FR(FunctionName, ReturnValue, JMethodID, Caller, JMethodName, Signature)                   \
     F(FunctionName, ReturnValue, JMethodID, Caller)
 #define F(FunctionName, ReturnValue, JMethodID, Caller)                                            \

--- a/src/common/android_storage.cpp
+++ b/src/common/android_storage.cpp
@@ -163,13 +163,27 @@ std::optional<std::string> GetUserDirectory() {
         throw std::runtime_error(
             "Unable to locate user directory: Function with ID 'get_user_directory' is missing");
     }
+
     auto env = GetEnvForThread();
-    auto j_user_directory =
-        (jstring)(env->CallStaticObjectMethod(native_library, get_user_directory, nullptr));
-    auto result = env->GetStringUTFChars(j_user_directory, nullptr);
-    if (result == "") {
+
+    jstring j_user_directory =
+        (jstring)env->CallStaticObjectMethod(native_library, get_user_directory);
+
+    if (env->ExceptionCheck() || j_user_directory == nullptr) {
+        env->ExceptionClear();
         return std::nullopt;
     }
+
+    const char* chars = env->GetStringUTFChars(j_user_directory, nullptr);
+
+    std::string result = chars ? chars : "";
+
+    env->ReleaseStringUTFChars(j_user_directory, chars);
+
+    if (result.empty()) {
+        return std::nullopt;
+    }
+
     return result;
 }
 
@@ -296,7 +310,7 @@ bool MoveAndRenameFile(const std::string& src_full_path, const std::string& dest
 std::string TranslateFilePath(const std::string& filepath) {
     std::optional<std::string> userDirLocation = GetUserDirectory();
     if (userDirLocation) {
-        return *userDirLocation + "/" + filepath;
+        return *userDirLocation + filepath;
     }
     return "";
 }

--- a/src/common/android_storage.cpp
+++ b/src/common/android_storage.cpp
@@ -296,7 +296,7 @@ bool MoveAndRenameFile(const std::string& src_full_path, const std::string& dest
 std::string TranslateFilePath(const std::string& filepath) {
     std::optional<std::string> userDirLocation = GetUserDirectory();
     if (userDirLocation) {
-        return *userDirLocation + filepath;
+        return *userDirLocation + "/" + filepath;
     }
     return "";
 }

--- a/src/common/android_storage.cpp
+++ b/src/common/android_storage.cpp
@@ -308,9 +308,16 @@ bool MoveAndRenameFile(const std::string& src_full_path, const std::string& dest
 }
 
 std::string TranslateFilePath(const std::string& filepath) {
+    // "!" at front of path indicates an already-native path.
+    // This is hacky, but I don't know how else we can do this without a lot of quite invasive
+    // changes to how Android file IO works.
+    // TODO: We should definitely change this in favour of a real solution down the line.
+    if (filepath.front() == '!') {
+        return filepath.substr(1);
+    }
     std::optional<std::string> userDirLocation = GetUserDirectory();
     if (userDirLocation) {
-        return *userDirLocation + filepath;
+        return *userDirLocation + "/" + filepath;
     }
     return "";
 }

--- a/src/common/android_storage.h
+++ b/src/common/android_storage.h
@@ -56,7 +56,9 @@ ANDROID_STORAGE_FUNCTIONS(FS)
 #undef F
 #undef FS
 #undef FR
+bool CanUseRawFS();
 bool MoveAndRenameFile(const std::string& src_full_path, const std::string& dest_full_path);
+std::string TranslateFilePath(const std::string& filepath);
 // Reference:
 // https://developer.android.com/reference/android/os/ParcelFileDescriptor#parseMode(java.lang.String)
 enum class AndroidOpenMode {

--- a/src/common/android_storage.h
+++ b/src/common/android_storage.h
@@ -20,7 +20,7 @@
     V(GetFilesName, std::vector<std::string>, (const std::string& filepath), get_files_name,       \
       "getFilesName", "(Ljava/lang/String;)[Ljava/lang/String;")                                   \
     V(GetUserDirectory, std::optional<std::string>, (), get_user_directory, "getUserDirectory",    \
-      "(Landroid/net/Uri;)Ljava/lang/String;")                                                     \
+      "()Ljava/lang/String;")                                                                      \
     V(CopyFile, bool,                                                                              \
       (const std::string& source, const std::string& destination_path,                             \
        const std::string& destination_filename),                                                   \

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -145,6 +145,23 @@ static void StripTailDirSlashes(std::string& fname) {
     fname.resize(i);
 }
 
+#if defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
+namespace {
+std::string AndroidTranslateFilename(const std::string& file) {
+    std::optional<std::string> userDirLocation = AndroidStorage::GetUserDirectory();
+    if (userDirLocation) {
+        return *userDirLocation + file;
+    }
+
+    return "";
+}
+
+bool AndroidCanUseRawFS() {
+    return AndroidStorage::GetBuildFlavor() != AndroidStorage::AndroidBuildFlavors::GOOGLEPLAY;
+}
+} // anonymous namespace
+#endif
+
 bool Exists(const std::string& filename) {
     std::string copy(filename);
     StripTailDirSlashes(copy);
@@ -157,7 +174,13 @@ bool Exists(const std::string& filename) {
 
     int result = _wstat64(Common::UTF8ToUTF16W(copy).c_str(), &file_info);
 #elif defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
-    int result = AndroidStorage::FileExists(filename) ? 0 : -1;
+    int result;
+    if (AndroidCanUseRawFS()) {
+        struct stat file_info;
+        result = stat(AndroidTranslateFilename(copy).c_str(), &file_info);
+    } else {
+        result = AndroidStorage::FileExists(filename) ? 0 : -1;
+    }
 #else
     struct stat file_info;
     int result = stat(copy.c_str(), &file_info);
@@ -167,9 +190,6 @@ bool Exists(const std::string& filename) {
 }
 
 bool IsDirectory(const std::string& filename) {
-#if defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
-    return AndroidStorage::IsDirectory(filename);
-#endif
 
     std::string copy(filename);
     StripTailDirSlashes(copy);
@@ -181,6 +201,14 @@ bool IsDirectory(const std::string& filename) {
         copy += DIR_SEP_CHR;
 
     int result = _wstat64(Common::UTF8ToUTF16W(copy).c_str(), &file_info);
+#elif defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
+    struct stat file_info;
+    int result;
+    if (AndroidCanUseRawFS()) {
+        result = stat(AndroidTranslateFilename(copy).c_str(), &file_info);
+    } else {
+        return AndroidStorage::IsDirectory(filename);
+    }
 #else
     struct stat file_info;
     int result = stat(copy.c_str(), &file_info);
@@ -239,9 +267,16 @@ bool Delete(const std::string& filename) {
 
     return false;
 #elif defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
-    if (!AndroidStorage::DeleteDocument(filename)) {
-        LOG_ERROR(Common_Filesystem, "unlink failed on {}", filename);
-        return false;
+    if (AndroidCanUseRawFS()) {
+        if (unlink(AndroidTranslateFilename(filename).c_str()) == -1) {
+            LOG_ERROR(Common_Filesystem, "unlink failed on {}: {}", filename, GetLastErrorMsg());
+            return false;
+        }
+    } else {
+        if (!AndroidStorage::DeleteDocument(filename)) {
+            LOG_ERROR(Common_Filesystem, "unlink failed on {}", filename);
+            return false;
+        }
     }
 #else
     if (unlink(filename.c_str()) == -1) {
@@ -266,23 +301,39 @@ bool CreateDir(const std::string& path) {
     LOG_ERROR(Common_Filesystem, "CreateDirectory failed on {}: {}", path, error);
     return false;
 #elif defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
-    std::string directory = path;
-    std::string filename = path;
-    if (Common::EndsWith(path, "/")) {
-        directory = GetParentPath(path);
-        filename = GetParentPath(path);
-    }
-    directory = GetParentPath(directory);
-    filename = GetFilename(filename);
-    // If directory path is empty, set it to root.
-    if (directory.empty()) {
-        directory = "/";
-    }
-    if (!AndroidStorage::CreateDir(directory, filename)) {
-        LOG_ERROR(Common_Filesystem, "mkdir failed on {}", path);
+    if (AndroidCanUseRawFS()) {
+        if (mkdir(AndroidTranslateFilename(path).c_str(), 0755) == 0)
+            return true;
+
+        int err = errno;
+
+        if (err == EEXIST) {
+            LOG_DEBUG(Common_Filesystem, "mkdir failed on {}: already exists", path);
+            return true;
+        }
+
+        LOG_ERROR(Common_Filesystem, "mkdir failed on {}: {}", path, strerror(err));
         return false;
-    };
-    return true;
+    } else {
+        std::string directory = path;
+        std::string filename = path;
+        if (Common::EndsWith(path, "/")) {
+            directory = GetParentPath(path);
+            filename = GetParentPath(path);
+        }
+        directory = GetParentPath(directory);
+        filename = GetFilename(filename);
+        // If directory path is empty, set it to root.
+        if (directory.empty()) {
+            directory = "/";
+        }
+        if (!AndroidStorage::CreateDir(directory, filename)) {
+            LOG_ERROR(Common_Filesystem, "mkdir failed on {}", path);
+            return false;
+        };
+        return true;
+    }
+
 #else
     if (mkdir(path.c_str(), 0755) == 0)
         return true;
@@ -353,8 +404,13 @@ bool DeleteDir(const std::string& filename) {
     if (::RemoveDirectoryW(Common::UTF8ToUTF16W(filename).c_str()))
         return true;
 #elif defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
-    if (AndroidStorage::DeleteDocument(filename))
-        return true;
+    if (AndroidCanUseRawFS()) {
+        if (rmdir(AndroidTranslateFilename(filename).c_str()) == 0)
+            return true;
+    } else {
+        if (AndroidStorage::DeleteDocument(filename))
+            return true;
+    }
 #else
     if (rmdir(filename.c_str()) == 0)
         return true;
@@ -372,16 +428,14 @@ bool Rename(const std::string& srcFullPath, const std::string& destFullPath) {
         return true;
     }
 #elif defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
-    // srcFullPath and destFullPath are relative to the user directory
-    if (AndroidStorage::GetBuildFlavor() == AndroidStorage::AndroidBuildFlavors::GOOGLEPLAY) {
-        if (AndroidStorage::MoveAndRenameFile(srcFullPath, destFullPath))
+    if (AndroidCanUseRawFS()) {
+        if (rename(AndroidTranslateFilename(srcFullPath).c_str(),
+                   AndroidTranslateFilename(destFullPath).c_str()) == 0) {
+
             return true;
+        }
     } else {
-        std::optional<std::string> userDirLocation = AndroidStorage::GetUserDirectory();
-        if (userDirLocation && rename((*userDirLocation + srcFullPath).c_str(),
-                                      (*userDirLocation + destFullPath).c_str()) == 0) {
-            AndroidStorage::UpdateDocumentLocation(srcFullPath, destFullPath);
-            // ^ TODO: This shouldn't fail, but what should we do if it somehow does?
+        if (AndroidStorage::MoveAndRenameFile(srcFullPath, destFullPath)) {
             return true;
         }
     }
@@ -404,52 +458,62 @@ bool Copy(const std::string& srcFilename, const std::string& destFilename) {
     LOG_ERROR(Common_Filesystem, "failed {} --> {}: {}", srcFilename, destFilename,
               GetLastErrorMsg());
     return false;
-#elif defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
-    return AndroidStorage::CopyFile(srcFilename, std::string(GetParentPath(destFilename)),
-                                    std::string(GetFilename(destFilename)));
 #else
+    auto copy_files = [](const std::string& src, const std::string& dst) -> bool {
+        // Open input file
+        FILE* input = FOPEN(src.c_str(), "rb");
+        if (!input) {
+            LOG_ERROR(Common_Filesystem, "opening input failed {} --> {}: {}", src, dst,
+                      GetLastErrorMsg());
+            return false;
+        }
+        SCOPE_EXIT({ FCLOSE(input); });
 
-    // Open input file
-    FILE* input = FOPEN(srcFilename.c_str(), "rb");
-    if (!input) {
-        LOG_ERROR(Common_Filesystem, "opening input failed {} --> {}: {}", srcFilename,
-                  destFilename, GetLastErrorMsg());
-        return false;
-    }
-    SCOPE_EXIT({ FCLOSE(input); });
+        // open output file
+        FILE* output = FOPEN(dst.c_str(), "wb");
+        if (!output) {
+            LOG_ERROR(Common_Filesystem, "opening output failed {} --> {}: {}", src, dst,
+                      GetLastErrorMsg());
+            return false;
+        }
+        SCOPE_EXIT({ FCLOSE(output); });
 
-    // open output file
-    FILE* output = FOPEN(destFilename.c_str(), "wb");
-    if (!output) {
-        LOG_ERROR(Common_Filesystem, "opening output failed {} --> {}: {}", srcFilename,
-                  destFilename, GetLastErrorMsg());
-        return false;
-    }
-    SCOPE_EXIT({ FCLOSE(output); });
+        // copy loop
+        std::array<char, 1024> buffer;
+        while (!FEOF(input)) {
+            // read input
+            std::size_t rnum = FREAD(buffer.data(), sizeof(char), buffer.size(), input);
+            if (rnum != buffer.size()) {
+                if (FERROR(input) != 0) {
+                    LOG_ERROR(Common_Filesystem, "failed reading from source, {} --> {}: {}", src,
+                              dst, GetLastErrorMsg());
+                    return false;
+                }
+            }
 
-    // copy loop
-    std::array<char, 1024> buffer;
-    while (!FEOF(input)) {
-        // read input
-        std::size_t rnum = FREAD(buffer.data(), sizeof(char), buffer.size(), input);
-        if (rnum != buffer.size()) {
-            if (FERROR(input) != 0) {
-                LOG_ERROR(Common_Filesystem, "failed reading from source, {} --> {}: {}",
-                          srcFilename, destFilename, GetLastErrorMsg());
+            // write output
+            std::size_t wnum = FWRITE(buffer.data(), sizeof(char), rnum, output);
+            if (wnum != rnum) {
+                LOG_ERROR(Common_Filesystem, "failed writing to output, {} --> {}: {}", src, dst,
+                          GetLastErrorMsg());
                 return false;
             }
         }
 
-        // write output
-        std::size_t wnum = FWRITE(buffer.data(), sizeof(char), rnum, output);
-        if (wnum != rnum) {
-            LOG_ERROR(Common_Filesystem, "failed writing to output, {} --> {}: {}", srcFilename,
-                      destFilename, GetLastErrorMsg());
-            return false;
-        }
-    }
+        return true;
+    };
 
-    return true;
+#if defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
+    if (AndroidCanUseRawFS()) {
+        return copy_files(AndroidTranslateFilename(srcFilename),
+                          AndroidTranslateFilename(destFilename));
+    } else {
+        return AndroidStorage::CopyFile(srcFilename, std::string(GetParentPath(destFilename)),
+                                        std::string(GetFilename(destFilename)));
+    }
+#else
+    return copy_files(srcFilename, destFilename);
+#endif
 #endif
 }
 
@@ -470,9 +534,15 @@ u64 GetSize(const std::string& filename) {
     struct _stat64 buf;
     if (_wstat64(Common::UTF8ToUTF16W(filename).c_str(), &buf) == 0)
 #elif defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
-    u64 result = AndroidStorage::GetSize(filename);
-    LOG_TRACE(Common_Filesystem, "{}: {}", filename, result);
-    return result;
+    if (AndroidCanUseRawFS()) {
+        if (stat(AndroidTranslateFilename(filename).c_str(), &buf) == 0) {
+            return buf.st_size;
+        }
+    } else {
+        u64 result = AndroidStorage::GetSize(filename);
+        LOG_TRACE(Common_Filesystem, "{}: {}", filename, result);
+        return result;
+    }
 #else
     if (stat(filename.c_str(), &buf) == 0)
 #endif
@@ -520,68 +590,97 @@ bool CreateEmptyFile(const std::string& filename) {
     return true;
 }
 
+namespace {
+
+#ifdef _WIN32
+
+std::optional<std::vector<std::string>> ListDirectoryEntries(const std::string& directory) {
+    std::vector<std::string> entries;
+
+    WIN32_FIND_DATAW ffd;
+    const std::wstring search_path = Common::UTF8ToUTF16W(directory + "\\*");
+
+    HANDLE handle = FindFirstFileW(search_path.c_str(), &ffd);
+    if (handle == INVALID_HANDLE_VALUE) {
+        return std::nullopt;
+    }
+
+    do {
+        entries.emplace_back(Common::UTF16ToUTF8(ffd.cFileName));
+    } while (FindNextFileW(handle, &ffd) != 0);
+
+    FindClose(handle);
+    return entries;
+}
+
+#elif defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
+
+std::optional<std::vector<std::string>> ListDirectoryEntries(const std::string& directory) {
+    if (AndroidCanUseRawFS()) {
+        std::vector<std::string> entries;
+
+        DIR* dirp = opendir(AndroidTranslateFilename(directory).c_str());
+        if (!dirp)
+            return std::nullopt;
+
+        while (dirent* entry = readdir(dirp)) {
+            entries.emplace_back(entry->d_name);
+        }
+
+        closedir(dirp);
+        return entries;
+    } else {
+        return AndroidStorage::GetFilesName(directory);
+    }
+}
+
+#else
+
+std::optional<std::vector<std::string>> ListDirectoryEntries(const std::string& directory) {
+    std::vector<std::string> entries;
+
+    DIR* dirp = opendir(directory.c_str());
+    if (!dirp)
+        return std::nullopt;
+
+    while (dirent* entry = readdir(dirp)) {
+        entries.emplace_back(entry->d_name);
+    }
+
+    closedir(dirp);
+    return entries;
+}
+
+#endif
+
+} // anonymous namespace
+
 bool ForeachDirectoryEntry(u64* num_entries_out, const std::string& directory,
                            DirectoryEntryCallable callback) {
     LOG_TRACE(Common_Filesystem, "directory {}", directory);
 
-    // How many files + directories we found
-    u64 found_entries = 0;
-
-    // Save the status of callback function
-    bool callback_error = false;
-
-#ifdef _WIN32
-    // Find the first file in the directory.
-    WIN32_FIND_DATAW ffd;
-
-    HANDLE handle_find = FindFirstFileW(Common::UTF8ToUTF16W(directory + "\\*").c_str(), &ffd);
-    if (handle_find == INVALID_HANDLE_VALUE) {
-        FindClose(handle_find);
+    const auto entries = ListDirectoryEntries(directory);
+    if (!entries.has_value()) {
         return false;
     }
-    // windows loop
-    do {
-        const std::string virtual_name(Common::UTF16ToUTF8(ffd.cFileName));
-#elif defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
-    // android loop
-    auto result = AndroidStorage::GetFilesName(directory);
-    for (auto virtual_name : result) {
-#else
-    DIR* dirp = opendir(directory.c_str());
-    if (!dirp)
-        return false;
 
-    // non windows loop
-    while (struct dirent* result = readdir(dirp)) {
-        const std::string virtual_name(result->d_name);
-#endif
+    u64 found_entries = 0;
 
+    for (const std::string& virtual_name : *entries) {
         if (virtual_name == "." || virtual_name == "..")
             continue;
 
         u64 ret_entries = 0;
-        if (!callback(&ret_entries, directory, virtual_name)) {
-            callback_error = true;
-            break;
-        }
+        if (!callback(&ret_entries, directory, virtual_name))
+            return false;
+
         found_entries += ret_entries;
-
-#ifdef _WIN32
-    } while (FindNextFileW(handle_find, &ffd) != 0);
-    FindClose(handle_find);
-#elif defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
     }
-#else
-    }
-    closedir(dirp);
-#endif
-
-    if (callback_error)
-        return false;
 
     // num_entries_out is allowed to be specified nullptr, in which case we shouldn't try to set it
-    if (num_entries_out != nullptr)
+    if (num_entries_out)
         *num_entries_out = found_entries;
+
     return true;
 }
 
@@ -658,48 +757,39 @@ bool DeleteDirRecursively(const std::string& directory, unsigned int recursion) 
 
 void CopyDir([[maybe_unused]] const std::string& source_path,
              [[maybe_unused]] const std::string& dest_path) {
-#ifndef _WIN32
     if (source_path == dest_path)
         return;
+
     if (!FileUtil::Exists(source_path))
         return;
+
     if (!FileUtil::Exists(dest_path))
         FileUtil::CreateFullPath(dest_path);
 
-#if defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
-    auto result = AndroidStorage::GetFilesName(source_path);
-    for (auto virtualName : result) {
-#else
-    DIR* dirp = opendir(source_path.c_str());
-    if (!dirp)
+    const auto entries = ListDirectoryEntries(source_path);
+    if (!entries.has_value() || (*entries).empty())
         return;
 
-    while (struct dirent* result = readdir(dirp)) {
-        const std::string virtualName(result->d_name);
-#endif // ANDROID
-
-        // check for "." and ".."
-        if (((virtualName[0] == '.') && (virtualName[1] == '\0')) ||
-            ((virtualName[0] == '.') && (virtualName[1] == '.') && (virtualName[2] == '\0')))
+    for (const std::string& virtual_name : *entries) {
+        if (virtual_name == "." || virtual_name == "..")
             continue;
 
-        std::string source, dest;
-        source = source_path + virtualName;
-        dest = dest_path + virtualName;
+        std::string source = source_path + virtual_name;
+        std::string dest = dest_path + virtual_name;
+
         if (IsDirectory(source)) {
             source += '/';
             dest += '/';
+
             if (!FileUtil::Exists(dest))
                 FileUtil::CreateFullPath(dest);
-            CopyDir(source, dest);
-        } else if (!FileUtil::Exists(dest))
-            FileUtil::Copy(source, dest);
-    }
 
-#if !(defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS))
-    closedir(dirp);
-#endif // ANDROID
-#endif // _WIN32
+            CopyDir(source, dest);
+        } else {
+            if (!FileUtil::Exists(dest))
+                FileUtil::Copy(source, dest);
+        }
+    }
 }
 
 std::optional<std::string> GetCurrentDir() {
@@ -1234,34 +1324,37 @@ bool IOFile::Open() {
     m_good = m_file != nullptr;
 
 #elif defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
-    // Check whether filepath is startsWith content
-    AndroidStorage::AndroidOpenMode android_open_mode = AndroidStorage::ParseOpenmode(openmode);
-    if (android_open_mode == AndroidStorage::AndroidOpenMode::WRITE ||
-        android_open_mode == AndroidStorage::AndroidOpenMode::READ_WRITE ||
-        android_open_mode == AndroidStorage::AndroidOpenMode::WRITE_APPEND ||
-        android_open_mode == AndroidStorage::AndroidOpenMode::WRITE_TRUNCATE ||
-        android_open_mode == AndroidStorage::AndroidOpenMode::READ_WRITE_TRUNCATE ||
-        android_open_mode == AndroidStorage::AndroidOpenMode::READ_WRITE_APPEND) {
-        if (!FileUtil::Exists(filename)) {
-            std::string directory(GetParentPath(filename));
-            std::string display_name(GetFilename(filename));
-            if (!AndroidStorage::CreateFile(directory, display_name)) {
-                m_good = m_file != nullptr;
-                return m_good;
+    if (AndroidCanUseRawFS()) {
+        m_file = FOPEN(AndroidTranslateFilename(filename).c_str(), openmode.c_str());
+    } else {
+        // Check whether filepath is startsWith content
+        AndroidStorage::AndroidOpenMode android_open_mode = AndroidStorage::ParseOpenmode(openmode);
+        if (android_open_mode == AndroidStorage::AndroidOpenMode::WRITE ||
+            android_open_mode == AndroidStorage::AndroidOpenMode::READ_WRITE ||
+            android_open_mode == AndroidStorage::AndroidOpenMode::WRITE_APPEND ||
+            android_open_mode == AndroidStorage::AndroidOpenMode::WRITE_TRUNCATE ||
+            android_open_mode == AndroidStorage::AndroidOpenMode::READ_WRITE_TRUNCATE ||
+            android_open_mode == AndroidStorage::AndroidOpenMode::READ_WRITE_APPEND) {
+            if (!FileUtil::Exists(filename)) {
+                std::string directory(GetParentPath(filename));
+                std::string display_name(GetFilename(filename));
+                if (!AndroidStorage::CreateFile(directory, display_name)) {
+                    m_good = m_file != nullptr;
+                    return m_good;
+                }
+            }
+        }
+        m_fd = AndroidStorage::OpenContentUri(filename, android_open_mode);
+        if (m_fd != -1) {
+            int error_num = 0;
+            m_file = fdopen(m_fd, openmode.c_str());
+            error_num = errno;
+            if (error_num != 0 && m_file == nullptr) {
+                LOG_ERROR(Common_Filesystem, "Error on file: {}, error: {}", filename,
+                          strerror(error_num));
             }
         }
     }
-    m_fd = AndroidStorage::OpenContentUri(filename, android_open_mode);
-    if (m_fd != -1) {
-        int error_num = 0;
-        m_file = fdopen(m_fd, openmode.c_str());
-        error_num = errno;
-        if (error_num != 0 && m_file == nullptr) {
-            LOG_ERROR(Common_Filesystem, "Error on file: {}, error: {}", filename,
-                      strerror(error_num));
-        }
-    }
-
     m_good = m_file != nullptr;
 #else
     m_file = FOPEN(filename.c_str(), openmode.c_str());

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -145,23 +145,6 @@ static void StripTailDirSlashes(std::string& fname) {
     fname.resize(i);
 }
 
-#if defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
-namespace {
-std::string AndroidTranslateFilename(const std::string& file) {
-    std::optional<std::string> userDirLocation = AndroidStorage::GetUserDirectory();
-    if (userDirLocation) {
-        return *userDirLocation + file;
-    }
-
-    return "";
-}
-
-bool AndroidCanUseRawFS() {
-    return AndroidStorage::GetBuildFlavor() != AndroidStorage::AndroidBuildFlavors::GOOGLEPLAY;
-}
-} // anonymous namespace
-#endif
-
 bool Exists(const std::string& filename) {
     std::string copy(filename);
     StripTailDirSlashes(copy);
@@ -175,9 +158,9 @@ bool Exists(const std::string& filename) {
     int result = _wstat64(Common::UTF8ToUTF16W(copy).c_str(), &file_info);
 #elif defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
     int result;
-    if (AndroidCanUseRawFS()) {
+    if (AndroidStorage::CanUseRawFS()) {
         struct stat file_info;
-        result = stat(AndroidTranslateFilename(copy).c_str(), &file_info);
+        result = stat(AndroidStorage::TranslateFilePath(copy).c_str(), &file_info);
     } else {
         result = AndroidStorage::FileExists(filename) ? 0 : -1;
     }
@@ -204,8 +187,8 @@ bool IsDirectory(const std::string& filename) {
 #elif defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
     struct stat file_info;
     int result;
-    if (AndroidCanUseRawFS()) {
-        result = stat(AndroidTranslateFilename(copy).c_str(), &file_info);
+    if (AndroidStorage::CanUseRawFS()) {
+        result = stat(AndroidStorage::TranslateFilePath(copy).c_str(), &file_info);
     } else {
         return AndroidStorage::IsDirectory(filename);
     }
@@ -222,19 +205,19 @@ bool IsDirectory(const std::string& filename) {
     return S_ISDIR(file_info.st_mode);
 }
 
-bool Delete(const std::string& filename) {
-    LOG_TRACE(Common_Filesystem, "file {}", filename);
+bool Delete(const std::string& filepath) {
+    LOG_TRACE(Common_Filesystem, "file {}", filepath);
 
     // Return true because we care about the file no
     // being there, not the actual delete.
-    if (!Exists(filename)) {
-        LOG_DEBUG(Common_Filesystem, "{} does not exist", filename);
+    if (!Exists(filepath)) {
+        LOG_DEBUG(Common_Filesystem, "{} does not exist", filepath);
         return true;
     }
 
     // We can't delete a directory
-    if (IsDirectory(filename)) {
-        LOG_ERROR(Common_Filesystem, "Failed: {} is a directory", filename);
+    if (IsDirectory(filepath)) {
+        LOG_ERROR(Common_Filesystem, "Failed: {} is a directory", filepath);
         return false;
     }
 
@@ -248,39 +231,39 @@ bool Delete(const std::string& filename) {
     // finally deleted.
     static std::atomic<uint64_t> counter{0};
 
-    const std::wstring wfilename = Common::UTF8ToUTF16W(filename);
+    const std::wstring wfilepath = Common::UTF8ToUTF16W(filepath);
     const DWORD pid = GetCurrentProcessId();
     const uint64_t id = counter++;
 
     std::wstring deleted_path =
-        wfilename + L".deleted." + std::to_wstring(pid) + L"." + std::to_wstring(id);
+        wfilepath + L".deleted." + std::to_wstring(pid) + L"." + std::to_wstring(id);
 
     // Rename first
-    if (MoveFileExW(wfilename.c_str(), deleted_path.c_str(), MOVEFILE_REPLACE_EXISTING)) {
+    if (MoveFileExW(wfilepath.c_str(), deleted_path.c_str(), MOVEFILE_REPLACE_EXISTING)) {
         // Then mark file for deletion
         DeleteFileW(deleted_path.c_str());
         return true;
     }
 
-    LOG_ERROR(Common_Filesystem, "Rename to deleted path failed on {}: {}", filename,
+    LOG_ERROR(Common_Filesystem, "Rename to deleted path failed on {}: {}", filepath,
               GetLastErrorMsg());
 
     return false;
 #elif defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
-    if (AndroidCanUseRawFS()) {
-        if (unlink(AndroidTranslateFilename(filename).c_str()) == -1) {
-            LOG_ERROR(Common_Filesystem, "unlink failed on {}: {}", filename, GetLastErrorMsg());
+    if (AndroidStorage::CanUseRawFS()) {
+        if (unlink(AndroidStorage::TranslateFilePath(filepath).c_str()) == -1) {
+            LOG_ERROR(Common_Filesystem, "unlink failed on {}: {}", filepath, GetLastErrorMsg());
             return false;
         }
     } else {
-        if (!AndroidStorage::DeleteDocument(filename)) {
-            LOG_ERROR(Common_Filesystem, "unlink failed on {}", filename);
+        if (!AndroidStorage::DeleteDocument(filepath)) {
+            LOG_ERROR(Common_Filesystem, "unlink failed on {}", filepath);
             return false;
         }
     }
 #else
-    if (unlink(filename.c_str()) == -1) {
-        LOG_ERROR(Common_Filesystem, "unlink failed on {}: {}", filename, GetLastErrorMsg());
+    if (unlink(filepath.c_str()) == -1) {
+        LOG_ERROR(Common_Filesystem, "unlink failed on {}: {}", filepath, GetLastErrorMsg());
         return false;
     }
 #endif
@@ -301,8 +284,8 @@ bool CreateDir(const std::string& path) {
     LOG_ERROR(Common_Filesystem, "CreateDirectory failed on {}: {}", path, error);
     return false;
 #elif defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
-    if (AndroidCanUseRawFS()) {
-        if (mkdir(AndroidTranslateFilename(path).c_str(), 0755) == 0)
+    if (AndroidStorage::CanUseRawFS()) {
+        if (mkdir(AndroidStorage::TranslateFilePath(path).c_str(), 0755) == 0)
             return true;
 
         int err = errno;
@@ -404,8 +387,8 @@ bool DeleteDir(const std::string& filename) {
     if (::RemoveDirectoryW(Common::UTF8ToUTF16W(filename).c_str()))
         return true;
 #elif defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
-    if (AndroidCanUseRawFS()) {
-        if (rmdir(AndroidTranslateFilename(filename).c_str()) == 0)
+    if (AndroidStorage::CanUseRawFS()) {
+        if (rmdir(AndroidStorage::TranslateFilePath(filename).c_str()) == 0)
             return true;
     } else {
         if (AndroidStorage::DeleteDocument(filename))
@@ -428,10 +411,9 @@ bool Rename(const std::string& srcFullPath, const std::string& destFullPath) {
         return true;
     }
 #elif defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
-    if (AndroidCanUseRawFS()) {
-        if (rename(AndroidTranslateFilename(srcFullPath).c_str(),
-                   AndroidTranslateFilename(destFullPath).c_str()) == 0) {
-
+    if (AndroidStorage::CanUseRawFS()) {
+        if (rename(AndroidStorage::TranslateFilePath(srcFullPath).c_str(),
+                   AndroidStorage::TranslateFilePath(destFullPath).c_str()) == 0) {
             return true;
         }
     } else {
@@ -504,9 +486,9 @@ bool Copy(const std::string& srcFilename, const std::string& destFilename) {
     };
 
 #if defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
-    if (AndroidCanUseRawFS()) {
-        return copy_files(AndroidTranslateFilename(srcFilename),
-                          AndroidTranslateFilename(destFilename));
+    if (AndroidStorage::CanUseRawFS()) {
+        return copy_files(AndroidStorage::TranslateFilePath(srcFilename),
+                          AndroidStorage::TranslateFilePath(destFilename));
     } else {
         return AndroidStorage::CopyFile(srcFilename, std::string(GetParentPath(destFilename)),
                                         std::string(GetFilename(destFilename)));
@@ -534,8 +516,8 @@ u64 GetSize(const std::string& filename) {
     struct _stat64 buf;
     if (_wstat64(Common::UTF8ToUTF16W(filename).c_str(), &buf) == 0)
 #elif defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
-    if (AndroidCanUseRawFS()) {
-        if (stat(AndroidTranslateFilename(filename).c_str(), &buf) == 0) {
+    if (AndroidStorage::CanUseRawFS()) {
+        if (stat(AndroidStorage::TranslateFilePath(filename).c_str(), &buf) == 0) {
             return buf.st_size;
         }
     } else {
@@ -616,10 +598,10 @@ std::optional<std::vector<std::string>> ListDirectoryEntries(const std::string& 
 #elif defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
 
 std::optional<std::vector<std::string>> ListDirectoryEntries(const std::string& directory) {
-    if (AndroidCanUseRawFS()) {
+    if (AndroidStorage::CanUseRawFS()) {
         std::vector<std::string> entries;
 
-        DIR* dirp = opendir(AndroidTranslateFilename(directory).c_str());
+        DIR* dirp = opendir(AndroidStorage::TranslateFilePath(directory).c_str());
         if (!dirp)
             return std::nullopt;
 
@@ -1324,8 +1306,8 @@ bool IOFile::Open() {
     m_good = m_file != nullptr;
 
 #elif defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
-    if (AndroidCanUseRawFS()) {
-        m_file = FOPEN(AndroidTranslateFilename(filename).c_str(), openmode.c_str());
+    if (AndroidStorage::CanUseRawFS()) {
+        m_file = FOPEN(AndroidStorage::TranslateFilePath(filename).c_str(), openmode.c_str());
     } else {
         // Check whether filepath is startsWith content
         AndroidStorage::AndroidOpenMode android_open_mode = AndroidStorage::ParseOpenmode(openmode);


### PR DESCRIPTION
This PR fully migrates all `file_util.cpp` functions on Android vanilla builds to use the raw UNIX FS access methods, instead of going through the documents contract which is very slow.

This change bring significant improvements to FS access on Android. For example, booting the home menu now takes 5 seconds (comparable to desktop times) instead of 30-45 seconds. Stutter caused by FS operations is greatly reduced or removed.

To do:
- [X] Migrate FS access to raw method calls
- [x] Fix application directory not being accessible
- [x] Fix CIA installation failing (^ probably related)
- [x] Fix CIA uninstallation failing (use Service::AM::UninstallProgram)
- [ ] Testing