### PR TITLE
video_core: Move shader and pipeline compilation into separate workers

### DIFF
--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.h
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.h
@@ -147,7 +147,8 @@ private:
     vk::UniquePipelineCache driver_pipeline_cache;
     vk::UniquePipelineLayout pipeline_layout;
     std::size_t num_worker_threads;
-    Common::ThreadWorker workers;
+    Common::ThreadWorker pipeline_workers;
+    Common::ThreadWorker shader_workers;
     PipelineInfo current_info{};
     GraphicsPipeline* current_pipeline{};
     std::array<DescriptorHeap, NumDescriptorHeaps> descriptor_heaps;


### PR DESCRIPTION
Separates the shader and pipeline compilation tasks into their own dedicated workers.

Previously a single worker was used for both tasks, which could decrease parallelism. WIth separate workers, shaders can get compiled without longer pipeline tasks blocking them.

Minor improvement in shader compilation stutter.