### PR TITLE
ci: Use macOS 26 runner for Intel build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
           path: artifacts/
 
   macos:
-    runs-on: ${{ (matrix.target == 'x86_64' && 'macos-15-intel') || 'macos-26' }}
+    runs-on: ${{ (matrix.target == 'x86_64' && 'macos-26-intel') || 'macos-26' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This brings the Intel macOS runner in line with the Apple Silicon runner.