### PR TITLE
Re: ci: Libretro artifacts are now packed within properly named archives

### DIFF
--- a/.github/workflows/libretro.yml
+++ b/.github/workflows/libretro.yml
@@ -41,11 +41,12 @@ jobs:
           export NDK_ROOT=${ANDROID_SDK_ROOT}/ndk/$ANDROID_NDK_VERSION
           ${ANDROID_SDK_ROOT}/cmake/3.30.3/bin/cmake $CORE_ARGS -DANDROID_PLATFORM=android-$API_LEVEL -DCMAKE_TOOLCHAIN_FILE=$NDK_ROOT/build/cmake/android.toolchain.cmake -DANDROID_STL=c++_static -DANDROID_ABI=$ANDROID_ABI . -B $BUILD_DIR
           ${ANDROID_SDK_ROOT}/cmake/3.30.3/bin/cmake --build $BUILD_DIR --target azahar_libretro --config Release -j $(nproc)
+          zip -j -9 azahar-libretro-android-arm64.zip ${{ env.BUILD_DIR }}/${{ env.EXTRA_PATH }}/azahar_libretro_android.*
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.OS }}-${{ env.TARGET }}
-          path: ${{ env.BUILD_DIR }}/${{ env.EXTRA_PATH }}/azahar_libretro_android.so
+          path: ./*.zip
   linux:
     runs-on: ubuntu-22.04
     env:
@@ -62,11 +63,12 @@ jobs:
         run: |
           cmake $CORE_ARGS $EXTRA_CORE_ARGS . -B $BUILD_DIR
           cmake --build $BUILD_DIR --target azahar_libretro --config Release -j $(nproc)
+          zip -j -9 azahar-libretro-linux-x86_64.zip ${{ env.BUILD_DIR }}/${{ env.EXTRA_PATH }}/azahar_libretro.*
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.OS }}-${{ env.TARGET }}
-          path: ${{ env.BUILD_DIR }}/${{ env.EXTRA_PATH }}/azahar_libretro.so
+          path: ./*.zip
   windows:
     runs-on: ubuntu-latest
     env:
@@ -91,11 +93,12 @@ jobs:
               bash -lc "\
                   ${CMAKE} $CORE_ARGS $EXTRA_CORE_ARGS . -B $BUILD_DIR && \
                   ${CMAKE} --build $BUILD_DIR --target azahar_libretro --config Release -j $(nproc)"
+                  zip -j -9 azahar-libretro-windows-x86_64.zip ${{ env.BUILD_DIR }}/${{ env.EXTRA_PATH }}/azahar_libretro.*
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.OS }}-${{ env.TARGET }}
-          path: ${{ env.BUILD_DIR }}/${{ env.EXTRA_PATH }}/azahar_libretro.dll
+          path: ./*.zip
   macos:
     runs-on: macos-26
     strategy:
@@ -117,11 +120,12 @@ jobs:
         run: |
           cmake $CORE_ARGS -DCMAKE_OSX_ARCHITECTURES=$TARGET . -B $BUILD_DIR
           cmake --build $BUILD_DIR --target azahar_libretro --config Release
+          zip -j -9 azahar-libretro-macos-$TARGET.zip ${{ env.BUILD_DIR }}/${{ env.EXTRA_PATH }}/azahar_libretro.*
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.OS }}-${{ env.TARGET }}
-          path: ${{ env.BUILD_DIR }}/${{ env.EXTRA_PATH }}/azahar_libretro.dylib
+          path: ./*.zip
   ios:
     runs-on: macos-26
     env:
@@ -138,11 +142,12 @@ jobs:
         run: |
           cmake $CORE_ARGS $EXTRA_CORE_ARGS . -B $BUILD_DIR
           cmake --build $BUILD_DIR --target azahar_libretro --config Release
+          zip -j -9 azahar-libretro-ios.zip ${{ env.BUILD_DIR }}/${{ env.EXTRA_PATH }}/azahar_libretro.*
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.OS }}-${{ env.TARGET }}
-          path: ${{ env.BUILD_DIR }}/${{ env.EXTRA_PATH }}/azahar_libretro.dylib
+          path: ./*.zip
   tvos:
     runs-on: macos-26
     env:
@@ -159,8 +164,9 @@ jobs:
         run: |
           cmake $CORE_ARGS $EXTRA_CORE_ARGS . -B $BUILD_DIR
           cmake --build $BUILD_DIR --target azahar_libretro --config Release
+          zip -j -9 azahar-libretro-tvos.zip ${{ env.BUILD_DIR }}/${{ env.EXTRA_PATH }}/azahar_libretro.*
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.OS }}-${{ env.TARGET }}
-          path: ${{ env.BUILD_DIR }}/${{ env.EXTRA_PATH }}/azahar_libretro.dylib
+          path: ./*.zip


### PR DESCRIPTION
Fixed version of #1804, which contained incorrect archive filenames due to a bad copy-paste. Whoops!