### PR TITLE
Make camera functions thread-safe

### DIFF
--- a/src/citra_qt/camera/qt_camera_base.cpp
+++ b/src/citra_qt/camera/qt_camera_base.cpp
@@ -42,9 +42,11 @@ void QtCameraInterface::SetEffect(Service::CAM::Effect effect) {
 
 std::vector<u16> QtCameraInterface::ReceiveFrame() {
     QImage img;
+    // If executing from Qt thread, call directly as normal
     if (QThread::currentThread() == QCoreApplication::instance()->thread()) {
         img = QtReceiveFrame();
-    } else {
+    } else { // If not on Qt thread, switch to Qt thread to call QtReceiveFrame, as calling it from
+             // a different thread will cause deadlocks in msys2 builds
         QMetaObject::invokeMethod(
             QCoreApplication::instance(), [&]() { img = QtReceiveFrame(); },
             Qt::BlockingQueuedConnection);

--- a/src/citra_qt/camera/qt_camera_base.cpp
+++ b/src/citra_qt/camera/qt_camera_base.cpp
@@ -1,8 +1,11 @@
-// Copyright Citra Emulator Project / Lime3DS Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <QCoreApplication>
 #include <QMessageBox>
+#include <QMetaObject>
+#include <QThread>
 #include "citra_qt/camera/camera_util.h"
 #include "citra_qt/camera/qt_camera_base.h"
 #include "common/logging/log.h"
@@ -38,8 +41,15 @@ void QtCameraInterface::SetEffect(Service::CAM::Effect effect) {
 }
 
 std::vector<u16> QtCameraInterface::ReceiveFrame() {
-    return CameraUtil::ProcessImage(QtReceiveFrame(), width, height, output_rgb, flip_horizontal,
-                                    flip_vertical);
+    QImage img;
+    if (QThread::currentThread() == QCoreApplication::instance()->thread()) {
+        img = QtReceiveFrame();
+    } else {
+        QMetaObject::invokeMethod(
+            QCoreApplication::instance(), [&]() { img = QtReceiveFrame(); },
+            Qt::BlockingQueuedConnection);
+    }
+    return CameraUtil::ProcessImage(img, width, height, output_rgb, flip_horizontal, flip_vertical);
 }
 
 std::unique_ptr<CameraInterface> QtCameraFactory::CreatePreview(const std::string& config,

--- a/src/citra_qt/camera/qt_multimedia_camera.h
+++ b/src/citra_qt/camera/qt_multimedia_camera.h
@@ -1,4 +1,4 @@
-// Copyright 2018 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -9,6 +9,8 @@
 #include <QCamera>
 #include <QImage>
 #include <QMediaCaptureSession>
+#include <QMetaObject>
+#include <QThread>
 #include <QVideoSink>
 #include "citra_qt/camera/camera_util.h"
 #include "citra_qt/camera/qt_camera_base.h"
@@ -24,8 +26,8 @@ public:
     explicit QtMultimediaCameraHandler(const std::string& camera_name);
     ~QtMultimediaCameraHandler();
 
-    void StartCapture();
-    void StopCapture();
+    Q_INVOKABLE void StartCapture();
+    Q_INVOKABLE void StopCapture();
 
     QImage QtReceiveFrame() {
         return camera_surface->videoFrame().toImage();
@@ -76,17 +78,33 @@ public:
         : QtCameraInterface(flip), handler(handler) {}
 
     void StartCapture() override {
-        handler->StartCapture();
+        if (handler->thread() == QThread::currentThread()) {
+            handler->StartCapture();
+        } else {
+            QMetaObject::invokeMethod(handler.get(), "StartCapture", Qt::BlockingQueuedConnection);
+        }
     }
 
     void StopCapture() override {
-        handler->StopCapture();
+        if (handler->thread() == QThread::currentThread()) {
+            handler->StopCapture();
+        } else {
+            QMetaObject::invokeMethod(handler.get(), "StopCapture", Qt::BlockingQueuedConnection);
+        }
     }
 
     void SetFrameRate(Service::CAM::FrameRate frame_rate) override {}
 
     QImage QtReceiveFrame() override {
-        return handler->QtReceiveFrame();
+        if (handler->thread() == QThread::currentThread()) {
+            return handler->QtReceiveFrame();
+        }
+
+        QImage frame;
+        QMetaObject::invokeMethod(
+            handler.get(), [&]() { frame = handler->QtReceiveFrame(); },
+            Qt::BlockingQueuedConnection);
+        return frame;
     }
 
     bool IsPreviewAvailable() override {

--- a/src/citra_qt/camera/qt_multimedia_camera.h
+++ b/src/citra_qt/camera/qt_multimedia_camera.h
@@ -1,4 +1,4 @@
-// Copyright Citra Emulator Project / Azahar Emulator Project
+// Copyright 2018 Citra Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -9,8 +9,6 @@
 #include <QCamera>
 #include <QImage>
 #include <QMediaCaptureSession>
-#include <QMetaObject>
-#include <QThread>
 #include <QVideoSink>
 #include "citra_qt/camera/camera_util.h"
 #include "citra_qt/camera/qt_camera_base.h"
@@ -26,8 +24,8 @@ public:
     explicit QtMultimediaCameraHandler(const std::string& camera_name);
     ~QtMultimediaCameraHandler();
 
-    Q_INVOKABLE void StartCapture();
-    Q_INVOKABLE void StopCapture();
+    void StartCapture();
+    void StopCapture();
 
     QImage QtReceiveFrame() {
         return camera_surface->videoFrame().toImage();
@@ -78,33 +76,17 @@ public:
         : QtCameraInterface(flip), handler(handler) {}
 
     void StartCapture() override {
-        if (handler->thread() == QThread::currentThread()) {
-            handler->StartCapture();
-        } else {
-            QMetaObject::invokeMethod(handler.get(), "StartCapture", Qt::BlockingQueuedConnection);
-        }
+        handler->StartCapture();
     }
 
     void StopCapture() override {
-        if (handler->thread() == QThread::currentThread()) {
-            handler->StopCapture();
-        } else {
-            QMetaObject::invokeMethod(handler.get(), "StopCapture", Qt::BlockingQueuedConnection);
-        }
+        handler->StopCapture();
     }
 
     void SetFrameRate(Service::CAM::FrameRate frame_rate) override {}
 
     QImage QtReceiveFrame() override {
-        if (handler->thread() == QThread::currentThread()) {
-            return handler->QtReceiveFrame();
-        }
-
-        QImage frame;
-        QMetaObject::invokeMethod(
-            handler.get(), [&]() { frame = handler->QtReceiveFrame(); },
-            Qt::BlockingQueuedConnection);
-        return frame;
+        return handler->QtReceiveFrame();
     }
 
     bool IsPreviewAvailable() override {


### PR DESCRIPTION
Fixes #1022 

The camera worked on MSVC builds due to the compiler being more lenient, but since MSYS2 tends to be more strict, it would just crash instead.