### PR TITLE
Qt: Bundle FXAA and grayscale post-processing shaders

### DIFF
--- a/dist/shaders/FXAA.glsl
+++ b/dist/shaders/FXAA.glsl
@@ -1,0 +1,67 @@
+//			DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//					Version 2, December 2004
+
+// Copyright (C) 2013 mudlord
+
+// Everyone is permitted to copy and distribute verbatim or modified
+// copies of this license document, and changing it is allowed as long
+// as the name is changed.
+
+//			DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//	TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+// 0. You just DO WHAT THE FUCK YOU WANT TO.
+
+#define FXAA_REDUCE_MIN		(1.0/ 128.0)
+#define FXAA_REDUCE_MUL		(1.0 / 8.0)
+#define FXAA_SPAN_MAX		8.0
+
+float4 applyFXAA(float2 fragCoord)
+{
+	float4 color;
+	float2 inverseVP = GetInvResolution();
+	float3 rgbNW = SampleLocation((fragCoord + float2(-1.0, -1.0)) * inverseVP).xyz;
+	float3 rgbNE = SampleLocation((fragCoord + float2(1.0, -1.0)) * inverseVP).xyz;
+	float3 rgbSW = SampleLocation((fragCoord + float2(-1.0, 1.0)) * inverseVP).xyz;
+	float3 rgbSE = SampleLocation((fragCoord + float2(1.0, 1.0)) * inverseVP).xyz;
+	float3 rgbM  = SampleLocation(fragCoord  * inverseVP).xyz;
+	float3 luma = float3(0.299, 0.587, 0.114);
+	float lumaNW = dot(rgbNW, luma);
+	float lumaNE = dot(rgbNE, luma);
+	float lumaSW = dot(rgbSW, luma);
+	float lumaSE = dot(rgbSE, luma);
+	float lumaM  = dot(rgbM,  luma);
+	float lumaMin = min(lumaM, min(min(lumaNW, lumaNE), min(lumaSW, lumaSE)));
+	float lumaMax = max(lumaM, max(max(lumaNW, lumaNE), max(lumaSW, lumaSE)));
+
+	float2 dir;
+	dir.x = -((lumaNW + lumaNE) - (lumaSW + lumaSE));
+	dir.y =  ((lumaNW + lumaSW) - (lumaNE + lumaSE));
+
+	float dirReduce = max((lumaNW + lumaNE + lumaSW + lumaSE) *
+						(0.25 * FXAA_REDUCE_MUL), FXAA_REDUCE_MIN);
+
+	float rcpDirMin = 1.0 / (min(abs(dir.x), abs(dir.y)) + dirReduce);
+	dir = min(float2(FXAA_SPAN_MAX, FXAA_SPAN_MAX),
+			max(float2(-FXAA_SPAN_MAX, -FXAA_SPAN_MAX),
+			dir * rcpDirMin)) * inverseVP;
+
+	float3 rgbA = 0.5 * (
+		SampleLocation(fragCoord * inverseVP + dir * (1.0 / 3.0 - 0.5)).xyz +
+		SampleLocation(fragCoord * inverseVP + dir * (2.0 / 3.0 - 0.5)).xyz);
+	float3 rgbB = rgbA * 0.5 + 0.25 * (
+		SampleLocation(fragCoord * inverseVP + dir * -0.5).xyz +
+		SampleLocation(fragCoord * inverseVP + dir * 0.5).xyz);
+
+	float lumaB = dot(rgbB, luma);
+	if ((lumaB < lumaMin) || (lumaB > lumaMax))
+		color = float4(rgbA, 1.0);
+	else
+		color = float4(rgbB, 1.0);
+	return color;
+}
+
+void main()
+{
+	SetOutput(applyFXAA(GetCoordinates() * GetResolution()));
+}

--- a/dist/shaders/grayscale.glsl
+++ b/dist/shaders/grayscale.glsl
@@ -1,0 +1,6 @@
+void main()
+{
+	float4 c0 = Sample();
+	float avg = (c0.r + c0.g + c0.b) / 3.0;
+	SetOutput(float4(avg, avg, avg, c0.a));
+}

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -164,7 +164,7 @@ void Config::ReadValues() {
 
     ReadSetting("Renderer", Settings::values.render_3d);
     ReadSetting("Renderer", Settings::values.factor_3d);
-    std::string default_shader = "None (builtin)";
+    std::string default_shader = "None";
     if (Settings::values.render_3d.GetValue() == Settings::StereoRenderOption::Anaglyph)
         default_shader = "Dubois (builtin)";
     else if (Settings::values.render_3d.GetValue() == Settings::StereoRenderOption::Interlaced)

--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -277,6 +277,14 @@ target_link_libraries(citra_qt PRIVATE ${PLATFORM_LIBRARIES} Threads::Threads)
 
 if (ENABLE_OPENGL)
     target_link_libraries(citra_qt PRIVATE glad)
+
+    file(GLOB SHADERS ${PROJECT_SOURCE_DIR}/dist/shaders/*)
+
+    qt_add_resources(citra_qt "shaders"
+    PREFIX "/shaders"
+    BASE "${PROJECT_SOURCE_DIR}/dist/shaders"
+    FILES ${SHADERS}
+    )
 endif()
 
 if (ENABLE_VULKAN)

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -461,6 +461,23 @@ GMainWindow::GMainWindow(Core::System& system_)
     if (!game_path.isEmpty()) {
         BootGame(game_path);
     }
+
+    // Add bundled post-processing shaders on first startup
+    std::string shader_dir = FileUtil::GetUserPath(FileUtil::UserPath::ShaderDir);
+
+    if (!FileUtil::IsDirectory(shader_dir)) {
+        FileUtil::CreateDir(shader_dir);
+
+        QDir resourceDir(QStringLiteral(":/shaders"));
+        const QStringList files = resourceDir.entryList(QDir::Files);
+
+        const QString shader_dir_q = QString::fromStdString(shader_dir);
+
+        for (const QString& file : files) {
+            QFile::copy(QStringLiteral(":/shaders/") + file,
+                        shader_dir_q + QLatin1Char('/') + file);
+        }
+    }
 }
 
 GMainWindow::~GMainWindow() {

--- a/src/citra_qt/configuration/configure_enhancements.cpp
+++ b/src/citra_qt/configuration/configure_enhancements.cpp
@@ -88,7 +88,7 @@ void ConfigureEnhancements::updateShaders(Settings::StereoRenderOption stereo_op
         ui->shader_combobox->addItem(QStringLiteral("Dubois (builtin)"));
         current_shader = Settings::values.anaglyph_shader_name.GetValue();
     } else {
-        ui->shader_combobox->addItem(QStringLiteral("None (builtin)"));
+        ui->shader_combobox->addItem(QStringLiteral("None"));
         current_shader = Settings::values.pp_shader_name.GetValue();
     }
 

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -601,7 +601,7 @@ struct Values {
     Setting<s32> cardboard_y_shift{0, Keys::cardboard_y_shift};
 
     SwitchableSetting<bool> filter_mode{true, Keys::filter_mode};
-    SwitchableSetting<std::string> pp_shader_name{"None (builtin)", Keys::pp_shader_name};
+    SwitchableSetting<std::string> pp_shader_name{"None", Keys::pp_shader_name};
     SwitchableSetting<std::string> anaglyph_shader_name{"Dubois (builtin)",
                                                         Keys::anaglyph_shader_name};
 

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -398,7 +398,7 @@ void RendererOpenGL::ReloadShader(Settings::StereoRenderOption render_3d) {
                render_3d == Settings::StereoRenderOption::ReverseInterlaced) {
         shader_data += HostShaders::OPENGL_PRESENT_INTERLACED_FRAG;
     } else {
-        if (Settings::values.pp_shader_name.GetValue() == "None (builtin)") {
+        if (Settings::values.pp_shader_name.GetValue() == "None") {
             shader_data += HostShaders::OPENGL_PRESENT_FRAG;
         } else {
             std::string shader_text = OpenGL::GetPostProcessingShaderCode(


### PR DESCRIPTION
Adds the possibility to bundle post-processing shaders (like [Dolphin does](https://github.com/dolphin-emu/dolphin/tree/master/Data/Sys/Shaders)), that are created upon first launch/when the shader folder is recreated. And with that, include Dolphin's FXAA and grayscale shaders (released under a "DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE")

FXAA provides a basic form of anti-aliasing until the proper implementation is finished. I actually find it to be surprisingly effective in this case. Add whatever more shaders you would like

Handled with Qt, as that was the simplest way I could think of. So does not apply to Android. Perhaps somebody could think of a better solution in the future?

Note: I may look into implementing shader support for Vulkan. It can also be noted that Azahar's OpenGL implementation of Dolphin's format is also technically incomplete, with `GetTime` and `GetOption` support missing, which might affect some few shaders atm