### PR TITLE
Desktop: Option to clear conflicting input maps rather than failing

### DIFF
--- a/src/citra_qt/configuration/configure_dialog.cpp
+++ b/src/citra_qt/configuration/configure_dialog.cpp
@@ -75,7 +75,10 @@ ConfigureDialog::ConfigureDialog(QWidget* parent, HotkeyRegistry& registry_, Cor
             &ConfigureHotkeys::OnInputKeysChanged);
     connect(hotkeys_tab.get(), &ConfigureHotkeys::HotkeysChanged, input_tab.get(),
             &ConfigureInput::OnHotkeysChanged);
-
+    connect(input_tab.get(), &ConfigureInput::ClearHotkey, hotkeys_tab.get(),
+            &ConfigureHotkeys::OnClearBinding);
+    connect(hotkeys_tab.get(), &ConfigureHotkeys::ClearInputBinding, input_tab.get(),
+            &ConfigureInput::OnClearBinding);
     // Synchronise lists upon initialisation
     input_tab->EmitInputKeysChanged();
     hotkeys_tab->EmitHotkeysChanged();

--- a/src/citra_qt/configuration/configure_hotkeys.cpp
+++ b/src/citra_qt/configuration/configure_hotkeys.cpp
@@ -43,13 +43,19 @@ void ConfigureHotkeys::EmitHotkeysChanged() {
     emit HotkeysChanged(GetUsedKeyList());
 }
 
-QList<QKeySequence> ConfigureHotkeys::GetUsedKeyList() const {
-    QList<QKeySequence> list;
+QMap<QKeySequence, ConfigureInput::InputBinding> ConfigureHotkeys::GetUsedKeyList() const {
+    QMap<QKeySequence, ConfigureInput::InputBinding> list;
     for (int r = 0; r < model->rowCount(); r++) {
         QStandardItem* parent = model->item(r, 0);
         for (int r2 = 0; r2 < parent->rowCount(); r2++) {
             QStandardItem* keyseq = parent->child(r2, 1);
-            list << QKeySequence::fromString(keyseq->text(), QKeySequence::NativeText);
+            auto seq = QKeySequence::fromString(keyseq->text(), QKeySequence::NativeText);
+            if (seq.count() == 1 &&
+                seq[0].keyboardModifiers() == Qt::KeyboardModifier::NoModifier) {
+                auto binding = ConfigureInput::InputBinding(
+                    "Hotkey", parent->child(r2, 0)->text().toStdString(), r2);
+                list[seq] = binding;
+            }
         }
     }
     return list;
@@ -75,7 +81,8 @@ void ConfigureHotkeys::Populate(const HotkeyRegistry& registry) {
     ui->hotkey_list->expandAll();
 }
 
-void ConfigureHotkeys::OnInputKeysChanged(QList<QKeySequence> new_key_list) {
+void ConfigureHotkeys::OnInputKeysChanged(
+    QMap<QKeySequence, ConfigureInput::InputBinding> new_key_list) {
     input_keys_list = new_key_list;
 }
 
@@ -96,7 +103,7 @@ void ConfigureHotkeys::Configure(QModelIndex index) {
     if (return_code == QDialog::Rejected || key_sequence.isEmpty()) {
         return;
     }
-    const auto [key_sequence_used, used_action] = IsUsedKey(key_sequence);
+    const auto [key_sequence_used, current_binding] = IsUsedKey(key_sequence);
 
     // Check for turbo/per-game speed conflict. Needed to prevent the user from binding both hotkeys
     // to the same action. Which cuases problems resetting the frame limit.to the inititla value.
@@ -131,22 +138,43 @@ void ConfigureHotkeys::Configure(QModelIndex index) {
     }
 
     if (key_sequence_used && key_sequence != QKeySequence(previous_key.toString())) {
-        QMessageBox::warning(
-            this, tr("Conflicting Key Sequence"),
-            tr("The entered key sequence is already assigned to: %1").arg(used_action));
-    } else {
-        model->setData(index, key_sequence.toString(QKeySequence::NativeText));
-        EmitHotkeysChanged();
+        auto response =
+            QMessageBox::question(this, QStringLiteral("Duplicate mapping"),
+                                  QString::fromStdString("This will clear the mapping for " +
+                                                         current_binding.name + ". Proceed?"),
+                                  QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+        if (response == QMessageBox::No) {
+            return;
+        } else {
+            if (current_binding.binding_type == "Hotkey") {
+                model->setData(index.sibling(current_binding.index, hotkey_column),
+                               QStringLiteral(""));
+            } else {
+                emit ClearInputBinding(current_binding);
+            }
+        }
     }
+
+    model->setData(index, key_sequence.toString(QKeySequence::NativeText));
+    EmitHotkeysChanged();
 }
 
-std::pair<bool, QString> ConfigureHotkeys::IsUsedKey(QKeySequence key_sequence) const {
+void ConfigureHotkeys::OnClearBinding(ConfigureInput::InputBinding hotkey_to_clear) {
+    const auto index = ui->hotkey_list->currentIndex();
+    if (hotkey_to_clear.binding_type == "Hotkey") {
+        model->setData(index.sibling(hotkey_to_clear.index, hotkey_column), QStringLiteral(""));
+    }
+    EmitHotkeysChanged();
+}
+
+std::pair<bool, ConfigureInput::InputBinding> ConfigureHotkeys::IsUsedKey(
+    QKeySequence key_sequence) const {
     if (key_sequence == QKeySequence::fromString(QStringLiteral(""), QKeySequence::NativeText)) {
-        return std::make_pair(false, QString());
+        return std::make_pair(false, ConfigureInput::InputBinding{"", "", -1});
     }
 
     if (input_keys_list.contains(key_sequence)) {
-        return std::make_pair(true, tr("A 3ds button"));
+        return std::make_pair(true, input_keys_list[key_sequence]);
     }
 
     for (int r = 0; r < model->rowCount(); ++r) {
@@ -158,12 +186,14 @@ std::pair<bool, QString> ConfigureHotkeys::IsUsedKey(QKeySequence key_sequence) 
             const auto key_seq = QKeySequence::fromString(key_seq_str, QKeySequence::NativeText);
 
             if (key_sequence == key_seq) {
-                return std::make_pair(true, parent->child(r2, 0)->text());
+                return std::make_pair(
+                    true, ConfigureInput::InputBinding{
+                              "Hotkey", parent->child(r2, 0)->text().toStdString(), r2});
             }
         }
     }
 
-    return std::make_pair(false, QString());
+    return std::make_pair(false, ConfigureInput::InputBinding{"", "", -1});
 }
 
 void ConfigureHotkeys::ApplyConfiguration(HotkeyRegistry& registry) {
@@ -197,6 +227,7 @@ void ConfigureHotkeys::RestoreDefaults() {
                 ->setText(QtConfig::default_hotkeys[r2].shortcut.keyseq);
         }
     }
+    EmitHotkeysChanged();
 }
 
 void ConfigureHotkeys::ClearAll() {
@@ -207,6 +238,7 @@ void ConfigureHotkeys::ClearAll() {
             model->item(r, 0)->child(r2, hotkey_column)->setText(QString{});
         }
     }
+    EmitHotkeysChanged();
 }
 
 void ConfigureHotkeys::PopupContextMenu(const QPoint& menu_location) {
@@ -234,12 +266,13 @@ void ConfigureHotkeys::RestoreHotkey(QModelIndex index) {
     const auto [key_sequence_used, used_action] = IsUsedKey(default_key_sequence);
 
     if (key_sequence_used && default_key_sequence != QKeySequence(model->data(index).toString())) {
-        QMessageBox::warning(
-            this, tr("Conflicting Key Sequence"),
-            tr("The default key sequence is already assigned to: %1").arg(used_action));
+        QMessageBox::warning(this, tr("Conflicting Key Sequence"),
+                             tr("The default key sequence is already assigned to: %1")
+                                 .arg(QString::fromStdString(used_action.name)));
     } else {
         model->setData(index, default_key_sequence.toString(QKeySequence::NativeText));
     }
+    EmitHotkeysChanged();
 }
 
 void ConfigureHotkeys::RetranslateUI() {

--- a/src/citra_qt/configuration/configure_hotkeys.cpp
+++ b/src/citra_qt/configuration/configure_hotkeys.cpp
@@ -52,8 +52,8 @@ QMap<QKeySequence, ConfigureInput::InputBinding> ConfigureHotkeys::GetUsedKeyLis
             auto seq = QKeySequence::fromString(keyseq->text(), QKeySequence::NativeText);
             if (seq.count() == 1 &&
                 seq[0].keyboardModifiers() == Qt::KeyboardModifier::NoModifier) {
-                auto binding =
-                    ConfigureInput::InputBinding("Hotkey", parent->child(r2, 0)->text(), r2);
+                auto binding = ConfigureInput::InputBinding(
+                    ConfigureInput::InputBindingType::Hotkey, parent->child(r2, 0)->text(), r2);
                 list[seq] = binding;
             }
         }
@@ -147,7 +147,7 @@ void ConfigureHotkeys::Configure(QModelIndex index) {
         if (response == QMessageBox::No) {
             return;
         } else {
-            if (current_binding.binding_type == "Hotkey") {
+            if (current_binding.binding_type == ConfigureInput::InputBindingType::Hotkey) {
                 model->setData(index.sibling(current_binding.index, hotkey_column),
                                QStringLiteral(""));
             } else {
@@ -162,7 +162,7 @@ void ConfigureHotkeys::Configure(QModelIndex index) {
 
 void ConfigureHotkeys::OnClearBinding(ConfigureInput::InputBinding hotkey_to_clear) {
     const auto index = ui->hotkey_list->currentIndex();
-    if (hotkey_to_clear.binding_type == "Hotkey") {
+    if (hotkey_to_clear.binding_type == ConfigureInput::InputBindingType::Hotkey) {
         model->setData(index.sibling(hotkey_to_clear.index, hotkey_column), QStringLiteral(""));
     }
     EmitHotkeysChanged();
@@ -171,7 +171,8 @@ void ConfigureHotkeys::OnClearBinding(ConfigureInput::InputBinding hotkey_to_cle
 std::pair<bool, ConfigureInput::InputBinding> ConfigureHotkeys::IsUsedKey(
     QKeySequence key_sequence) const {
     if (key_sequence == QKeySequence::fromString(QStringLiteral(""), QKeySequence::NativeText)) {
-        return std::make_pair(false, ConfigureInput::InputBinding{"", QStringLiteral(""), -1});
+        return std::make_pair(false, ConfigureInput::InputBinding{
+                                         ConfigureInput::InputBindingType::Empty, QString(), -1});
     }
 
     if (input_keys_list.contains(key_sequence)) {
@@ -188,12 +189,15 @@ std::pair<bool, ConfigureInput::InputBinding> ConfigureHotkeys::IsUsedKey(
 
             if (key_sequence == key_seq) {
                 return std::make_pair(
-                    true, ConfigureInput::InputBinding{"Hotkey", parent->child(r2, 0)->text(), r2});
+                    true, ConfigureInput::InputBinding{ConfigureInput::InputBindingType::Hotkey,
+                                                       parent->child(r2, 0)->text(), r2});
             }
         }
     }
 
-    return std::make_pair(false, ConfigureInput::InputBinding{"", QStringLiteral(""), -1});
+    return std::make_pair(false,
+                          ConfigureInput::InputBinding{ConfigureInput::InputBindingType::Empty,
+                                                       QStringLiteral(""), -1});
 }
 
 void ConfigureHotkeys::ApplyConfiguration(HotkeyRegistry& registry) {

--- a/src/citra_qt/configuration/configure_hotkeys.cpp
+++ b/src/citra_qt/configuration/configure_hotkeys.cpp
@@ -140,8 +140,8 @@ void ConfigureHotkeys::Configure(QModelIndex index) {
     if (key_sequence_used && key_sequence != QKeySequence(previous_key.toString())) {
         auto response = QMessageBox::information(
             this, tr("Combination Already Bound"),
-            tr("This key combination is already bound to the '%1' hotkey.\n\n"
-               "Continuing will unbind the previous hotkey. Proceed?")
+            tr("This key combination is already bound to the '%1' input.\n\n"
+               "Continuing will remove the previous binding. Proceed?")
                 .arg(current_binding.name),
             QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
         if (response == QMessageBox::No) {
@@ -269,7 +269,7 @@ void ConfigureHotkeys::RestoreHotkey(QModelIndex index) {
         QMessageBox::warning(
             this, tr("Failed to Restore"),
             tr("Unable to restore the default binding for this hotkey, as it's already "
-               "bound to the '%1' hotkey.")
+               "bound to the '%1' input.")
                 .arg(used_action.name));
     } else {
         model->setData(index, default_key_sequence.toString(QKeySequence::NativeText));

--- a/src/citra_qt/configuration/configure_hotkeys.cpp
+++ b/src/citra_qt/configuration/configure_hotkeys.cpp
@@ -52,8 +52,8 @@ QMap<QKeySequence, ConfigureInput::InputBinding> ConfigureHotkeys::GetUsedKeyLis
             auto seq = QKeySequence::fromString(keyseq->text(), QKeySequence::NativeText);
             if (seq.count() == 1 &&
                 seq[0].keyboardModifiers() == Qt::KeyboardModifier::NoModifier) {
-                auto binding = ConfigureInput::InputBinding(
-                    "Hotkey", parent->child(r2, 0)->text().toStdString(), r2);
+                auto binding =
+                    ConfigureInput::InputBinding("Hotkey", parent->child(r2, 0)->text(), r2);
                 list[seq] = binding;
             }
         }
@@ -171,7 +171,7 @@ void ConfigureHotkeys::OnClearBinding(ConfigureInput::InputBinding hotkey_to_cle
 std::pair<bool, ConfigureInput::InputBinding> ConfigureHotkeys::IsUsedKey(
     QKeySequence key_sequence) const {
     if (key_sequence == QKeySequence::fromString(QStringLiteral(""), QKeySequence::NativeText)) {
-        return std::make_pair(false, ConfigureInput::InputBinding{"", "", -1});
+        return std::make_pair(false, ConfigureInput::InputBinding{"", QStringLiteral(""), -1});
     }
 
     if (input_keys_list.contains(key_sequence)) {
@@ -188,13 +188,12 @@ std::pair<bool, ConfigureInput::InputBinding> ConfigureHotkeys::IsUsedKey(
 
             if (key_sequence == key_seq) {
                 return std::make_pair(
-                    true, ConfigureInput::InputBinding{
-                              "Hotkey", parent->child(r2, 0)->text().toStdString(), r2});
+                    true, ConfigureInput::InputBinding{"Hotkey", parent->child(r2, 0)->text(), r2});
             }
         }
     }
 
-    return std::make_pair(false, ConfigureInput::InputBinding{"", "", -1});
+    return std::make_pair(false, ConfigureInput::InputBinding{"", QStringLiteral(""), -1});
 }
 
 void ConfigureHotkeys::ApplyConfiguration(HotkeyRegistry& registry) {

--- a/src/citra_qt/configuration/configure_hotkeys.cpp
+++ b/src/citra_qt/configuration/configure_hotkeys.cpp
@@ -130,7 +130,7 @@ void ConfigureHotkeys::Configure(QModelIndex index) {
 
         // Show warning if either hotkey is already set
         if (!key_sequence.isEmpty() && !other_sequence.isEmpty()) {
-            QMessageBox::warning(this, tr("Conflicting Key Sequence"),
+            QMessageBox::warning(this, tr("Conflicting Hotkeys"),
                                  tr("The per-application speed and turbo speed hotkeys cannot be "
                                     "bound at the same time."));
             return;
@@ -138,11 +138,12 @@ void ConfigureHotkeys::Configure(QModelIndex index) {
     }
 
     if (key_sequence_used && key_sequence != QKeySequence(previous_key.toString())) {
-        auto response =
-            QMessageBox::question(this, QStringLiteral("Duplicate mapping"),
-                                  QString::fromStdString("This will clear the mapping for " +
-                                                         current_binding.name + ". Proceed?"),
-                                  QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+        auto response = QMessageBox::information(
+            this, tr("Combination Already Bound"),
+            tr("This key combination is already bound to the '%1' hotkey.\n\n"
+               "Continuing will unbind the previous hotkey. Proceed?")
+                .arg(current_binding.name),
+            QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
         if (response == QMessageBox::No) {
             return;
         } else {
@@ -266,9 +267,11 @@ void ConfigureHotkeys::RestoreHotkey(QModelIndex index) {
     const auto [key_sequence_used, used_action] = IsUsedKey(default_key_sequence);
 
     if (key_sequence_used && default_key_sequence != QKeySequence(model->data(index).toString())) {
-        QMessageBox::warning(this, tr("Conflicting Key Sequence"),
-                             tr("The default key sequence is already assigned to: %1")
-                                 .arg(QString::fromStdString(used_action.name)));
+        QMessageBox::warning(
+            this, tr("Failed to Restore"),
+            tr("Unable to restore the default binding for this hotkey, as it's already "
+               "bound to the '%1' hotkey.")
+                .arg(used_action.name));
     } else {
         model->setData(index, default_key_sequence.toString(QKeySequence::NativeText));
     }

--- a/src/citra_qt/configuration/configure_hotkeys.h
+++ b/src/citra_qt/configuration/configure_hotkeys.h
@@ -1,4 +1,4 @@
-// Copyright 2017 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/citra_qt/configuration/configure_hotkeys.h
+++ b/src/citra_qt/configuration/configure_hotkeys.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <QWidget>
+#include "citra_qt/configuration/configure_input.h"
 
 namespace Ui {
 class ConfigureHotkeys;
@@ -34,15 +35,16 @@ public:
     void Populate(const HotkeyRegistry& registry);
 
 public slots:
-    void OnInputKeysChanged(QList<QKeySequence> new_key_list);
-
+    void OnInputKeysChanged(QMap<QKeySequence, ConfigureInput::InputBinding> new_key_list);
+    void OnClearBinding(ConfigureInput::InputBinding hotkey_to_clear);
 signals:
-    void HotkeysChanged(QList<QKeySequence> new_key_list);
+    void HotkeysChanged(QMap<QKeySequence, ConfigureInput::InputBinding> new_key_list);
+    void ClearInputBinding(ConfigureInput::InputBinding binding);
 
 private:
     void Configure(QModelIndex index);
-    std::pair<bool, QString> IsUsedKey(QKeySequence key_sequence) const;
-    QList<QKeySequence> GetUsedKeyList() const;
+    std::pair<bool, ConfigureInput::InputBinding> IsUsedKey(QKeySequence key_sequence) const;
+    QMap<QKeySequence, ConfigureInput::InputBinding> GetUsedKeyList() const;
 
     void RestoreDefaults();
     void ClearAll();
@@ -54,7 +56,7 @@ private:
      * These can't be bound to any hotkey.
      * Synchronised with ConfigureInput via signal-slot.
      */
-    QList<QKeySequence> input_keys_list;
+    QMap<QKeySequence, ConfigureInput::InputBinding> input_keys_list;
 
     std::unique_ptr<Ui::ConfigureHotkeys> ui;
 

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -174,6 +174,11 @@ ConfigureInput::ConfigureInput(Core::System& _system, QWidget* parent)
         ui->buttonHome,   ui->buttonPower,
     };
 
+    button_names = {"A Button",     "B Button",      "X Button",     "Y Button",     "D-Pad Up",
+                    "D-Pad Down",   "D-Pad Left",    "D-Pad Right",  "L Button",     "R Button",
+                    "Start Button", "Select Button", "Debug Button", "GPIO4 Button", "ZL Button",
+                    "ZR Button",    "Home Button",   "Power Button"};
+
     analog_map_buttons = {{
         {
             ui->buttonCircleUp,
@@ -198,7 +203,7 @@ ConfigureInput::ConfigureInput(Core::System& _system, QWidget* parent)
             nullptr,
         },
     }};
-
+    analog_names = {"Circle Pad", "C Stick"};
     analog_map_stick = {ui->buttonCircleAnalog, ui->buttonCStickAnalog};
     analog_map_deadzone_and_modifier_slider = {ui->sliderCirclePadDeadzoneAndModifier,
                                                ui->sliderCStickDeadzoneAndModifier};
@@ -439,16 +444,72 @@ void ConfigureInput::EmitInputKeysChanged() {
     emit InputKeysChanged(GetUsedKeyboardKeys());
 }
 
-void ConfigureInput::OnHotkeysChanged(QList<QKeySequence> new_key_list) {
+void ConfigureInput::OnHotkeysChanged(
+    QMap<QKeySequence, ConfigureInput::InputBinding> new_key_list) {
     hotkey_list = new_key_list;
 }
 
-QList<QKeySequence> ConfigureInput::GetUsedKeyboardKeys() {
-    QList<QKeySequence> list;
+void ConfigureInput::OnClearBinding(ConfigureInput::InputBinding binding) {
+    ClearBinding(binding);
+}
+
+bool sameInput(const Common::ParamPackage& param1, const Common::ParamPackage& param2) {
+    return param1.Has("engine") && param2.Has("engine") &&
+           param1.Get("engine", "") == param2.Get("engine", "") &&
+           param1.Get("guid", "") == param2.Get("guid", "") &&
+           (param1.Get("code", -1) == param2.Get("code", -2) ||
+            param1.Get("button", -1) == param2.Get("button", -2) ||
+            (param1.Get("axis", -1) == param2.Get("axis", -2) &&
+             param1.Get("direction", "a") == param2.Get("direction", "b")) ||
+            (param1.Get("axis_x", -1) == param2.Get("axis_x", -2) &&
+             param1.Get("axis_y", -1) == param2.Get("axis_y", -2)) ||
+            (param1.Get("hat", -1) == param2.Get("hat", -2) &&
+             param1.Get("direction", "a") == param2.Get("direction", "b")));
+}
+
+ConfigureInput::InputBinding ConfigureInput::GetMapping(const Common::ParamPackage& param) {
+    if (!param.Has("engine"))
+        return {"", "", 0};
+    // check for a button map
+    for (int button = 0; button < Settings::NativeButton::NumButtons; ++button) {
+        const auto& button_param = buttons_param[button];
+        if (sameInput(param, button_param)) {
+            return {"NativeButton", button_names[button], button};
+        }
+    }
+    // check for an analog map
+    for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs; ++analog_id) {
+        const auto& analog_param = analogs_param[analog_id];
+        if (analog_param.Get("engine", "") == "analog_from_button") {
+            for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM; ++sub_button_id) {
+                const Common::ParamPackage sub_button{
+                    analog_param.Get(analog_sub_buttons[sub_button_id], "")};
+                if (sameInput(param, sub_button)) {
+                    return {"AnalogButton",
+                            analog_names[analog_id] + " " + analog_sub_buttons[sub_button_id],
+                            analog_id, sub_button_id};
+                }
+            }
+        } else if (sameInput(param, analog_param)) {
+            return {"Analog", analog_names[analog_id], analog_id};
+        }
+    }
+
+    if (param.Get("engine", "") == "keyboard" &&
+        hotkey_list.contains(QKeySequence(param.Get("code", 0)))) {
+        return hotkey_list[QKeySequence(param.Get("code", 0))];
+    }
+
+    return {"", "", 0};
+}
+
+QMap<QKeySequence, ConfigureInput::InputBinding> ConfigureInput::GetUsedKeyboardKeys() {
+    QMap<QKeySequence, ConfigureInput::InputBinding> list;
     for (int button = 0; button < Settings::NativeButton::NumButtons; button++) {
         const auto& button_param = buttons_param[button];
         if (button_param.Get("engine", "") == "keyboard") {
-            list << QKeySequence(button_param.Get("code", 0));
+            list[QKeySequence(button_param.Get("code", 0))] =
+                ConfigureInput::InputBinding{"NativeButton", button_names[button], button};
         }
     }
 
@@ -458,7 +519,10 @@ QList<QKeySequence> ConfigureInput::GetUsedKeyboardKeys() {
             for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM; ++sub_button_id) {
                 const Common::ParamPackage sub_button{
                     analog_param.Get(analog_sub_buttons[sub_button_id], "")};
-                list << QKeySequence(sub_button.Get("code", 0));
+                list[QKeySequence(sub_button.Get("code", 0))] = ConfigureInput::InputBinding{
+                    "AnalogButton",
+                    analog_names[analog_id] + " " + analog_sub_buttons[sub_button_id], analog_id,
+                    sub_button_id};
             }
         }
     }
@@ -496,6 +560,25 @@ void ConfigureInput::RestoreDefaults() {
 
     ApplyConfiguration();
     Settings::SaveProfile(Settings::values.current_input_profile_index);
+}
+
+void ConfigureInput::ClearBinding(InputBinding binding) {
+    if (binding.binding_type == "NativeButton") {
+        buttons_param[binding.index].Clear();
+        button_map[binding.index]->setText(tr("[not set]"));
+    } else if (binding.binding_type == "AnalogButton") {
+        const auto analog_id = binding.index;
+        const auto sub_button_id = binding.sub_index;
+        analogs_param[analog_id].Erase(analog_sub_buttons[sub_button_id]);
+        analog_map_buttons[analog_id][sub_button_id]->setText(tr("[not set]"));
+    } else if (binding.binding_type == "Analog") {
+        const auto analog_id = binding.index;
+        analogs_param[analog_id].Clear();
+        UpdateButtonLabels();
+    } else if (binding.binding_type == "Hotkey") {
+        emit ClearHotkey(binding);
+    }
+    ApplyConfiguration();
 }
 
 void ConfigureInput::ClearAll() {
@@ -628,7 +711,7 @@ void ConfigureInput::HandleClick(QPushButton* button,
     poll_timer->start(200);     // Check for new inputs every 200ms
 }
 
-void ConfigureInput::SetPollingResult(const Common::ParamPackage& params, bool abort) {
+void ConfigureInput::StopPolling() {
     releaseKeyboard();
     releaseMouse();
     timeout_timer->stop();
@@ -636,7 +719,24 @@ void ConfigureInput::SetPollingResult(const Common::ParamPackage& params, bool a
     for (auto& poller : device_pollers) {
         poller->Stop();
     }
+}
 
+void ConfigureInput::SetPollingResult(const Common::ParamPackage& params, bool abort) {
+    auto const currentBinding = GetMapping(params);
+    StopPolling();
+    if (!abort && currentBinding.binding_type != "") {
+        auto response =
+            QMessageBox::question(this, QStringLiteral("Duplicate mapping"),
+                                  QString::fromStdString("This will clear the mapping for " +
+                                                         currentBinding.name + ". Proceed?"),
+                                  QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+        if (response == QMessageBox::No) {
+            abort = true;
+            return;
+        } else {
+            ClearBinding(currentBinding);
+        }
+    }
     if (!abort && input_setter) {
         (*input_setter)(params);
     }
@@ -651,16 +751,9 @@ void ConfigureInput::keyPressEvent(QKeyEvent* event) {
 
     if (event->key() != Qt::Key_Escape && event->key() != previous_key_code) {
         if (want_keyboard_keys) {
-            // Check if key is already bound
-            if (hotkey_list.contains(QKeySequence(event->key())) ||
-                GetUsedKeyboardKeys().contains(QKeySequence(event->key()))) {
-                SetPollingResult({}, true);
-                QMessageBox::critical(this, tr("Error!"),
-                                      tr("You're using a key that's already bound."));
-                return;
-            }
-            SetPollingResult(Common::ParamPackage{InputCommon::GenerateKeyboardParam(event->key())},
-                             false);
+            auto param = Common::ParamPackage(InputCommon::GenerateKeyboardParam(event->key()));
+            previous_key_code = 0;
+            SetPollingResult(param, false);
         } else {
             // Escape key wasn't pressed and we don't want any keyboard keys, so don't stop
             // polling

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -497,12 +497,16 @@ ConfigureInput::InputBinding ConfigureInput::GetMapping(const Common::ParamPacka
                 const Common::ParamPackage sub_button{
                     analog_param.Get(analog_sub_buttons[sub_button_id], "")};
                 if (sameInput(param, sub_button)) {
+                    if (analog_sub_buttons[sub_button_id] == "modifier") {
+                        return {"CircleModButton", QStringLiteral("circle mod button"), 0};
+                    }
                     return {"AnalogButton",
                             QStringLiteral("%1 (%2)").arg(analog_names[analog_id],
                                                           analog_sub_button_names[sub_button_id]),
                             analog_id, sub_button_id};
                 }
             }
+
         } else if (sameInput(param, analog_param)) {
             return {"Analog", analog_names[analog_id], analog_id};
         }
@@ -591,6 +595,11 @@ void ConfigureInput::ClearBinding(InputBinding binding) {
         UpdateButtonLabels();
     } else if (binding.binding_type == "Hotkey") {
         emit ClearHotkey(binding);
+    } else if (binding.binding_type == "CircleModButton") {
+        for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs; analog_id++) {
+            analogs_param[analog_id].Erase("modifier");
+        }
+        ui->buttonCircleMod->setText(tr("[not set]"));
     }
     ApplyConfiguration();
 }

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -750,7 +750,7 @@ void ConfigureInput::SetPollingResult(const Common::ParamPackage& params, bool a
         auto response =
             QMessageBox::information(this, tr("Key Already Bound"),
                                      tr("This key is already bound to the '%1' input.\n\n"
-                                        "Continuing will unbind the previous input. Proceed?")
+                                        "Continuing will remove the previous binding. Proceed?")
                                          .arg(current_binding.name),
                                      QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
         if (response == QMessageBox::No) {

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -208,7 +208,7 @@ ConfigureInput::ConfigureInput(Core::System& _system, QWidget* parent)
         },
     }};
 
-    analog_names = {tr("Circle Pad"), tr("C Stick")};
+    analog_names = {tr("Circle Pad"), tr("C-Stick")};
     analog_map_stick = {ui->buttonCircleAnalog, ui->buttonCStickAnalog};
     analog_map_deadzone_and_modifier_slider = {ui->sliderCirclePadDeadzoneAndModifier,
                                                ui->sliderCStickDeadzoneAndModifier};

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -722,19 +722,20 @@ void ConfigureInput::StopPolling() {
 }
 
 void ConfigureInput::SetPollingResult(const Common::ParamPackage& params, bool abort) {
-    auto const currentBinding = GetMapping(params);
+    auto const current_binding = GetMapping(params);
     StopPolling();
-    if (!abort && currentBinding.binding_type != "") {
+    if (!abort && current_binding.binding_type != "") {
         auto response =
-            QMessageBox::question(this, QStringLiteral("Duplicate mapping"),
-                                  QString::fromStdString("This will clear the mapping for " +
-                                                         currentBinding.name + ". Proceed?"),
-                                  QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+            QMessageBox::information(this, tr("Key Already Bound"),
+                                     tr("This key is already bound to the '%1' input.\n\n"
+                                        "Continuing will unbind the previous input. Proceed?")
+                                         .arg(current_binding.name),
+                                     QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
         if (response == QMessageBox::No) {
             abort = true;
             return;
         } else {
-            ClearBinding(currentBinding);
+            ClearBinding(current_binding);
         }
     }
     if (!abort && input_setter) {

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -459,17 +459,24 @@ void ConfigureInput::OnClearBinding(ConfigureInput::InputBinding binding) {
 }
 
 bool sameInput(const Common::ParamPackage& param1, const Common::ParamPackage& param2) {
-    return param1.Has("engine") && param2.Has("engine") &&
-           param1.Get("engine", "") == param2.Get("engine", "") &&
-           param1.Get("guid", "") == param2.Get("guid", "") &&
-           (param1.Get("code", -1) == param2.Get("code", -2) ||
-            param1.Get("button", -1) == param2.Get("button", -2) ||
-            (param1.Get("axis", -1) == param2.Get("axis", -2) &&
-             param1.Get("direction", "a") == param2.Get("direction", "b")) ||
-            (param1.Get("axis_x", -1) == param2.Get("axis_x", -2) &&
-             param1.Get("axis_y", -1) == param2.Get("axis_y", -2)) ||
-            (param1.Get("hat", -1) == param2.Get("hat", -2) &&
-             param1.Get("direction", "a") == param2.Get("direction", "b")));
+    // if the engines or guid's don't match, return false as default
+    if (!param1.Has("engine") || !param2.Has("engine"))
+        return false;
+    if (param1.Get("engine", "") != param2.Get("engine", ""))
+        return false;
+    if (param1.Get("guid", "") != param2.Get("guid", ""))
+        return false;
+
+    const bool sameCode = param1.Get("code", -1) == param2.Get("code", -2);
+    const bool sameButton = param1.Get("button", -1) == param2.Get("button", -2);
+    const bool sameAxisAndDirection = param1.Get("axis", -1) == param2.Get("axis", -2) &&
+                                      param1.Get("direction", "a") == param2.Get("direction", "b");
+    const bool sameAxisXAndAxisY = param1.Get("axis_x", -1) == param2.Get("axis_x", -2) &&
+                                   param1.Get("axis_y", -1) == param2.Get("axis_y", -2);
+    const bool sameHatAndDirection = param1.Get("hat", -1) == param2.Get("hat", -2) &&
+                                     param1.Get("direction", "a") == param2.Get("direction", "b");
+    return sameCode || sameButton || sameAxisAndDirection || sameAxisXAndAxisY ||
+           sameHatAndDirection;
 }
 
 ConfigureInput::InputBinding ConfigureInput::GetMapping(const Common::ParamPackage& param) {

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -46,16 +46,6 @@ static QString GetKeyName(int key_code) {
     }
 }
 
-static void SetAnalogButton(const Common::ParamPackage& input_param,
-                            Common::ParamPackage& analog_param, const std::string& button_name) {
-    if (analog_param.Get("engine", "") != "analog_from_button") {
-        analog_param = {
-            {"engine", "analog_from_button"},
-        };
-    }
-    analog_param.Set(button_name, input_param.Serialize());
-}
-
 static QString ButtonToText(const Common::ParamPackage& param) {
     if (!param.Has("engine")) {
         return QObject::tr("[not set]");
@@ -223,24 +213,7 @@ ConfigureInput::ConfigureInput(Core::System& _system, QWidget* parent)
             HandleClick(
                 button_map[button_id],
                 [this, button_id](Common::ParamPackage params) {
-                    // Workaround for ZL & ZR for analog triggers like on XBOX controllors.
-                    // Analog triggers (from controllers like the XBOX controller) would not
-                    // work due to a different range of their signals (from 0 to 255 on
-                    // analog triggers instead of -32768 to 32768 on analog joysticks). The
-                    // SDL driver misinterprets analog triggers as analog joysticks.
-                    // TODO: reinterpret the signal range for analog triggers to map the
-                    // values correctly. This is required for the correct emulation of the
-                    // analog triggers of the GameCube controller.
-                    if (button_id == Settings::NativeButton::ZL ||
-                        button_id == Settings::NativeButton::ZR) {
-                        params.Set("direction", "+");
-                        params.Set("threshold", "0.5");
-                    }
-                    buttons_param[button_id] = std::move(params);
-                    // If the user closes the dialog, the changes are reverted in
-                    // `GMainWindow::OnConfigure()`
-                    ApplyConfiguration();
-                    Settings::SaveProfile(ui->profile->currentIndex());
+                    SetBinding({InputBindingType::NativeButton, QString(), button_id}, params);
                 },
                 InputCommon::Polling::DeviceType::Button);
         });
@@ -248,18 +221,13 @@ ConfigureInput::ConfigureInput(Core::System& _system, QWidget* parent)
                 [this, button_id](const QPoint& menu_location) {
                     QMenu context_menu;
                     context_menu.addAction(tr("Clear"), this, [&] {
-                        buttons_param[button_id].Clear();
-                        button_map[button_id]->setText(tr("[not set]"));
-                        ApplyConfiguration();
-                        Settings::SaveProfile(ui->profile->currentIndex());
+                        ClearBinding({InputBindingType::NativeButton, QString(), button_id});
                     });
                     context_menu.addAction(tr("Restore Default"), this, [&] {
-                        buttons_param[button_id] =
+                        Common::ParamPackage def =
                             Common::ParamPackage{InputCommon::GenerateKeyboardParam(
                                 QtConfig::default_buttons[button_id])};
-                        button_map[button_id]->setText(ButtonToText(buttons_param[button_id]));
-                        ApplyConfiguration();
-                        Settings::SaveProfile(ui->profile->currentIndex());
+                        SetBinding({InputBindingType::NativeButton, QString(), button_id}, def);
                     });
                     context_menu.exec(button_map[button_id]->mapToGlobal(menu_location));
                 });
@@ -276,10 +244,9 @@ ConfigureInput::ConfigureInput(Core::System& _system, QWidget* parent)
                         HandleClick(
                             analog_map_buttons[analog_id][sub_button_id],
                             [this, analog_id, sub_button_id](const Common::ParamPackage& params) {
-                                SetAnalogButton(params, analogs_param[analog_id],
-                                                analog_sub_buttons[sub_button_id]);
-                                ApplyConfiguration();
-                                Settings::SaveProfile(ui->profile->currentIndex());
+                                SetBinding({InputBindingType::AnalogFromButton, QString(),
+                                            analog_id, sub_button_id},
+                                           params);
                             },
                             InputCommon::Polling::DeviceType::Button);
                     });
@@ -288,20 +255,15 @@ ConfigureInput::ConfigureInput(Core::System& _system, QWidget* parent)
                     [this, analog_id, sub_button_id](const QPoint& menu_location) {
                         QMenu context_menu;
                         context_menu.addAction(tr("Clear"), this, [&] {
-                            analogs_param[analog_id].Erase(analog_sub_buttons[sub_button_id]);
-                            analog_map_buttons[analog_id][sub_button_id]->setText(tr("[not set]"));
-                            ApplyConfiguration();
-                            Settings::SaveProfile(ui->profile->currentIndex());
+                            ClearBinding({InputBindingType::AnalogFromButton, QString(), analog_id,
+                                          sub_button_id});
                         });
                         context_menu.addAction(tr("Restore Default"), this, [&] {
                             Common::ParamPackage params{InputCommon::GenerateKeyboardParam(
                                 QtConfig::default_analogs[analog_id][sub_button_id])};
-                            SetAnalogButton(params, analogs_param[analog_id],
-                                            analog_sub_buttons[sub_button_id]);
-                            analog_map_buttons[analog_id][sub_button_id]->setText(AnalogToText(
-                                analogs_param[analog_id], analog_sub_buttons[sub_button_id]));
-                            ApplyConfiguration();
-                            Settings::SaveProfile(ui->profile->currentIndex());
+                            SetBinding({InputBindingType::AnalogFromButton, QString(), analog_id,
+                                        sub_button_id},
+                                       params);
                         });
                         context_menu.exec(analog_map_buttons[analog_id][sub_button_id]->mapToGlobal(
                             menu_location));
@@ -316,9 +278,7 @@ ConfigureInput::ConfigureInput(Core::System& _system, QWidget* parent)
                 HandleClick(
                     analog_map_stick[analog_id],
                     [this, analog_id](const Common::ParamPackage& params) {
-                        analogs_param[analog_id] = params;
-                        ApplyConfiguration();
-                        Settings::SaveProfile(ui->profile->currentIndex());
+                        SetBinding({InputBindingType::NativeAnalog, QString(), analog_id}, params);
                     },
                     InputCommon::Polling::DeviceType::Analog);
             }
@@ -348,40 +308,22 @@ ConfigureInput::ConfigureInput(Core::System& _system, QWidget* parent)
         HandleClick(
             ui->buttonCircleMod,
             [this](const Common::ParamPackage& params) {
-                for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs;
-                     analog_id++) {
-                    SetAnalogButton(params, analogs_param[analog_id], "modifier");
-                }
-                ApplyConfiguration();
-                Settings::SaveProfile(ui->profile->currentIndex());
+                SetBinding({InputBindingType::CModButton, QString()}, params);
             },
             InputCommon::Polling::DeviceType::Button);
     });
+    ui->buttonCircleMod->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(ui->buttonCircleMod, &QPushButton::customContextMenuRequested, this,
             [&](const QPoint& menu_location) {
                 QMenu context_menu;
                 context_menu.addAction(tr("Clear"), this, [&] {
-                    for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs;
-                         analog_id++) {
-                        analogs_param[analog_id].Erase("modifier");
-                    }
-                    ui->buttonCircleMod->setText(tr("[not set]"));
-                    ApplyConfiguration();
-                    Settings::SaveProfile(ui->profile->currentIndex());
+                    ClearBinding({InputBindingType::CModButton, QString()});
                 });
 
                 context_menu.addAction(tr("Restore Default"), this, [&] {
-                    for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs;
-                         analog_id++) {
-                        Common::ParamPackage params{InputCommon::GenerateKeyboardParam(
-                            QtConfig::default_analogs[analog_id][static_cast<u32>(
-                                AnalogSubButtons::modifier)])};
-                        SetAnalogButton(params, analogs_param[analog_id], "modifier");
-                        ui->buttonCircleMod->setText(
-                            AnalogToText(analogs_param[analog_id], "modifier"));
-                    }
-                    ApplyConfiguration();
-                    Settings::SaveProfile(ui->profile->currentIndex());
+                    Common::ParamPackage params{
+                        InputCommon::GenerateKeyboardParam(QtConfig::default_analogs[0][4])};
+                    SetBinding({InputBindingType::CModButton, QString()}, params);
                 });
                 context_menu.exec(ui->buttonCircleMod->mapToGlobal(menu_location));
             });
@@ -428,6 +370,80 @@ ConfigureInput::ConfigureInput(Core::System& _system, QWidget* parent)
 }
 
 ConfigureInput::~ConfigureInput() = default;
+
+/**
+ * Returns true if we find a conflict and should stop, otherwise it clears the map and returns true.
+ */
+bool ConfigureInput::CheckForDuplicateMap(const Common::ParamPackage& params,
+                                          InputBinding this_binding) {
+    auto const current_binding = GetMapping(params);
+    bool abort = false;
+    if (current_binding.binding_type != InputBindingType::Empty &&
+        !(current_binding.binding_type == this_binding.binding_type &&
+          current_binding.index == this_binding.index &&
+          current_binding.sub_index == this_binding.sub_index)) {
+        auto response =
+            QMessageBox::information(this, tr("Key Already Bound"),
+                                     tr("This key is already bound to the '%1' input.\n\n"
+                                        "Continuing will unbind the previous input. Proceed?")
+                                         .arg(current_binding.name),
+                                     QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+        if (response == QMessageBox::No) {
+            abort = true;
+        } else {
+            ClearBinding(current_binding);
+        }
+    }
+    return abort;
+}
+
+void ConfigureInput::SetBinding(InputBinding binding, const Common::ParamPackage& params) {
+    bool abort = CheckForDuplicateMap(params, binding);
+    if (!abort) {
+        if (binding.binding_type == InputBindingType::NativeButton) {
+            const auto button_id = binding.index;
+            // Workaround for ZL & ZR for analog triggers like on XBOX controllors.
+            // Analog triggers (from controllers like the XBOX controller) would not
+            // work due to a different range of their signals (from 0 to 255 on
+            // analog triggers instead of -32768 to 32768 on analog joysticks). The
+            // SDL driver misinterprets analog triggers as analog joysticks.
+            // TODO: reinterpret the signal range for analog triggers to map the
+            // values correctly. This is required for the correct emulation of the
+            // analog triggers of the GameCube controller.
+            Common::ParamPackage new_params = params;
+            if (button_id == Settings::NativeButton::ZL ||
+                button_id == Settings::NativeButton::ZR) {
+                new_params.Set("direction", "+");
+                new_params.Set("threshold", "0.5");
+            }
+            buttons_param[button_id] = std::move(new_params);
+        } else if (binding.binding_type == InputBindingType::AnalogFromButton) {
+            const auto button_name = analog_sub_buttons[binding.sub_index];
+            if (analogs_param[binding.index].Get("engine", "") != "analog_from_button") {
+                analogs_param[binding.index] = {
+                    {"engine", "analog_from_button"},
+                };
+            }
+            analogs_param[binding.index].Set(button_name, params.Serialize());
+        } else if (binding.binding_type == InputBindingType::NativeAnalog) {
+            const auto analog_id = binding.index;
+            analogs_param[analog_id] = params;
+        } else if (binding.binding_type == InputBindingType::CModButton) {
+            for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs; analog_id++) {
+                if (analogs_param[analog_id].Get("engine", "") != "analog_from_button") {
+                    analogs_param[analog_id] = {
+                        {"engine", "analog_from_button"},
+                    };
+                }
+                analogs_param[analog_id].Set("modifier", params.Serialize());
+            }
+        }
+    }
+
+    ApplyConfiguration();
+    UpdateButtonLabels();
+    Settings::SaveProfile(ui->profile->currentIndex());
+}
 
 void ConfigureInput::ApplyConfiguration() {
 
@@ -481,12 +497,12 @@ bool sameInput(const Common::ParamPackage& param1, const Common::ParamPackage& p
 
 ConfigureInput::InputBinding ConfigureInput::GetMapping(const Common::ParamPackage& param) {
     if (!param.Has("engine"))
-        return {"", QStringLiteral(""), 0};
+        return {InputBindingType::Empty, QString(), 0};
     // check for a button map
     for (int button = 0; button < Settings::NativeButton::NumButtons; ++button) {
         const auto& button_param = buttons_param[button];
         if (sameInput(param, button_param)) {
-            return {"NativeButton", button_names[button], button};
+            return {InputBindingType::NativeButton, button_names[button], button};
         }
     }
     // check for an analog map
@@ -501,13 +517,14 @@ ConfigureInput::InputBinding ConfigureInput::GetMapping(const Common::ParamPacka
                         analog_names[analog_id], analog_sub_button_names[sub_button_id]);
 
                     if (analog_sub_buttons[sub_button_id] == "modifier") {
-                        return {"CircleModButton", input_ui_string, 0};
+                        return {InputBindingType::CModButton, input_ui_string, 0};
                     }
-                    return {"AnalogButton", input_ui_string, analog_id, sub_button_id};
+                    return {InputBindingType::AnalogFromButton, input_ui_string, analog_id,
+                            sub_button_id};
                 }
             }
         } else if (sameInput(param, analog_param)) {
-            return {"Analog", analog_names[analog_id], analog_id};
+            return {InputBindingType::NativeAnalog, analog_names[analog_id], analog_id};
         }
     }
 
@@ -516,7 +533,7 @@ ConfigureInput::InputBinding ConfigureInput::GetMapping(const Common::ParamPacka
         return hotkey_list[QKeySequence(param.Get("code", 0))];
     }
 
-    return {"", QStringLiteral(""), 0};
+    return {InputBindingType::Empty, QStringLiteral(""), 0};
 }
 
 QMap<QKeySequence, ConfigureInput::InputBinding> ConfigureInput::GetUsedKeyboardKeys() {
@@ -524,22 +541,30 @@ QMap<QKeySequence, ConfigureInput::InputBinding> ConfigureInput::GetUsedKeyboard
     for (int button = 0; button < Settings::NativeButton::NumButtons; button++) {
         const auto& button_param = buttons_param[button];
         if (button_param.Get("engine", "") == "keyboard") {
-            list[QKeySequence(button_param.Get("code", 0))] =
-                ConfigureInput::InputBinding{"NativeButton", button_names[button], button};
+            list[QKeySequence(button_param.Get("code", 0))] = ConfigureInput::InputBinding{
+                InputBindingType::NativeButton, button_names[button], button};
         }
     }
 
     for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs; ++analog_id) {
         const auto& analog_param = analogs_param[analog_id];
         if (analog_param.Get("engine", "") == "analog_from_button") {
-            for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM; ++sub_button_id) {
+            // stop one early so as not to include the "modifier" option
+            for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM - 1;
+                 ++sub_button_id) {
                 const Common::ParamPackage sub_button{
                     analog_param.Get(analog_sub_buttons[sub_button_id], "")};
                 list[QKeySequence(sub_button.Get("code", 0))] = ConfigureInput::InputBinding{
-                    "AnalogButton",
+                    InputBindingType::AnalogFromButton,
                     QStringLiteral("%1 (%2)").arg(analog_names[analog_id],
                                                   analog_sub_button_names[sub_button_id]),
                     analog_id, sub_button_id};
+            }
+            // add the circle mod button if it exist
+            const Common::ParamPackage modButton{analog_param.Get("modifier", "")};
+            if (modButton.Get("code", 0) != 0) {
+                list[QKeySequence(modButton.Get("code", 0))] =
+                    InputBinding{InputBindingType::CModButton, QStringLiteral("Circle Mod")};
             }
         }
     }
@@ -580,21 +605,21 @@ void ConfigureInput::RestoreDefaults() {
 }
 
 void ConfigureInput::ClearBinding(InputBinding binding) {
-    if (binding.binding_type == "NativeButton") {
+    if (binding.binding_type == InputBindingType::NativeButton) {
         buttons_param[binding.index].Clear();
         button_map[binding.index]->setText(tr("[not set]"));
-    } else if (binding.binding_type == "AnalogButton") {
+    } else if (binding.binding_type == InputBindingType::AnalogFromButton) {
         const auto analog_id = binding.index;
         const auto sub_button_id = binding.sub_index;
         analogs_param[analog_id].Erase(analog_sub_buttons[sub_button_id]);
         analog_map_buttons[analog_id][sub_button_id]->setText(tr("[not set]"));
-    } else if (binding.binding_type == "Analog") {
+    } else if (binding.binding_type == InputBindingType::NativeAnalog) {
         const auto analog_id = binding.index;
         analogs_param[analog_id].Clear();
         UpdateButtonLabels();
-    } else if (binding.binding_type == "Hotkey") {
+    } else if (binding.binding_type == InputBindingType::Hotkey) {
         emit ClearHotkey(binding);
-    } else if (binding.binding_type == "CircleModButton") {
+    } else if (binding.binding_type == InputBindingType::CModButton) {
         for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs; analog_id++) {
             analogs_param[analog_id].Erase("modifier");
         }
@@ -744,26 +769,10 @@ void ConfigureInput::StopPolling() {
 }
 
 void ConfigureInput::SetPollingResult(const Common::ParamPackage& params, bool abort) {
-    auto const current_binding = GetMapping(params);
     StopPolling();
-    if (!abort && current_binding.binding_type != "") {
-        auto response =
-            QMessageBox::information(this, tr("Key Already Bound"),
-                                     tr("This key is already bound to the '%1' input.\n\n"
-                                        "Continuing will remove the previous binding. Proceed?")
-                                         .arg(current_binding.name),
-                                     QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
-        if (response == QMessageBox::No) {
-            abort = true;
-            return;
-        } else {
-            ClearBinding(current_binding);
-        }
-    }
     if (!abort && input_setter) {
         (*input_setter)(params);
     }
-
     UpdateButtonLabels();
     input_setter.reset();
 }
@@ -778,8 +787,8 @@ void ConfigureInput::keyPressEvent(QKeyEvent* event) {
             previous_key_code = 0;
             SetPollingResult(param, false);
         } else {
-            // Escape key wasn't pressed and we don't want any keyboard keys, so don't stop
-            // polling
+            // Escape key wasn't pressed and we don't want any keyboard keys, so don't
+            // stop polling
             return;
         }
     }

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -19,19 +19,6 @@
 #include "core/core.h"
 #include "ui_configure_input.h"
 
-const std::array<std::string, ConfigureInput::ANALOG_SUB_BUTTONS_NUM>
-    ConfigureInput::analog_sub_buttons{{
-        "up",
-        "down",
-        "left",
-        "right",
-        "up_left",
-        "up_right",
-        "down_left",
-        "down_right",
-        "modifier",
-    }};
-
 enum class AnalogSubButtons {
     up,
     down,
@@ -166,6 +153,17 @@ ConfigureInput::ConfigureInput(Core::System& _system, QWidget* parent)
 
     ui->profile->setCurrentIndex(Settings::values.current_input_profile_index);
 
+    // clang-format off
+    analog_sub_buttons = {
+        "up",       "down",      "left",       "right",    "up_left",
+        "up_right", "down_left", "down_right", "modifier",
+    };
+
+    analog_sub_button_names = {
+        tr("Up"),       tr("Down"),      tr("Left"),       tr("Right"),    tr("Up-Left"),
+        tr("Up-Right"), tr("Down-Left"), tr("Down-Right"), tr("Modifier"),
+    };
+
     button_map = {
         ui->buttonA,      ui->buttonB,        ui->buttonX,        ui->buttonY,
         ui->buttonDpadUp, ui->buttonDpadDown, ui->buttonDpadLeft, ui->buttonDpadRight,
@@ -174,11 +172,17 @@ ConfigureInput::ConfigureInput(Core::System& _system, QWidget* parent)
         ui->buttonHome,   ui->buttonPower,
     };
 
-    button_names = {"A Button",     "B Button",      "X Button",     "Y Button",     "D-Pad Up",
-                    "D-Pad Down",   "D-Pad Left",    "D-Pad Right",  "L Button",     "R Button",
-                    "Start Button", "Select Button", "Debug Button", "GPIO4 Button", "ZL Button",
-                    "ZR Button",    "Home Button",   "Power Button"};
+    button_names = {
+        tr("A Button"),     tr("B Button"),      tr("X Button"),     tr("Y Button"),
+        tr("D-Pad Up"),     tr("D-Pad Down"),    tr("D-Pad Left"),   tr("D-Pad Right"),
+        tr("L Button"),     tr("R Button"),      tr("Start Button"), tr("Select Button"),
+        tr("Debug"),        tr("GPIO4"),         tr("ZL Button"),    tr("ZR Button"),
+        tr("Home Button"),  tr("Power Button")
+    };
+    // clang-format on
 
+    /// A group of five QPushButtons represent one analog input. The buttons each represent up,
+    /// down, left, right, and modifier, respectively.
     analog_map_buttons = {{
         {
             ui->buttonCircleUp,
@@ -203,7 +207,8 @@ ConfigureInput::ConfigureInput(Core::System& _system, QWidget* parent)
             nullptr,
         },
     }};
-    analog_names = {"Circle Pad", "C Stick"};
+
+    analog_names = {tr("Circle Pad"), tr("C Stick")};
     analog_map_stick = {ui->buttonCircleAnalog, ui->buttonCStickAnalog};
     analog_map_deadzone_and_modifier_slider = {ui->sliderCirclePadDeadzoneAndModifier,
                                                ui->sliderCStickDeadzoneAndModifier};
@@ -469,7 +474,7 @@ bool sameInput(const Common::ParamPackage& param1, const Common::ParamPackage& p
 
 ConfigureInput::InputBinding ConfigureInput::GetMapping(const Common::ParamPackage& param) {
     if (!param.Has("engine"))
-        return {"", "", 0};
+        return {"", QStringLiteral(""), 0};
     // check for a button map
     for (int button = 0; button < Settings::NativeButton::NumButtons; ++button) {
         const auto& button_param = buttons_param[button];
@@ -486,7 +491,8 @@ ConfigureInput::InputBinding ConfigureInput::GetMapping(const Common::ParamPacka
                     analog_param.Get(analog_sub_buttons[sub_button_id], "")};
                 if (sameInput(param, sub_button)) {
                     return {"AnalogButton",
-                            analog_names[analog_id] + " " + analog_sub_buttons[sub_button_id],
+                            QStringLiteral("%1 (%2)").arg(analog_names[analog_id],
+                                                          analog_sub_button_names[sub_button_id]),
                             analog_id, sub_button_id};
                 }
             }
@@ -500,7 +506,7 @@ ConfigureInput::InputBinding ConfigureInput::GetMapping(const Common::ParamPacka
         return hotkey_list[QKeySequence(param.Get("code", 0))];
     }
 
-    return {"", "", 0};
+    return {"", QStringLiteral(""), 0};
 }
 
 QMap<QKeySequence, ConfigureInput::InputBinding> ConfigureInput::GetUsedKeyboardKeys() {
@@ -521,8 +527,9 @@ QMap<QKeySequence, ConfigureInput::InputBinding> ConfigureInput::GetUsedKeyboard
                     analog_param.Get(analog_sub_buttons[sub_button_id], "")};
                 list[QKeySequence(sub_button.Get("code", 0))] = ConfigureInput::InputBinding{
                     "AnalogButton",
-                    analog_names[analog_id] + " " + analog_sub_buttons[sub_button_id], analog_id,
-                    sub_button_id};
+                    QStringLiteral("%1 (%2)").arg(analog_names[analog_id],
+                                                  analog_sub_button_names[sub_button_id]),
+                    analog_id, sub_button_id};
             }
         }
     }

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -497,16 +497,15 @@ ConfigureInput::InputBinding ConfigureInput::GetMapping(const Common::ParamPacka
                 const Common::ParamPackage sub_button{
                     analog_param.Get(analog_sub_buttons[sub_button_id], "")};
                 if (sameInput(param, sub_button)) {
+                    const auto input_ui_string = QStringLiteral("%1 (%2)").arg(
+                        analog_names[analog_id], analog_sub_button_names[sub_button_id]);
+
                     if (analog_sub_buttons[sub_button_id] == "modifier") {
-                        return {"CircleModButton", QStringLiteral("circle mod button"), 0};
+                        return {"CircleModButton", input_ui_string, 0};
                     }
-                    return {"AnalogButton",
-                            QStringLiteral("%1 (%2)").arg(analog_names[analog_id],
-                                                          analog_sub_button_names[sub_button_id]),
-                            analog_id, sub_button_id};
+                    return {"AnalogButton", input_ui_string, analog_id, sub_button_id};
                 }
             }
-
         } else if (sameInput(param, analog_param)) {
             return {"Analog", analog_names[analog_id], analog_id};
         }

--- a/src/citra_qt/configuration/configure_input.h
+++ b/src/citra_qt/configuration/configure_input.h
@@ -1,4 +1,4 @@
-// Copyright Citra Emulator Project / Lime3DS Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/citra_qt/configuration/configure_input.h
+++ b/src/citra_qt/configuration/configure_input.h
@@ -30,6 +30,12 @@ class ConfigureInput : public QWidget {
     Q_OBJECT
 
 public:
+    struct InputBinding {
+        std::string binding_type;
+        std::string name;
+        int index;
+        int sub_index = -1; // used for sub-buttons
+    };
     explicit ConfigureInput(Core::System& system, QWidget* parent = nullptr);
     ~ConfigureInput() override;
 
@@ -44,10 +50,12 @@ public:
     /// Save the current input profile index
     void ApplyProfile();
 public slots:
-    void OnHotkeysChanged(QList<QKeySequence> new_key_list);
+    void OnHotkeysChanged(QMap<QKeySequence, ConfigureInput::InputBinding> new_key_list);
+    void OnClearBinding(ConfigureInput::InputBinding binding);
 
 signals:
-    void InputKeysChanged(QList<QKeySequence> new_key_list);
+    void InputKeysChanged(QMap<QKeySequence, ConfigureInput::InputBinding> new_key_list);
+    void ClearHotkey(ConfigureInput::InputBinding hotkey_to_clear);
 
 private:
     Core::System& system;
@@ -66,6 +74,8 @@ private:
 
     /// Each button input is represented by a QPushButton.
     std::array<QPushButton*, Settings::NativeButton::NumButtons> button_map;
+    std::array<std::string, Settings::NativeButton::NumButtons> button_names;
+    std::array<std::string, Settings::NativeAnalog::NumAnalogs> analog_names;
 
     /// A group of five QPushButtons represent one analog input. The buttons each represent up,
     /// down, left, right, and modifier, respectively.
@@ -89,14 +99,17 @@ private:
      * These can't be bound to any input key.
      * Synchronised with ConfigureHotkeys via signal-slot.
      */
-    QList<QKeySequence> hotkey_list;
+    QMap<QKeySequence, ConfigureInput::InputBinding> hotkey_list;
 
     /// A flag to indicate if keyboard keys are okay when configuring an input. If this is false,
     /// keyboard events are ignored.
     bool want_keyboard_keys = false;
 
-    /// Generates list of all used keys
-    QList<QKeySequence> GetUsedKeyboardKeys();
+    /// Generates list of all used keyboard keys for sharing with hotkey code
+    QMap<QKeySequence, ConfigureInput::InputBinding> GetUsedKeyboardKeys();
+    InputBinding GetMapping(const Common::ParamPackage& param);
+
+    void ClearBinding(InputBinding binding);
 
     void MapFromButton(const Common::ParamPackage& params);
     void AutoMap();
@@ -117,7 +130,9 @@ private:
     /// The key code of the previous state of the key being currently bound.
     int previous_key_code;
 
-    /// Finish polling and configure input using the input_setter
+    /// Stop polling
+    void StopPolling();
+    /// configure input using the input_setter
     void SetPollingResult(const Common::ParamPackage& params, bool abort);
 
     /// Handle key press events.

--- a/src/citra_qt/configuration/configure_input.h
+++ b/src/citra_qt/configuration/configure_input.h
@@ -32,7 +32,7 @@ class ConfigureInput : public QWidget {
 public:
     struct InputBinding {
         std::string binding_type;
-        std::string name;
+        QString name;
         int index;
         int sub_index = -1; // used for sub-buttons
     };
@@ -74,8 +74,8 @@ private:
 
     /// Each button input is represented by a QPushButton.
     std::array<QPushButton*, Settings::NativeButton::NumButtons> button_map;
-    std::array<std::string, Settings::NativeButton::NumButtons> button_names;
-    std::array<std::string, Settings::NativeAnalog::NumAnalogs> analog_names;
+    std::array<QString, Settings::NativeButton::NumButtons> button_names;
+    std::array<QString, Settings::NativeAnalog::NumAnalogs> analog_names;
 
     /// A group of five QPushButtons represent one analog input. The buttons each represent up,
     /// down, left, right, and modifier, respectively.
@@ -90,7 +90,8 @@ private:
     std::array<QLabel*, Settings::NativeAnalog::NumAnalogs>
         analog_map_deadzone_and_modifier_slider_label;
 
-    static const std::array<std::string, ANALOG_SUB_BUTTONS_NUM> analog_sub_buttons;
+    std::array<std::string, ANALOG_SUB_BUTTONS_NUM> analog_sub_buttons;
+    std::array<QString, ANALOG_SUB_BUTTONS_NUM> analog_sub_button_names;
 
     std::vector<std::unique_ptr<InputCommon::Polling::DevicePoller>> device_pollers;
 

--- a/src/citra_qt/configuration/configure_input.h
+++ b/src/citra_qt/configuration/configure_input.h
@@ -30,12 +30,21 @@ class ConfigureInput : public QWidget {
     Q_OBJECT
 
 public:
+    enum class InputBindingType {
+        NativeButton,
+        AnalogFromButton,
+        NativeAnalog,
+        Hotkey,
+        CModButton,
+        Empty
+    };
     struct InputBinding {
-        std::string binding_type;
+        ConfigureInput::InputBindingType binding_type;
         QString name;
-        int index;
+        int index = -1;     // used for anything there are multiple of
         int sub_index = -1; // used for sub-buttons
     };
+
     explicit ConfigureInput(Core::System& system, QWidget* parent = nullptr);
     ~ConfigureInput() override;
 
@@ -111,7 +120,8 @@ private:
     InputBinding GetMapping(const Common::ParamPackage& param);
 
     void ClearBinding(InputBinding binding);
-
+    void SetBinding(InputBinding binding, const Common::ParamPackage& params);
+    bool CheckForDuplicateMap(const Common::ParamPackage& params, InputBinding this_binding);
     void MapFromButton(const Common::ParamPackage& params);
     void AutoMap();
 


### PR DESCRIPTION
Presently, if you attempt to bind an input or hotkey that is already bound, you get a failure dialog but only on keyboard, not controller.

This PR:

1) Replaces the failure with a confirmation dialog that says "This will clear the binding for _____. Proceed?" with Yes and No options

2) Applies to controller buttons as well as keyboard buttons (within the input tab)

<img width="437" height="187" alt="Screenshot 2026-03-07 at 3 37 29 PM" src="https://github.com/user-attachments/assets/1adc5dfb-9743-4b46-9e43-8f6a9e36a98f" />

### Internal Changes

* Create an InputBinding struct inside the ConfigureInput class that contains additional information about input bindings internally to allow clearing the other input

* Changed the signals and slots in ConfigureInput and ConfigureHotkey so that they pass a map of keysequences to input bindings, rather than simply a list of keysequences

* Added signals and slots to allow ConfigureInput and ConfigureHotkeys to send each other signals to clear bindings 

* Create a method to determine if two controller parameter strings represent the same input so that controller conflicts can be found as well


Closes #1724 
