### PR TITLE
core: nwm: Implement NWM_SOC::GetMACAddress

### DIFF
--- a/src/core/hle/service/nwm/nwm.cpp
+++ b/src/core/hle/service/nwm/nwm.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -20,7 +20,7 @@ void InstallInterfaces(Core::System& system) {
     std::make_shared<NWM_EXT>()->InstallAsService(service_manager);
     std::make_shared<NWM_INF>()->InstallAsService(service_manager);
     std::make_shared<NWM_SAP>()->InstallAsService(service_manager);
-    std::make_shared<NWM_SOC>()->InstallAsService(service_manager);
+    std::make_shared<NWM_SOC>(system)->InstallAsService(service_manager);
     std::make_shared<NWM_TST>()->InstallAsService(service_manager);
     std::make_shared<NWM_UDS>(system)->InstallAsService(service_manager);
 }

--- a/src/core/hle/service/nwm/nwm_soc.cpp
+++ b/src/core/hle/service/nwm/nwm_soc.cpp
@@ -1,20 +1,46 @@
-// Copyright 2016 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
 #include "common/archives.h"
+#include "core/core.h"
+#include "core/hle/ipc_helpers.h"
+#include "core/hle/service/cfg/cfg.h"
+#include "core/hle/service/cfg/cfg_u.h"
 #include "core/hle/service/nwm/nwm_soc.h"
+#include "core/hle/service/nwm/nwm_uds.h"
 
 SERIALIZE_EXPORT_IMPL(Service::NWM::NWM_SOC)
+SERVICE_CONSTRUCT_IMPL(Service::NWM::NWM_SOC)
 
 namespace Service::NWM {
 
-NWM_SOC::NWM_SOC() : ServiceFramework("nwm::SOC") {
-    /*
+void NWM_SOC::GetMACAddress(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp(ctx);
+    const u32 size = rp.Pop<u32>();
+
+    std::vector<u8> mac_buffer(size);
+    MacAddress mac;
+
+    if (auto cfg = system.ServiceManager().GetService<Service::CFG::CFG_U>("cfg:u")) {
+        auto cfg_module = cfg->GetModule();
+        mac = Service::CFG::MacToArray(cfg_module->GetMacAddress());
+    }
+
+    std::copy(mac.begin(), mac.begin() + std::min(mac.size(), mac_buffer.size()),
+              mac_buffer.begin());
+
+    IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
+    rb.Push(ResultSuccess);
+    rb.PushStaticBuffer(mac_buffer, 0);
+}
+
+NWM_SOC::NWM_SOC(Core::System& _system) : ServiceFramework("nwm::SOC"), system(_system) {
+
     static const FunctionInfo functions[] = {
+        {0x0008, &NWM_SOC::GetMACAddress, "GetMACAddress"},
     };
     RegisterHandlers(functions);
-    */
 }
 
 } // namespace Service::NWM

--- a/src/core/hle/service/nwm/nwm_soc.h
+++ b/src/core/hle/service/nwm/nwm_soc.h
@@ -1,4 +1,4 @@
-// Copyright 2016 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -10,12 +10,17 @@ namespace Service::NWM {
 
 class NWM_SOC final : public ServiceFramework<NWM_SOC> {
 public:
-    NWM_SOC();
+    explicit NWM_SOC(Core::System& system);
 
 private:
+    void GetMACAddress(Kernel::HLERequestContext& ctx);
+
+    Core::System& system;
+
     SERVICE_SERIALIZATION_SIMPLE
 };
 
 } // namespace Service::NWM
 
+SERVICE_CONSTRUCT(Service::NWM::NWM_SOC)
 BOOST_CLASS_EXPORT_KEY(Service::NWM::NWM_SOC)


### PR DESCRIPTION
Implements `NWM_SOC::GetMACAddress`.

This change fixes compatibility with [NetPass](https://netpass.cafe/). (However, it still needs LLE CECD and BOSS modules)

Closes #1709 