### PR TITLE
core: Enable LLE CECD and BOSS when online LLE modules are enabled

### DIFF
--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -69,14 +69,14 @@ const std::array<ServiceModuleInfo, 41> service_module_map{
      {"AC", 0x00040130'00002402, AC::InstallInterfaces, false},
      {"ACT", 0x00040130'00003802, ACT::InstallInterfaces, true},
      {"AM", 0x00040130'00001502, AM::InstallInterfaces, false},
-     {"BOSS", 0x00040130'00003402, BOSS::InstallInterfaces, false},
+     {"BOSS", 0x00040130'00003402, BOSS::InstallInterfaces, true},
      {"CAM", 0x00040130'00001602,
       [](Core::System& system) {
           CAM::InstallInterfaces(system);
           Y2R::InstallInterfaces(system);
       },
       false},
-     {"CECD", 0x00040130'00002602, CECD::InstallInterfaces, false},
+     {"CECD", 0x00040130'00002602, CECD::InstallInterfaces, true},
      {"CFG", 0x00040130'00001702, CFG::InstallInterfaces, false},
      {"DLP", 0x00040130'00002802, DLP::InstallInterfaces, true},
      {"DSP", 0x00040130'00001A02, DSP::InstallInterfaces, false},


### PR DESCRIPTION
Enables the CECD and BOSS modules when the option "enable LLE modules for online play" option is enabled. This fixes compatibility issues with SpotPass and StreetPass until their HLE counterparts are fully implemented.

EDIT: Making BOSS LLE enabled for online play has been reverted in #1847 