### PR TITLE
core: Fix application jump parameters

### DIFF
--- a/src/core/hle/service/apt/applet_manager.cpp
+++ b/src/core/hle/service/apt/applet_manager.cpp
@@ -1456,6 +1456,8 @@ Result AppletManager::PrepareToStartApplication(u64 title_id, FS::MediaType medi
 
     capture_buffer_info.reset();
 
+    app_jump_parameters.Invalidate();
+
     return ResultSuccess;
 }
 

--- a/src/core/hle/service/apt/applet_manager.h
+++ b/src/core/hle/service/apt/applet_manager.h
@@ -185,12 +185,21 @@ private:
 using SysMenuArg = std::array<u8, SysMenuArgSize>;
 
 struct ApplicationJumpParameters {
-    u64 next_title_id;
-    FS::MediaType next_media_type;
-    ApplicationJumpFlags flags;
+    u64 next_title_id = ~0ULL;
+    FS::MediaType next_media_type{};
+    ApplicationJumpFlags flags{};
 
-    u64 current_title_id;
-    FS::MediaType current_media_type;
+    u64 current_title_id = ~0ULL;
+    FS::MediaType current_media_type{};
+
+    bool Valid() const {
+        return next_title_id != ~0ULL && current_title_id != ~0ULL;
+    }
+
+    void Invalidate() {
+        next_title_id = ~0ULL;
+        current_title_id = ~0ULL;
+    }
 
 private:
     template <class Archive>

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -1251,23 +1251,26 @@ void Module::APTInterface::GetStartupArgument(Kernel::HLERequestContext& ctx) {
     bool exists = false;
 
     if (auto arg = apt->applet_manager->ReceiveDeliverArg()) {
-        param = std::move(arg->param);
-
         // TODO: This is a complete guess based on observations. It is unknown how the OtherMedia
         // type is handled and how it interacts with the OtherApp type, and it is unknown if
         // this (checking the jump parameters) is indeed the way the 3DS checks the types.
         const auto& jump_parameters = apt->applet_manager->GetApplicationJumpParameters();
-        switch (startup_argument_type) {
-        case StartupArgumentType::OtherApp:
-            exists = jump_parameters.current_title_id != jump_parameters.next_title_id &&
-                     jump_parameters.current_media_type == jump_parameters.next_media_type;
-            break;
-        case StartupArgumentType::Restart:
-            exists = jump_parameters.current_title_id == jump_parameters.next_title_id;
-            break;
-        case StartupArgumentType::OtherMedia:
-            exists = jump_parameters.current_media_type != jump_parameters.next_media_type;
-            break;
+
+        if (jump_parameters.Valid()) {
+            param = std::move(arg->param);
+
+            switch (startup_argument_type) {
+            case StartupArgumentType::OtherApp:
+                exists = jump_parameters.current_title_id != jump_parameters.next_title_id &&
+                         jump_parameters.current_media_type == jump_parameters.next_media_type;
+                break;
+            case StartupArgumentType::Restart:
+                exists = jump_parameters.current_title_id == jump_parameters.next_title_id;
+                break;
+            case StartupArgumentType::OtherMedia:
+                exists = jump_parameters.current_media_type != jump_parameters.next_media_type;
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
Fixes the APT application jump parameters not being initialized nor marked as invalid when they do not exist (for example, when calling StartApplication instead of DoApplicationJump). This made apps think that there were application jump parameters available when they actually weren't. Implementation is not fully accurate and more research is needed.

Fixes Badge Arcade sometimes thinking there were application jump parameters and displaying an "update data has been applied" message. 