### PR TITLE
core: Stub AC::CancelConnectAsync

### DIFF
--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -63,6 +63,21 @@ void Module::Interface::GetConnectResult(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(ResultSuccess);
+
+    LOG_WARNING(Service_AC, "(STUBBED) called");
+}
+
+void Module::Interface::CancelConnectAsync(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp(ctx);
+    rp.Skip(2, false); // ProcessId descriptor
+
+    IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
+    rb.Push(ac->ac_connected ? Result(static_cast<ErrorDescription>(301), ErrorModule::AC,
+                                      ErrorSummary::InvalidState, ErrorLevel::Usage)
+                             : Result(static_cast<ErrorDescription>(302), ErrorModule::AC,
+                                      ErrorSummary::InvalidState, ErrorLevel::Usage));
+
+    LOG_WARNING(Service_AC, "(STUBBED) called");
 }
 
 void Module::Interface::CloseAsync(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/ac/ac.h
+++ b/src/core/hle/service/ac/ac.h
@@ -59,6 +59,15 @@ public:
         void GetConnectResult(Kernel::HLERequestContext& ctx);
 
         /**
+         * AC::CancelConnectAsync service function
+         *  Inputs:
+         *      1 : ProcessId Header
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         */
+        void CancelConnectAsync(Kernel::HLERequestContext& ctx);
+
+        /**
          * AC::CloseAsync service function
          *  Inputs:
          *      1 : ProcessId Header

--- a/src/core/hle/service/ac/ac_i.cpp
+++ b/src/core/hle/service/ac/ac_i.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -13,7 +13,7 @@ AC_I::AC_I(std::shared_ptr<Module> ac) : Module::Interface(std::move(ac), "ac:i"
         {0x0001, &AC_I::CreateDefaultConfig, "CreateDefaultConfig"},
         {0x0004, &AC_I::ConnectAsync, "ConnectAsync"},
         {0x0005, &AC_I::GetConnectResult, "GetConnectResult"},
-        {0x0007, nullptr, "CancelConnectAsync"},
+        {0x0007, &AC_I::CancelConnectAsync, "CancelConnectAsync"},
         {0x0008, &AC_I::CloseAsync, "CloseAsync"},
         {0x0009, &AC_I::GetCloseResult, "GetCloseResult"},
         {0x000A, nullptr, "GetLastErrorCode"},

--- a/src/core/hle/service/ac/ac_u.cpp
+++ b/src/core/hle/service/ac/ac_u.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -13,7 +13,7 @@ AC_U::AC_U(std::shared_ptr<Module> ac) : Module::Interface(std::move(ac), "ac:u"
         {0x0001, &AC_U::CreateDefaultConfig, "CreateDefaultConfig"},
         {0x0004, &AC_U::ConnectAsync, "ConnectAsync"},
         {0x0005, &AC_U::GetConnectResult, "GetConnectResult"},
-        {0x0007, nullptr, "CancelConnectAsync"},
+        {0x0007, &AC_U::CancelConnectAsync, "CancelConnectAsync"},
         {0x0008, &AC_U::CloseAsync, "CloseAsync"},
         {0x0009, &AC_U::GetCloseResult, "GetCloseResult"},
         {0x000A, nullptr, "GetLastErrorCode"},


### PR DESCRIPTION
Stubs `AC::CancelConnectAsync` to return proper errors when ac is connected or not.

Intended to fix another issue and turned out not to be the problem.