### PR TITLE
core: Disable BOSS for enabled LLE online services

### DIFF
--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -69,7 +69,7 @@ const std::array<ServiceModuleInfo, 41> service_module_map{
      {"AC", 0x00040130'00002402, AC::InstallInterfaces, false},
      {"ACT", 0x00040130'00003802, ACT::InstallInterfaces, true},
      {"AM", 0x00040130'00001502, AM::InstallInterfaces, false},
-     {"BOSS", 0x00040130'00003402, BOSS::InstallInterfaces, true},
+     {"BOSS", 0x00040130'00003402, BOSS::InstallInterfaces, false},
      {"CAM", 0x00040130'00001602,
       [](Core::System& system) {
           CAM::InstallInterfaces(system);


### PR DESCRIPTION
Amendment of #1842 

For some reason, the LLE BOSS module is causing issues when it is enabled. In some games such as Donkey Kong Country, it prevents the home menu from opening because the home menu does a BOSS service call, but the boss thread is never scheduled to pick it up. This causes the emulation to lock up.

This issue seems like a deep thread scheduling bug or emulation accuracy issue, so for the time beeing lets disable it. 