### PR TITLE
android: Fix IOFile::GetFd not functioning as expected in vanilla

### DIFF
--- a/src/common/android_storage.cpp
+++ b/src/common/android_storage.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #ifdef ANDROID
+#include <boost/algorithm/string/replace.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include "common/android_storage.h"
@@ -317,7 +318,9 @@ std::string TranslateFilePath(const std::string& filepath) {
     }
     std::optional<std::string> userDirLocation = GetUserDirectory();
     if (userDirLocation) {
-        return *userDirLocation + "/" + filepath;
+        std::string translatedPath = *userDirLocation + "/" + filepath;
+        boost::replace_all(translatedPath, "//", "/");
+        return translatedPath;
     }
     return "";
 }

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -34,6 +34,9 @@
 #ifdef _MSC_VER
 #include "common/string_util.h"
 #endif
+#if defined(ANDROID) && !defined(HAVE_LIBRETRO_VFS)
+#include "android_storage.h"
+#endif
 
 #ifdef HAVE_LIBRETRO_VFS
 #define SKIP_STDIO_REDEFINES
@@ -438,13 +441,16 @@ public:
         if (m_file == nullptr)
             return -1;
         return fileno(filestream_get_vfs_handle(m_file)->fp);
-#elif defined(ANDROID)
-        return m_fd;
 #else
+#ifdef ANDROID
+        if (!AndroidStorage::CanUseRawFS()) {
+            return m_fd;
+        }
+#endif // ANDROID
         if (m_file == nullptr)
             return -1;
         return fileno(m_file);
-#endif
+#endif // HAVE_LIBRETRO_VFS
     }
     [[nodiscard]] explicit operator bool() const {
         return IsGood();

--- a/src/core/cheats/cheats.cpp
+++ b/src/core/cheats/cheats.cpp
@@ -65,6 +65,8 @@ void CheatEngine::SaveCheatFile(u64 title_id) const {
     const std::string cheat_dir = FileUtil::GetUserPath(FileUtil::UserPath::CheatsDir);
     const std::string filepath = fmt::format("{}{:016X}.txt", cheat_dir, title_id);
 
+    LOG_INFO(Core_Cheats, "Attempting to save cheats file: {}", filepath);
+
     if (!FileUtil::IsDirectory(cheat_dir)) {
         FileUtil::CreateDir(cheat_dir);
     }
@@ -86,6 +88,8 @@ void CheatEngine::LoadCheatFile(u64 title_id) {
 
     const std::string cheat_dir = FileUtil::GetUserPath(FileUtil::UserPath::CheatsDir);
     const std::string filepath = fmt::format("{}{:016X}.txt", cheat_dir, title_id);
+
+    LOG_INFO(Core_Cheats, "Attempting to load cheats file: {}", filepath);
 
     if (!FileUtil::IsDirectory(cheat_dir)) {
         FileUtil::CreateDir(cheat_dir);

--- a/src/core/cheats/gateway_cheat.cpp
+++ b/src/core/cheats/gateway_cheat.cpp
@@ -488,12 +488,14 @@ std::vector<std::shared_ptr<CheatBase>> GatewayCheat::LoadFile(const std::string
     std::vector<std::shared_ptr<CheatBase>> cheats;
 
     if (!FileUtil::Exists(filepath)) {
+        LOG_INFO(Core_Cheats, "GatewayCheat::LoadFile failed, file doesn't exist: {}", filepath);
         return cheats;
     }
 
     boost::iostreams::stream<boost::iostreams::file_descriptor_source> file;
     FileUtil::OpenFStream<std::ios_base::in>(file, filepath);
     if (!file.is_open()) {
+        LOG_INFO(Core_Cheats, "GatewayCheat::LoadFile failed, file failed to open: {}", filepath);
         return cheats;
     }
 


### PR DESCRIPTION
Closes #1850 

This fixes the cheats menu not loading correctly.

This commit additionally contains some extra logging and a minor cleanup step in `AndroidStorage::TranslateFilePath` which shouldn't affect anything but is best practice.