### PR TITLE
core: kernel: Set debug thread name based on process name

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1308,7 +1308,7 @@ Result SVC::CreateThread(Handle* out_handle, u32 entry_point, u32 arg, VAddr sta
     }
 
     // Create thread.
-    const std::string name = fmt::format("thread-{:08X}", entry_point);
+    const std::string name = fmt::format("{}-{:08X}", current_process->codeset->name, entry_point);
     CASCADE_RESULT(std::shared_ptr<Thread> thread,
                    kernel.CreateThread(name, entry_point, priority, arg, processor_id, stack_top,
                                        current_process));

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -455,9 +455,9 @@ std::shared_ptr<Thread> SetupMainThread(KernelSystem& kernel, u32 entry_point, u
     }
 
     // Initialize new "main" thread
-    auto thread_res =
-        kernel.CreateThread("main", entry_point, priority, 0, owner_process->ideal_processor,
-                            Memory::HEAP_VADDR_END, owner_process, sleep_time_ns == 0);
+    auto thread_res = kernel.CreateThread(
+        fmt::format("{}-main", owner_process->codeset->name), entry_point, priority, 0,
+        owner_process->ideal_processor, Memory::HEAP_VADDR_END, owner_process, sleep_time_ns == 0);
 
     std::shared_ptr<Thread> thread = std::move(thread_res).Unwrap();
 


### PR DESCRIPTION
Sets thread names based on their owner process, making debugging easier. Has no impact on normal emulator usage.