### PR TITLE
core: ac: Implement GetNZoneBeaconNotFoundEvent

### DIFF
--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -155,6 +155,20 @@ void Module::Interface::SetRequestEulaVersion(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_AC, "(STUBBED) called, major={}, minor={}", major, minor);
 }
 
+void Module::Interface::GetNZoneBeaconNotFoundEvent(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp(ctx);
+    rp.Skip(2, false); // ProcessId descriptor
+
+    ac->nintendo_zone_beacon_not_found_event = rp.PopObject<Kernel::Event>();
+
+    ac->nintendo_zone_beacon_not_found_event->Signal();
+
+    IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
+    rb.Push(ResultSuccess);
+
+    LOG_WARNING(Service_AC, "(STUBBED) called");
+}
+
 void Module::Interface::RegisterDisconnectEvent(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     rp.Skip(2, false); // ProcessId descriptor
@@ -226,6 +240,7 @@ void Module::serialize(Archive& ar, const unsigned int) {
     ar & close_event;
     ar & connect_event;
     ar & disconnect_event;
+    ar & nintendo_zone_beacon_not_found_event;
     // default_config is never written to
 }
 SERIALIZE_IMPL(Module)

--- a/src/core/hle/service/ac/ac.h
+++ b/src/core/hle/service/ac/ac.h
@@ -130,6 +130,18 @@ public:
         void SetRequestEulaVersion(Kernel::HLERequestContext& ctx);
 
         /**
+         * AC::GetNZoneBeaconNotFoundEvent service function
+         *  Inputs:
+         *      1 : ProcessId Header
+         *      2 : ProcessId
+         *      3 : Copy Handle Header
+         *      4 : Event handle, should be signaled when a Nintendo Zone beacon is not found
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         */
+        void GetNZoneBeaconNotFoundEvent(Kernel::HLERequestContext& ctx);
+
+        /**
          * AC::RegisterDisconnectEvent service function
          *  Inputs:
          *      1 : ProcessId Header
@@ -194,6 +206,7 @@ protected:
     std::shared_ptr<Kernel::Event> close_event;
     std::shared_ptr<Kernel::Event> connect_event;
     std::shared_ptr<Kernel::Event> disconnect_event;
+    std::shared_ptr<Kernel::Event> nintendo_zone_beacon_not_found_event;
 
 private:
     [[maybe_unused]]

--- a/src/core/hle/service/ac/ac_i.cpp
+++ b/src/core/hle/service/ac/ac_i.cpp
@@ -26,6 +26,7 @@ AC_I::AC_I(std::shared_ptr<Module> ac) : Module::Interface(std::move(ac), "ac:i"
         {0x0024, nullptr, "AddDenyApType"},
         {0x0027, &AC_I::GetInfraPriority, "GetInfraPriority"},
         {0x002D, &AC_I::SetRequestEulaVersion, "SetRequestEulaVersion"},
+        {0x002F, &AC_I::GetNZoneBeaconNotFoundEvent, "GetNZoneBeaconNotFoundEvent"},
         {0x0030, &AC_I::RegisterDisconnectEvent, "RegisterDisconnectEvent"},
         {0x0036, &AC_I::GetConnectingProxyEnable, "GetConnectingProxyEnable"},
         {0x003C, nullptr, "GetAPSSIDList"},

--- a/src/core/hle/service/ac/ac_u.cpp
+++ b/src/core/hle/service/ac/ac_u.cpp
@@ -26,6 +26,7 @@ AC_U::AC_U(std::shared_ptr<Module> ac) : Module::Interface(std::move(ac), "ac:u"
         {0x0024, nullptr, "AddDenyApType"},
         {0x0027, &AC_U::GetInfraPriority, "GetInfraPriority"},
         {0x002D, &AC_U::SetRequestEulaVersion, "SetRequestEulaVersion"},
+        {0x002F, &AC_U::GetNZoneBeaconNotFoundEvent, "GetNZoneBeaconNotFoundEvent"},
         {0x0030, &AC_U::RegisterDisconnectEvent, "RegisterDisconnectEvent"},
         {0x0036, &AC_U::GetConnectingProxyEnable, "GetConnectingProxyEnable"},
         {0x003C, nullptr, "GetAPSSIDList"},


### PR DESCRIPTION
Stubs `AC::GetNZoneBeaconNotFoundEvent`.

This was done during the research of another issue, but turned out not to be the problem. Has no impact on normal emulator usage.