### PR TITLE
core: apt: Fix GetStartupArgument operation order

### DIFF
--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -1250,13 +1250,14 @@ void Module::APTInterface::GetStartupArgument(Kernel::HLERequestContext& ctx) {
     std::vector<u8> param;
     bool exists = false;
 
-    if (auto arg = apt->applet_manager->ReceiveDeliverArg()) {
-        // TODO: This is a complete guess based on observations. It is unknown how the OtherMedia
-        // type is handled and how it interacts with the OtherApp type, and it is unknown if
-        // this (checking the jump parameters) is indeed the way the 3DS checks the types.
-        const auto& jump_parameters = apt->applet_manager->GetApplicationJumpParameters();
+    const auto& jump_parameters = apt->applet_manager->GetApplicationJumpParameters();
 
-        if (jump_parameters.Valid()) {
+    // TODO: This is a complete guess based on observations. It is unknown how the
+    // OtherMedia type is handled and how it interacts with the OtherApp type, and it is
+    // unknown if this (checking the jump parameters) is indeed the way the 3DS checks the
+    // types.
+    if (jump_parameters.Valid()) {
+        if (auto arg = apt->applet_manager->ReceiveDeliverArg()) {
             param = std::move(arg->param);
 
             switch (startup_argument_type) {


### PR DESCRIPTION
Fixes a regression introduced in #1845 where the order of operations in `APT::GetStartupArgument` are wrong. It should first check if the jump parameters exist first then pop the deliver arg, not the other way around.

Fixes #1857 