### PR TITLE
android: Use StorageManager to get removable media path

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
@@ -737,7 +737,7 @@ object NativeLibrary {
             return primaryStoragePath + dirSep + virtualPath
         } else { // User directory probably located on a removable storage device
             val storageIdString = pathSegment.substringBefore(":")
-            val removablePath = RemovableStorageHelper.getRemovableStoragePath(storageIdString)
+            val removablePath = RemovableStorageHelper.getRemovableStoragePath(CitraApplication.appContext, storageIdString)
 
             if (removablePath == null) {
                 android.util.Log.e("NativeLibrary",

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/RemovableStorageHelper.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/RemovableStorageHelper.kt
@@ -4,28 +4,39 @@
 
 package org.citra.citra_emu.utils
 
-import org.citra.citra_emu.utils.BuildUtil
-import java.io.File
+import android.content.Context
+import android.os.storage.StorageManager
 
 object RemovableStorageHelper {
-    // This really shouldn't be necessary, but the Android API seemingly
-    // doesn't have a way of doing this?
-    fun getRemovableStoragePath(idString: String): String? {
-        BuildUtil.assertNotGooglePlay()
 
-        // On certain Android flavours the external storage mount location can
-        // vary, so add extra cases here if we discover them.
-        val possibleMountPaths = listOf("/mnt/media_rw/$idString", "/storage/$idString")
+    private val pathCache = mutableMapOf<String, String?>()
+    private var scanned = false
 
-        for (mountPath in possibleMountPaths) {
-            val pathFile = File(mountPath);
-            if (pathFile.exists()) {
-                // TODO: Cache which mount location is being used for the remainder of the
-                //       session, as it should never change. -OS
-                return pathFile.absolutePath
-            }
+    private fun scanVolumes(context: Context) {
+        if (scanned) return
+
+        val storageManager = context.getSystemService(Context.STORAGE_SERVICE) as StorageManager
+
+        for (volume in storageManager.storageVolumes) {
+            if (!volume.isRemovable) continue
+
+            val uuid = volume.uuid ?: continue
+            val dir = volume.directory ?: continue
+
+            pathCache[uuid.uppercase()] = dir.absolutePath
         }
 
-        return null
+        scanned = true
+    }
+
+    fun getRemovableStoragePath(context: Context, idString: String): String? {
+        BuildUtil.assertNotGooglePlay()
+        val key = idString.uppercase()
+
+        if (!scanned) {
+            scanVolumes(context)
+        }
+
+        return pathCache[key]
     }
 }

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/RemovableStorageHelper.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/RemovableStorageHelper.kt
@@ -13,12 +13,16 @@ object RemovableStorageHelper {
     private var scanned = false
 
     private fun scanVolumes(context: Context) {
-        if (scanned) return
+        if (scanned) {
+            return
+        }
 
         val storageManager = context.getSystemService(Context.STORAGE_SERVICE) as StorageManager
 
         for (volume in storageManager.storageVolumes) {
-            if (!volume.isRemovable) continue
+            if (!volume.isRemovable) {
+                continue
+            }
 
             val uuid = volume.uuid ?: continue
             val dir = volume.directory ?: continue


### PR DESCRIPTION
Uses the `STORAGE_SERVICE` to list all available removable media and their absolute paths. This allows getting the list of mount points which are vendor dependent.

Tested on a Retroid Pocket 5 with an external SD card.