### PR TITLE
shader_jit_a64_compiler: Added missing include

### DIFF
--- a/src/video_core/shader/shader_jit_a64_compiler.cpp
+++ b/src/video_core/shader/shader_jit_a64_compiler.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <memory>
 #include <nihstro/shader_bytecode.h>
 #include "common/aarch64/cpu_detect.h"
 #include "common/aarch64/oaknut_abi.h"


### PR DESCRIPTION
Fixes a build issue on ARM64 Linux w/ GCC

Fix proposed by PabloMK7