### PR TITLE
macos: Add warning dialog when launching `azahar` executable directly

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -116,6 +116,7 @@
 
 #ifdef __APPLE__
 #include "common/apple_authorization.h"
+#include "common/apple_utils.h"
 Q_IMPORT_PLUGIN(QDarwinCameraPermissionPlugin);
 #endif
 
@@ -423,6 +424,19 @@ GMainWindow::GMainWindow(Core::System& system_)
     secondary_window->setWindowIcon(azahar_icon);
 
     show();
+
+#ifdef __APPLE__
+    if (AppleUtils::IsRunningFromTerminal()) {
+        QMessageBox::warning(
+            this, tr("Warning"),
+            tr("The `azahar` executable is being run directly rather than via the Azahar.app "
+               "bundle.\n\n"
+               "When run this way, the app may be missing certain functionality such as camera "
+               "emulation.\n\n"
+               "It is recommended to instead run Azahar using the `open` command, e.g.:\n"
+               "`open ./Azahar.app`"));
+    }
+#endif
 
 #ifdef ENABLE_QT_UPDATE_CHECKER
     if (UISettings::values.check_for_update_on_start) {

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -120,6 +120,7 @@ if (APPLE AND NOT ENABLE_LIBRETRO)
   target_sources(citra_common PUBLIC
     apple_authorization.h
     apple_authorization.cpp
+    apple_utils.cpp
     apple_utils.h
     apple_utils.mm
   )

--- a/src/common/apple_utils.cpp
+++ b/src/common/apple_utils.cpp
@@ -2,10 +2,12 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <unistd.h>
+
 namespace AppleUtils {
 
-float GetRefreshRate();
-int IsLowPowerModeEnabled();
-bool IsRunningFromTerminal();
+bool IsRunningFromTerminal() {
+    return (getppid() != 1);
+}
 
 } // namespace AppleUtils


### PR DESCRIPTION
Closes #1719

Was originally going to warn via stderr output, however, after reconsidering that running Azahar this way can cause real issues and that a console message could easily be missed, I've decided to instead warn via a translatable warning dialog.