### PR TITLE
android: Separate package IDs for build variants

### DIFF
--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -63,7 +63,7 @@ android {
     defaultConfig {
         // The application ID refers to Lime3DS to allow for
         // the Play Store listing, which was originally set up for Lime3DS, to still be used.
-        applicationId = "io.github.lime3ds.android"
+        applicationId = "org.azahar_emu.azahar"
         minSdk = 29
         targetSdk = 35
         versionCode = autoVersion
@@ -173,6 +173,7 @@ android {
         register("googlePlay") {
             dimension = "version"
             versionNameSuffix = "-googleplay"
+            applicationId = "io.github.lime3ds.android"
         }
     }
 


### PR DESCRIPTION
Closes #1584

The change is as follows:

- Vanilla: `org.azahar_emu.azahar`
- Google Play: `io.github.lime3ds.android` (same as before out of necessity)