### PR TITLE
Added Command Line Interface for compression and decompression

### DIFF
--- a/src/citra_meta/common_strings.h
+++ b/src/citra_meta/common_strings.h
@@ -15,6 +15,8 @@ constexpr char help_string[] =
     "-g, --gdbport [port]        Enable gdb stub on the given port\n"
     "-h, --help                  Display this help and exit\n"
     "-i, --install [path]        Install a CIA file at the given path\n"
+    "-c, --compress [path]       Compress the cci/3ds/cxi/app/3dsx/cia file at the given path\n"
+    "-x, --decompress [path]     Decompress zcci/zcxi/z3dsx/zcia file at the given path\n"
     "-p, --movie-play [path]     Play a TAS movie located at the given path\n"
     "-r, --movie-record [path]   Record a TAS movie to the given file path\n"
     "-a, --movie-record-author [author]   Set the author for the recorded TAS movie (to be used "

--- a/src/citra_meta/common_strings.h
+++ b/src/citra_meta/common_strings.h
@@ -10,22 +10,24 @@ namespace Common {
 
 constexpr char help_string[] =
     "Usage: {} [options] <file path>\n"
-    "-d, --dump-video [path]     Dump video recording of emulator playback to the given file path\n"
-    "-f, --fullscreen            Start in fullscreen mode\n"
-    "-g, --gdbport [port]        Enable gdb stub on the given port\n"
-    "-h, --help                  Display this help and exit\n"
-    "-i, --install [path]        Install a CIA file at the given path\n"
-    "-c, --compress [path]       Compress the cci/3ds/cxi/app/3dsx/cia file at the given path\n"
-    "-x, --decompress [path]     Decompress zcci/zcxi/z3dsx/zcia file at the given path\n"
-    "-p, --movie-play [path]     Play a TAS movie located at the given path\n"
-    "-r, --movie-record [path]   Record a TAS movie to the given file path\n"
+    "-d, --dump-video [path]              Dump video recording of emulator playback to the given file path\n"
+    "-f, --fullscreen                     Start in fullscreen mode\n"
+    "-g, --gdbport [port]                 Enable gdb stub on the given port\n"
+    "-h, --help                           Display this help and exit\n"
+    "-i, --install [path]                 Install a CIA file at the given path\n"
+    "-c, --compress [path]... -o [path]   Compress the cci/3ds/cxi/app/3dsx/cia files at the given path\n"
+    "                                     If \'-o [path]\' isnt used, it compresses in place\n"
+    "-x, --decompress [path]... -o [path] Decompress zcci/zcxi/z3dsx/zcia files at the given path\n"
+    "                                     If \'-o [path]\' isnt used, it decompresses in place\n"
+    "-p, --movie-play [path]              Play a TAS movie located at the given path\n"
+    "-r, --movie-record [path]            Record a TAS movie to the given file path\n"
     "-a, --movie-record-author [author]   Set the author for the recorded TAS movie (to be used "
     "alongside --movie-record)\n"
 #ifdef ENABLE_ROOM
-    "    --room                  Utilize dedicated multiplayer room functionality (equivalent to "
+    "    --room                           Utilize dedicated multiplayer room functionality (equivalent to "
     "the old citra-room executable)\n"
 #endif
-    "-v, --version               Output version information and exit\n"
-    "-w, --windowed              Start in windowed mode";
+    "-v, --version                        Output version information and exit\n"
+    "-w, --windowed                       Start in windowed mode";
 
 } // namespace Common

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -87,6 +87,7 @@
 #include "common/literals.h"
 #include "common/logging/backend.h"
 #include "common/logging/log.h"
+#include "common/logging/filter.h"
 #include "common/memory_detect.h"
 #include "common/scm_rev.h"
 #include "common/scope_exit.h"
@@ -342,6 +343,11 @@ GMainWindow::GMainWindow(Core::System& system_)
             if (i >= args.size() - 1 || args[i + 1].startsWith(QChar::fromLatin1('-'))) {
                 continue;
             }
+            UISettings::values.show_console = true;
+            Debugger::ToggleConsole();
+            Common::Log::Filter filter;
+            filter.ParseFilterString("*:Warning");
+            Common::Log::SetGlobalFilter(filter);
             i++;
             for (; i < args.size(); i++){
                 QFileInfo currPath(args[i]);
@@ -362,6 +368,11 @@ GMainWindow::GMainWindow(Core::System& system_)
             if (i >= args.size() - 1 || args[i + 1].startsWith(QChar::fromLatin1('-'))) {
                 continue;
             }
+            UISettings::values.show_console = true;
+            Debugger::ToggleConsole();
+            Common::Log::Filter filter;
+            filter.ParseFilterString("*:Warning");
+            Common::Log::SetGlobalFilter(filter);
             i++;
             for (; i < args.size(); i++){
                 QFileInfo currPath(args[i]);

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -336,6 +336,46 @@ GMainWindow::GMainWindow(Core::System& system_)
             game_path = args[i];
             continue;
         }
+
+        // Compress files in place
+        if (args[i] == QStringLiteral("--compress") || args[i] == QStringLiteral("-c")) {
+            if (i >= args.size() - 1 || args[i + 1].startsWith(QChar::fromLatin1('-'))) {
+                continue;
+            }
+            i++;
+            for (; i < args.size(); i++){
+                QFileInfo currPath(args[i]);
+                if (currPath.isFile()){
+                    compress_paths.append(args[i]);
+                } else {
+                    QTextStream(stderr) << "Error: " << args[i] << " is not a file!\n";
+                    exit(1);
+                }
+            }
+            GMainWindow::OnCompressFileCLI();
+            compression_future.waitForFinished();
+            exit(0);
+        }
+
+        // Decompress files in place
+        if (args[i] == QStringLiteral("--decompress") || args[i] == QStringLiteral("-x")) {
+            if (i >= args.size() - 1 || args[i + 1].startsWith(QChar::fromLatin1('-'))) {
+                continue;
+            }
+            i++;
+            for (; i < args.size(); i++){
+                QFileInfo currPath(args[i]);
+                if (currPath.isFile()){
+                    decompress_paths.append(args[i]);
+                } else {
+                    QTextStream(stderr) << "Error: " << args[i] << " is not a file!\n";
+                    exit(1);
+                }
+            }
+            GMainWindow::OnDecompressFileCLI();
+            compression_future.waitForFinished();
+            exit(0);
+        }
     }
 
 #ifdef __unix__
@@ -3281,6 +3321,72 @@ void GMainWindow::OnCompressFile() {
     });
 }
 
+void GMainWindow::OnCompressFileCLI() {
+    // NOTE: Encrypted files SHOULD NEVER be compressed, otherwise the resulting
+    // compressed file will have very poor compression ratios, due to the high
+    // entropy caused by encryption. This may cause confusion to the user as they
+    // will see the files do not compress well and blame the emulator.
+    //
+    // This is enforced using the loaders as they already return an error on encryption.
+
+    QString out_path;
+    QStringList filepaths = compress_paths;
+    if (compress_paths.isEmpty()) {
+        return;
+    }
+
+    bool single_file = filepaths.size() == 1;
+
+    // Set the output directory based on the starting file
+    QFileInfo startFileInfo(filepaths[0]);
+    out_path = startFileInfo.absolutePath();
+    if (out_path.isEmpty()) {
+        return;
+    }
+
+    compression_future = QtConcurrent::run([&, filepaths, out_path] {
+        bool single_file = filepaths.size() == 1;
+        QString out_filepath;
+        bool total_success = true;
+
+        for (const QString& filepath : filepaths) {
+            QFileInfo filepathInfo(filepath);
+            QTextStream(stdout) << "Compressing " << filepathInfo.fileName() << "\n";
+            std::string in_path = filepath.toStdString();
+
+            // Identify file type
+            auto compress_info = GetCompressFileInfo(filepath.toStdString(), true);
+            if (!compress_info.has_value()) {
+                total_success = false;
+                continue;
+            }
+
+            QFileInfo fileinfo(filepath);
+            out_filepath = out_path + QStringLiteral(DIR_SEP) + fileinfo.completeBaseName() +
+                           QStringLiteral(".") +
+                           QString::fromStdString(
+                               compress_info.value().first.recommended_compressed_extension);
+
+            std::string out_path = out_filepath.toStdString();
+            emit UpdateProgress(0, 0);
+            const auto progress = [&](std::size_t written, std::size_t total) {
+                emit UpdateProgress(written, total);
+            };
+            bool success = FileUtil::CompressZ3DSFile(in_path, out_path,
+                                                      compress_info.value().first.underlying_magic,
+                                                      compress_info.value().second, progress,
+                                                      compress_info.value().first.default_metadata);
+            if (!success) {
+                total_success = false;
+                FileUtil::Delete(out_path);
+            }
+        }
+        emit CompressFinished(true, total_success);
+    });
+}
+
+
+
 void GMainWindow::OnDecompressFile() {
 
     QStringList filepaths = QFileDialog::getOpenFileNames(
@@ -3370,6 +3476,58 @@ void GMainWindow::OnDecompressFile() {
             }
         }
 
+        emit CompressFinished(false, total_success);
+    });
+}
+
+void GMainWindow::OnDecompressFileCLI() {
+    QStringList filepaths = decompress_paths;
+    QString out_path;
+
+    if (filepaths.isEmpty()) {
+        return;
+    }
+
+    bool single_file = filepaths.size() == 1;
+    QFileInfo startFileInfo(filepaths[0]);
+    out_path = startFileInfo.absolutePath();
+
+    compression_future = QtConcurrent::run([&, filepaths, out_path] {
+        bool single_file = filepaths.size() == 1;
+        QString out_filepath;
+        bool total_success = true;
+
+        for (const QString& filepath : filepaths) {
+            QFileInfo filepathInfo(filepath);
+            QTextStream(stdout) << "Decompressing " << filepathInfo.fileName() << "\n";
+            std::string in_path = filepath.toStdString();
+
+            // Identify file type
+            auto compress_info = GetCompressFileInfo(filepath.toStdString(), false);
+            if (!compress_info.has_value()) {
+                total_success = false;
+                continue;
+            }
+
+            QFileInfo fileinfo(filepath);
+
+            out_filepath = out_path + QStringLiteral(DIR_SEP) + fileinfo.completeBaseName() +
+                           QStringLiteral(".") +
+                           QString::fromStdString(
+                               compress_info.value().first.recommended_uncompressed_extension);
+            std::string out_path = out_filepath.toStdString();
+            emit UpdateProgress(0, 0);
+            const auto progress = [&](std::size_t written, std::size_t total) {
+                emit UpdateProgress(written, total);
+            };
+
+            // TODO(PabloMK7): What should we do with the metadata?
+            bool success = FileUtil::DeCompressZ3DSFile(in_path, out_path, progress);
+            if (!success) {
+                total_success = false;
+                FileUtil::Delete(out_path);
+            }
+        }
         emit CompressFinished(false, total_success);
     });
 }

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -357,11 +357,16 @@ GMainWindow::GMainWindow(Core::System& system_)
             for (; i < args.size(); i++){
                 if (args[i] == QStringLiteral("-o") || args[i] == QStringLiteral("--output")){
                     i++;
-                    QFileInfo outputPath(args[i]);
-                    if (outputPath.isDir()){
-                        cli_out_path = args[i];
+                    if (i < args.size()){
+                        QFileInfo outputPath(args[i]);
+                        if (outputPath.isDir()){
+                            cli_out_path = args[i];
+                        } else {
+                            QTextStream(stderr) << "Error: " << args[i] << " is not a directory!\n";
+                            exit(1);
+                        }
                     } else {
-                        QTextStream(stderr) << "Error: " << args[i] << " is not a directory!\n";
+                        QTextStream(stderr) << "Error: No directory specified";
                         exit(1);
                     }
                     break;
@@ -393,11 +398,16 @@ GMainWindow::GMainWindow(Core::System& system_)
             for (; i < args.size(); i++){
                 if (args[i] == QStringLiteral("-o") || args[i] == QStringLiteral("--output")){
                     i++;
-                    QFileInfo outputPath(args[i]);
-                    if (outputPath.isDir()){
-                        cli_out_path = args[i];
+                    if (i < args.size()){
+                        QFileInfo outputPath(args[i]);
+                        if (outputPath.isDir()){
+                            cli_out_path = args[i];
+                        } else {
+                            QTextStream(stderr) << "Error: " << args[i] << " is not a directory!\n";
+                            exit(1);
+                        }
                     } else {
-                        QTextStream(stderr) << "Error: " << args[i] << " is not a directory!\n";
+                        QTextStream(stderr) << "Error: No directory specified";
                         exit(1);
                     }
                     break;

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -247,7 +247,12 @@ GMainWindow::GMainWindow(Core::System& system_)
         }
 
         if (args[i] == QStringLiteral("--help") || args[i] == QStringLiteral("-h")) {
-            ShowCommandOutput("Help", fmt::format(Common::help_string, args[0].toStdString()));
+            UISettings::values.show_console = true;
+            Debugger::ToggleConsole();
+            Common::Log::Filter filter;
+            filter.ParseFilterString("*:Error");
+            QFileInfo azaharFile(args[0]);
+            QTextStream(stdout) << QString::fromStdString(fmt::format(Common::help_string, azaharFile.fileName().toStdString()));
             exit(0);
         }
 
@@ -350,6 +355,17 @@ GMainWindow::GMainWindow(Core::System& system_)
             Common::Log::SetGlobalFilter(filter);
             i++;
             for (; i < args.size(); i++){
+                if (args[i] == QStringLiteral("-o") || args[i] == QStringLiteral("--output")){
+                    i++;
+                    QFileInfo outputPath(args[i]);
+                    if (outputPath.isDir()){
+                        cli_out_path = args[i];
+                    } else {
+                        QTextStream(stderr) << "Error: " << args[i] << " is not a directory!\n";
+                        exit(1);
+                    }
+                    break;
+                }
                 QFileInfo currPath(args[i]);
                 if (currPath.isFile()){
                     compress_paths.append(args[i]);
@@ -375,6 +391,17 @@ GMainWindow::GMainWindow(Core::System& system_)
             Common::Log::SetGlobalFilter(filter);
             i++;
             for (; i < args.size(); i++){
+                if (args[i] == QStringLiteral("-o") || args[i] == QStringLiteral("--output")){
+                    i++;
+                    QFileInfo outputPath(args[i]);
+                    if (outputPath.isDir()){
+                        cli_out_path = args[i];
+                    } else {
+                        QTextStream(stderr) << "Error: " << args[i] << " is not a directory!\n";
+                        exit(1);
+                    }
+                    break;
+                }
                 QFileInfo currPath(args[i]);
                 if (currPath.isFile()){
                     decompress_paths.append(args[i]);
@@ -3340,20 +3367,13 @@ void GMainWindow::OnCompressFileCLI() {
     //
     // This is enforced using the loaders as they already return an error on encryption.
 
-    QString out_path;
+    QString out_path = cli_out_path;
     QStringList filepaths = compress_paths;
     if (compress_paths.isEmpty()) {
         return;
     }
 
     bool single_file = filepaths.size() == 1;
-
-    // Set the output directory based on the starting file
-    QFileInfo startFileInfo(filepaths[0]);
-    out_path = startFileInfo.absolutePath();
-    if (out_path.isEmpty()) {
-        return;
-    }
 
     compression_future = QtConcurrent::run([&, filepaths, out_path] {
         bool single_file = filepaths.size() == 1;
@@ -3373,7 +3393,13 @@ void GMainWindow::OnCompressFileCLI() {
             }
 
             QFileInfo fileinfo(filepath);
-            out_filepath = out_path + QStringLiteral(DIR_SEP) + fileinfo.completeBaseName() +
+            if (out_path.isEmpty()){
+                out_filepath = fileinfo.absolutePath();
+            } else {
+                out_filepath = out_path;
+            }
+
+            out_filepath = out_filepath + QStringLiteral(DIR_SEP) + fileinfo.completeBaseName() +
                            QStringLiteral(".") +
                            QString::fromStdString(
                                compress_info.value().first.recommended_compressed_extension);
@@ -3493,15 +3519,13 @@ void GMainWindow::OnDecompressFile() {
 
 void GMainWindow::OnDecompressFileCLI() {
     QStringList filepaths = decompress_paths;
-    QString out_path;
+    QString out_path = cli_out_path;
 
     if (filepaths.isEmpty()) {
         return;
     }
 
     bool single_file = filepaths.size() == 1;
-    QFileInfo startFileInfo(filepaths[0]);
-    out_path = startFileInfo.absolutePath();
 
     compression_future = QtConcurrent::run([&, filepaths, out_path] {
         bool single_file = filepaths.size() == 1;
@@ -3522,7 +3546,12 @@ void GMainWindow::OnDecompressFileCLI() {
 
             QFileInfo fileinfo(filepath);
 
-            out_filepath = out_path + QStringLiteral(DIR_SEP) + fileinfo.completeBaseName() +
+            if (out_path.isEmpty()){
+                out_filepath = fileinfo.absolutePath();
+            } else {
+                out_filepath = out_path;
+            }
+            out_filepath = out_filepath + QStringLiteral(DIR_SEP) + fileinfo.completeBaseName() +
                            QStringLiteral(".") +
                            QString::fromStdString(
                                compress_info.value().first.recommended_uncompressed_extension);

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -346,7 +346,7 @@ GMainWindow::GMainWindow(Core::System& system_)
             UISettings::values.show_console = true;
             Debugger::ToggleConsole();
             Common::Log::Filter filter;
-            filter.ParseFilterString("*:Warning");
+            filter.ParseFilterString("*:Error");
             Common::Log::SetGlobalFilter(filter);
             i++;
             for (; i < args.size(); i++){
@@ -371,7 +371,7 @@ GMainWindow::GMainWindow(Core::System& system_)
             UISettings::values.show_console = true;
             Debugger::ToggleConsole();
             Common::Log::Filter filter;
-            filter.ParseFilterString("*:Warning");
+            filter.ParseFilterString("*:Error");
             Common::Log::SetGlobalFilter(filter);
             i++;
             for (; i < args.size(); i++){
@@ -3362,7 +3362,7 @@ void GMainWindow::OnCompressFileCLI() {
 
         for (const QString& filepath : filepaths) {
             QFileInfo filepathInfo(filepath);
-            QTextStream(stdout) << "Compressing " << filepathInfo.fileName() << "\n";
+            QTextStream(stdout) << "Compressing \"" << filepathInfo.fileName() << "\"...\n";
             std::string in_path = filepath.toStdString();
 
             // Identify file type
@@ -3510,7 +3510,7 @@ void GMainWindow::OnDecompressFileCLI() {
 
         for (const QString& filepath : filepaths) {
             QFileInfo filepathInfo(filepath);
-            QTextStream(stdout) << "Decompressing " << filepathInfo.fileName() << "\n";
+            QTextStream(stdout) << "Decompressing \"" << filepathInfo.fileName() << "\"...\n";
             std::string in_path = filepath.toStdString();
 
             // Identify file type

--- a/src/citra_qt/citra_qt.h
+++ b/src/citra_qt/citra_qt.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <memory>
 #include <vector>
+#include <qfuture.h>
 #ifdef __unix__
 #include <QDBusObjectPath>
 #endif
@@ -290,7 +291,9 @@ private slots:
     void OnCaptureScreenshot();
     void OnDumpVideo();
     void OnCompressFile();
+    void OnCompressFileCLI();
     void OnDecompressFile();
+    void OnDecompressFileCLI();
 #ifdef _WIN32
     void OnOpenFFmpeg();
 #endif
@@ -397,6 +400,12 @@ private:
     // Video dumping
     bool video_dumping_on_start = false;
     QString video_dumping_path;
+
+    // Compress/Decompress Paths and Future
+    QStringList compress_paths;
+    QStringList decompress_paths;
+    QFuture<void> compression_future;
+
     // Whether game shutdown is delayed due to video dumping
     bool game_shutdown_delayed = false;
     // Whether game was paused due to stopping video dumping
@@ -404,7 +413,6 @@ private:
 
     QString gl_renderer;
     std::vector<QString> physical_devices;
-
     // Debugger panes
     ProfilerWidget* profilerWidget;
 #if MICROPROFILE_ENABLED

--- a/src/citra_qt/citra_qt.h
+++ b/src/citra_qt/citra_qt.h
@@ -404,6 +404,7 @@ private:
     // Compress/Decompress Paths and Future
     QStringList compress_paths;
     QStringList decompress_paths;
+    QString cli_out_path;
     QFuture<void> compression_future;
 
     // Whether game shutdown is delayed due to video dumping

--- a/src/citra_qt/debugger/console.cpp
+++ b/src/citra_qt/debugger/console.cpp
@@ -25,10 +25,13 @@ void ToggleConsole() {
 #ifdef _WIN32
     FILE* temp;
     if (UISettings::values.show_console) {
-        BOOL alloc_console_res = AllocConsole();
         DWORD last_error = 0;
+        BOOL alloc_console_res = AttachConsole(ATTACH_PARENT_PROCESS);
         if (!alloc_console_res) {
-            last_error = GetLastError();
+            alloc_console_res = AllocConsole();
+            if (!alloc_console_res) {
+                last_error = GetLastError();
+            }
         }
         // If the windows debugger already opened a console, calling AllocConsole again
         // will cause ERROR_ACCESS_DENIED. If that's the case assume a console is open.


### PR DESCRIPTION
This PR adds a basic command line interface for compressing and decompressing files. At the moment it just compresses/decompresses files in the same directory. When compressing/decompressing multiple files on the same line, all the files are created in the directory of the first file. 

-c or --compress [path]
-x or --decompress [path]


Closes #1278 
Related https://github.com/RetroDECK/RetroDECK/issues/1309