### PR TITLE
android: Fixed installed app shortcut creation failing on vanilla

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
@@ -729,6 +729,10 @@ object NativeLibrary {
             return uriString
         }
 
+        if (uri.scheme == "file") {
+            return uri.path!!
+        }
+
         val pathSegment = uri.lastPathSegment ?: return ""
         val virtualPath = pathSegment.substringAfter(":")
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/model/Game.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/model/Game.kt
@@ -7,11 +7,16 @@ package org.citra.citra_emu.model
 import android.os.Parcelable
 import android.content.Intent
 import android.net.Uri
+import androidx.core.net.toUri
+import java.io.File
+import java.io.IOException
 import java.util.HashSet
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
 import org.citra.citra_emu.CitraApplication
+import org.citra.citra_emu.NativeLibrary
 import org.citra.citra_emu.activities.EmulationActivity
+import org.citra.citra_emu.utils.BuildUtil
 
 @Parcelize
 @Serializable
@@ -37,12 +42,25 @@ class Game(
     val keyLastPlayedTime get() = "${filename}_LastPlayed"
 
     val launchIntent: Intent
-        get() = Intent(CitraApplication.appContext, EmulationActivity::class.java).apply {
-            action = Intent.ACTION_VIEW
-            data = if (isInstalled) {
-                CitraApplication.documentsTree.getUri(path)
+        get() {
+            var appUri: Uri
+            if (isInstalled) {
+                if (BuildUtil.isGooglePlayBuild) {
+                    appUri = CitraApplication.documentsTree.getUri(path)
+                } else {
+                    val nativePath = NativeLibrary.getUserDirectory() + "/" + path
+                    val nativeFile = File(nativePath)
+                    if (!nativeFile.exists()) {
+                        throw IOException("Attempting to create shortcut for an executable that doesn't exist: $nativePath")
+                    }
+                    appUri = Uri.fromFile(nativeFile)
+                }
             } else {
-                Uri.parse(path)
+                appUri = path.toUri()
+            }
+            return Intent(CitraApplication.appContext, EmulationActivity::class.java).apply {
+                action = Intent.ACTION_VIEW
+                data = appUri
             }
         }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.kt
@@ -219,10 +219,16 @@ object FileUtil {
      */
     @JvmStatic
     fun getFilename(uri: Uri): String {
-        val columns = arrayOf(DocumentsContract.Document.COLUMN_DISPLAY_NAME)
         var filename = ""
         var c: Cursor? = null
         try {
+            if (uri.scheme == "file") {
+                BuildUtil.assertNotGooglePlay()
+                val file = File(uri.path!!);
+                return file.name
+            }
+
+            val columns = arrayOf(DocumentsContract.Document.COLUMN_DISPLAY_NAME)
             c = context.contentResolver.query(
                 uri,
                 columns,


### PR DESCRIPTION
This PR also adds some code which partially handles `file:` URIs, because getting this code to use the existing `content:` URI scheme with only native file I/O involved some string manipulation war crimes that I couldn't bring myself to commit.

Breaks backwards compatibility with existing shortcuts, but that's fine because the vanilla package ID change already broke compatibility with existing shortcuts.