### PR TITLE
android: camera: Fix still image camera input

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/camera/StillImageCameraHelper.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/camera/StillImageCameraHelper.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -57,6 +57,7 @@ object StillImageCameraHelper {
         val request = ImageRequest.Builder(context)
             .data(uri)
             .size(width, height)
+            .allowHardware(false)
             .build()
         return context.imageLoader.executeBlocking(request).drawable?.toBitmap(
             width,


### PR DESCRIPTION
Fixes the still image camera input crashing the emulator. This was caused by a hardware image being rendered to a software canvas.

There is still another issue that causes emulation not to be resumed after selecting the image.

This bug was present in the google play and vanilla builds.