### PR TITLE
Qt compat fix (again)

### DIFF
--- a/src/citra_qt/configuration/configure_cheats.cpp
+++ b/src/citra_qt/configuration/configure_cheats.cpp
@@ -60,11 +60,11 @@ void ConfigureCheats::LoadCheats() {
             i, 2, new QTableWidgetItem(QString::fromStdString(cheats[i]->GetType())));
         enabled->setProperty("row", static_cast<int>(i));
 
-    #if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
         connect(enabled, &QCheckBox::stateChanged, this, &ConfigureCheats::OnCheckChanged);
-    #else
+#else
         connect(enabled, &QCheckBox::checkStateChanged, this, &ConfigureCheats::OnCheckChanged);
-    #endif
+#endif
     }
 }
 

--- a/src/citra_qt/configuration/configure_cheats.cpp
+++ b/src/citra_qt/configuration/configure_cheats.cpp
@@ -60,11 +60,11 @@ void ConfigureCheats::LoadCheats() {
             i, 2, new QTableWidgetItem(QString::fromStdString(cheats[i]->GetType())));
         enabled->setProperty("row", static_cast<int>(i));
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
+    #if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
         connect(enabled, &QCheckBox::stateChanged, this, &ConfigureCheats::OnCheckChanged);
-#else
+    #else
         connect(enabled, &QCheckBox::checkStateChanged, this, &ConfigureCheats::OnCheckChanged);
-#endif
+    #endif
     }
 }
 

--- a/src/citra_qt/configuration/configure_motion_touch.cpp
+++ b/src/citra_qt/configuration/configure_motion_touch.cpp
@@ -231,11 +231,10 @@ void ConfigureMotionTouch::ConnectEvents() {
         }
     });
 #if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
-        connect(ui->touchpad_checkbox, &QCheckBox::StateChanged, this,
-        [this]() { UpdateUiDisplay(); });
+    connect(ui->touchpad_checkbox, &QCheckBox::StateChanged, this, [this]() { UpdateUiDisplay(); });
 #else
-        connect(ui->touchpad_checkbox, &QCheckBox::checkStateChanged, this,
-        [this]() { UpdateUiDisplay(); });
+    connect(ui->touchpad_checkbox, &QCheckBox::checkStateChanged, this,
+            [this]() { UpdateUiDisplay(); });
 #endif
 
     connect(ui->touchpad_config_btn, &QPushButton::clicked, this, [this]() {

--- a/src/citra_qt/configuration/configure_motion_touch.cpp
+++ b/src/citra_qt/configuration/configure_motion_touch.cpp
@@ -230,8 +230,14 @@ void ConfigureMotionTouch::ConnectEvents() {
             poll_timer->start(200);     // Check for new inputs every 200ms
         }
     });
-    connect(ui->touchpad_checkbox, &QCheckBox::checkStateChanged, this,
-            [this]() { UpdateUiDisplay(); });
+    #if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
+        connect(ui->touchpad_checkbox, &QCheckBox::StateChanged, this,
+        [this]() { UpdateUiDisplay(); });
+    #else
+        connect(ui->touchpad_checkbox, &QCheckBox::checkStateChanged, this,
+        [this]() { UpdateUiDisplay(); });
+    #endif
+
     connect(ui->touchpad_config_btn, &QPushButton::clicked, this, [this]() {
         if (QMessageBox::information(this, tr("Information"),
                                      tr("After pressing OK, tap the touchpad on the controller "

--- a/src/citra_qt/configuration/configure_motion_touch.cpp
+++ b/src/citra_qt/configuration/configure_motion_touch.cpp
@@ -230,13 +230,13 @@ void ConfigureMotionTouch::ConnectEvents() {
             poll_timer->start(200);     // Check for new inputs every 200ms
         }
     });
-    #if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
         connect(ui->touchpad_checkbox, &QCheckBox::StateChanged, this,
         [this]() { UpdateUiDisplay(); });
-    #else
+#else
         connect(ui->touchpad_checkbox, &QCheckBox::checkStateChanged, this,
         [this]() { UpdateUiDisplay(); });
-    #endif
+#endif
 
     connect(ui->touchpad_config_btn, &QPushButton::clicked, this, [this]() {
         if (QMessageBox::information(this, tr("Information"),

--- a/src/citra_qt/configuration/configure_motion_touch.cpp
+++ b/src/citra_qt/configuration/configure_motion_touch.cpp
@@ -231,7 +231,7 @@ void ConfigureMotionTouch::ConnectEvents() {
         }
     });
 #if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
-    connect(ui->touchpad_checkbox, &QCheckBox::StateChanged, this, [this]() { UpdateUiDisplay(); });
+    connect(ui->touchpad_checkbox, &QCheckBox::stateChanged, this, [this]() { UpdateUiDisplay(); });
 #else
     connect(ui->touchpad_checkbox, &QCheckBox::checkStateChanged, this,
             [this]() { UpdateUiDisplay(); });


### PR DESCRIPTION
Reattempt at https://github.com/azahar-emu/azahar/pull/1886
This is a little embarassing.

```cmake
/home/runner/azahar/src/citra_qt/configuration/configure_motion_touch.cpp:234:48: error: no member named 'StateChanged' in 'QCheckBox'
  234 |     connect(ui->touchpad_checkbox, &QCheckBox::StateChanged, this, [this]() { UpdateUiDisplay(); });
      |                                     ~~~~~~~~~~~^
1 error generated.
make[2]: *** [src/citra_qt/CMakeFiles/citra_qt.dir/build.make:949: src/citra_qt/CMakeFiles/citra_qt.dir/configuration/configure_motion_touch.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```

Might want to squash and merge this branch to clean up my commit mess here.
<img width="346" height="274" alt="image" src="https://github.com/user-attachments/assets/89d5fdac-1d41-4c1f-b1d6-1048eadf621f" />
