### PR TITLE
android: Attempt fixing lifecycle bugs on SetupFragment

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
@@ -23,7 +23,6 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -32,7 +31,6 @@ import androidx.preference.PreferenceManager
 import androidx.viewpager2.widget.ViewPager2.OnPageChangeCallback
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.transition.MaterialFadeThrough
-import org.citra.citra_emu.BuildConfig
 import org.citra.citra_emu.CitraApplication
 import org.citra.citra_emu.NativeLibrary
 import org.citra.citra_emu.R
@@ -42,13 +40,11 @@ import org.citra.citra_emu.features.settings.model.Settings
 import org.citra.citra_emu.model.ButtonState
 import org.citra.citra_emu.model.PageButton
 import org.citra.citra_emu.model.PageState
-import org.citra.citra_emu.model.SetupCallback
 import org.citra.citra_emu.model.SetupPage
 import org.citra.citra_emu.ui.main.MainActivity
 import org.citra.citra_emu.utils.BuildUtil
 import org.citra.citra_emu.utils.CitraDirectoryHelper
 import org.citra.citra_emu.utils.GameHelper
-import org.citra.citra_emu.utils.Log
 import org.citra.citra_emu.utils.PermissionsHandler
 import org.citra.citra_emu.utils.ViewUtils
 import org.citra.citra_emu.viewmodel.GamesViewModel
@@ -94,12 +90,16 @@ class SetupFragment : Fragment() {
         mainActivity = requireActivity() as MainActivity
 
         homeViewModel.selectedCitraDirectoryLiveData.observe(viewLifecycleOwner) { uri ->
-            if (uri == null) return@observe
+            if (uri == null) {
+                return@observe
+            }
             onOpenCitraDirectory(uri)
             homeViewModel.selectedCitraDirectory = null
         }
         homeViewModel.selectedGamesDirectoryLiveData.observe(viewLifecycleOwner) { uri ->
-            if (uri == null) return@observe
+            if (uri == null) {
+                return@observe
+            }
             onGetGamesDirectory(uri)
             homeViewModel.selectedGamesDirectory = null
         }

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
@@ -40,6 +40,7 @@ import org.citra.citra_emu.features.settings.model.Settings
 import org.citra.citra_emu.model.ButtonState
 import org.citra.citra_emu.model.PageButton
 import org.citra.citra_emu.model.PageState
+import org.citra.citra_emu.model.SetupCallback
 import org.citra.citra_emu.model.SetupPage
 import org.citra.citra_emu.ui.main.MainActivity
 import org.citra.citra_emu.utils.BuildUtil
@@ -148,6 +149,7 @@ class SetupFragment : Fragment() {
                                     R.string.filesystem_permission,
                                     R.string.filesystem_permission_description,
                                     buttonAction = {
+                                        pageButtonCallback = it
                                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                                             manageExternalStoragePermissionLauncher.launch(
                                                 Intent(
@@ -196,6 +198,7 @@ class SetupFragment : Fragment() {
                                     R.string.notifications,
                                     R.string.notifications_description,
                                     buttonAction = {
+                                        pageButtonCallback = it
                                         permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
                                     },
                                     buttonState = {
@@ -220,6 +223,7 @@ class SetupFragment : Fragment() {
                                 R.string.microphone_permission,
                                 R.string.microphone_permission_description,
                                 buttonAction = {
+                                    pageButtonCallback = it
                                     permissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
                                 },
                                 buttonState = {
@@ -241,6 +245,7 @@ class SetupFragment : Fragment() {
                                 R.string.camera_permission,
                                 R.string.camera_permission_description,
                                 buttonAction = {
+                                    pageButtonCallback = it
                                     permissionLauncher.launch(Manifest.permission.CAMERA)
                                 },
                                 buttonState = {
@@ -309,6 +314,7 @@ class SetupFragment : Fragment() {
                                 R.string.select_citra_user_folder,
                                 R.string.select_citra_user_folder_description,
                                 buttonAction = {
+                                    pageButtonCallback = it
                                     PermissionsHandler.compatibleSelectDirectory(mainActivity.setupOpenCitraDirectory)
                                 },
                                 buttonState = {
@@ -331,7 +337,8 @@ class SetupFragment : Fragment() {
                                 R.drawable.ic_controller,
                                 R.string.games,
                                 R.string.games_description,
-                                buttonAction =  {
+                                buttonAction = {
+                                    pageButtonCallback = it
                                     mainActivity.setupGetGamesDirectory.launch(
                                         Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).data
                                     )
@@ -497,6 +504,8 @@ class SetupFragment : Fragment() {
         _binding = null
     }
 
+    private lateinit var pageButtonCallback: SetupCallback
+
     private fun updateNavigationButtons(position: Int) {
         if (position == 0) {
             ViewUtils.hideView(binding.buttonBack)
@@ -517,10 +526,19 @@ class SetupFragment : Fragment() {
 
         val isPageComplete = page.pageSteps() == PageState.PAGE_STEPS_COMPLETE
 
-        binding.viewPager2.adapter?.notifyItemChanged(currentIndex)
-
         if (isPageComplete) {
+            binding.viewPager2.adapter?.notifyItemChanged(currentIndex)
             ViewUtils.showView(binding.buttonNext)
+        } else {
+            page.pageButtons?.forEach {
+                if (it.buttonState() == ButtonState.BUTTON_ACTION_COMPLETE) {
+                    if (this::pageButtonCallback.isInitialized) {
+                        pageButtonCallback.onStepCompleted(it.titleId, pageFullyCompleted = false)
+                    } else {
+                        binding.viewPager2.adapter?.notifyItemChanged(currentIndex)
+                    }
+                }
+            }
         }
     }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
@@ -407,6 +407,8 @@ class SetupFragment : Fragment() {
             }
         )
 
+        binding.viewPager2.currentItem = homeViewModel.setupCurrentPage
+
         requireActivity().window.navigationBarColor =
             ContextCompat.getColor(requireContext(), android.R.color.transparent)
 
@@ -599,10 +601,12 @@ class SetupFragment : Fragment() {
 
     fun pageForward() {
         binding.viewPager2.currentItem = binding.viewPager2.currentItem + 1
+        homeViewModel.setupCurrentPage = binding.viewPager2.currentItem
     }
 
     fun pageBackward() {
         binding.viewPager2.currentItem = binding.viewPager2.currentItem - 1
+        homeViewModel.setupCurrentPage = binding.viewPager2.currentItem
     }
 
     fun setPageWarned(page: Int) {

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
@@ -92,24 +92,6 @@ class SetupFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         mainActivity = requireActivity() as MainActivity
 
-        homeViewModel.setNavigationVisibility(visible = false, animated = false)
-
-        requireActivity().onBackPressedDispatcher.addCallback(
-            viewLifecycleOwner,
-            object : OnBackPressedCallback(true) {
-                override fun handleOnBackPressed() {
-                    if (binding.viewPager2.currentItem > 0) {
-                        pageBackward()
-                    } else {
-                        requireActivity().finish()
-                    }
-                }
-            }
-        )
-
-        requireActivity().window.navigationBarColor =
-            ContextCompat.getColor(requireContext(), android.R.color.transparent)
-
         pages = mutableListOf()
         pages.apply {
             add(
@@ -154,7 +136,6 @@ class SetupFragment : Fragment() {
                                     R.string.filesystem_permission,
                                     R.string.filesystem_permission_description,
                                     buttonAction = {
-                                        pageButtonCallback = it
                                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                                             manageExternalStoragePermissionLauncher.launch(
                                                 Intent(
@@ -203,7 +184,6 @@ class SetupFragment : Fragment() {
                                     R.string.notifications,
                                     R.string.notifications_description,
                                     buttonAction = {
-                                        pageButtonCallback = it
                                         permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
                                     },
                                     buttonState = {
@@ -228,7 +208,6 @@ class SetupFragment : Fragment() {
                                 R.string.microphone_permission,
                                 R.string.microphone_permission_description,
                                 buttonAction = {
-                                    pageButtonCallback = it
                                     permissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
                                 },
                                 buttonState = {
@@ -250,7 +229,6 @@ class SetupFragment : Fragment() {
                                 R.string.camera_permission,
                                 R.string.camera_permission_description,
                                 buttonAction = {
-                                    pageButtonCallback = it
                                     permissionLauncher.launch(Manifest.permission.CAMERA)
                                 },
                                 buttonState = {
@@ -319,7 +297,6 @@ class SetupFragment : Fragment() {
                                 R.string.select_citra_user_folder,
                                 R.string.select_citra_user_folder_description,
                                 buttonAction = {
-                                    pageButtonCallback = it
                                     PermissionsHandler.compatibleSelectDirectory(openCitraDirectory)
                                 },
                                 buttonState = {
@@ -343,7 +320,6 @@ class SetupFragment : Fragment() {
                                 R.string.games,
                                 R.string.games_description,
                                 buttonAction =  {
-                                    pageButtonCallback = it
                                     getGamesDirectory.launch(
                                         Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).data
                                     )
@@ -409,26 +385,30 @@ class SetupFragment : Fragment() {
         }
 
         binding.viewPager2.registerOnPageChangeCallback(object : OnPageChangeCallback() {
-            var previousPosition: Int = 0
 
             override fun onPageSelected(position: Int) {
                 super.onPageSelected(position)
-
-                if (position == 1 && previousPosition == 0) {
-                    ViewUtils.showView(binding.buttonNext)
-                    ViewUtils.showView(binding.buttonBack)
-                } else if (position == 0 && previousPosition == 1) {
-                    ViewUtils.hideView(binding.buttonBack)
-                    ViewUtils.hideView(binding.buttonNext)
-                } else if (position == pages.size - 1 && previousPosition == pages.size - 2) {
-                    ViewUtils.hideView(binding.buttonNext)
-                } else if (position == pages.size - 2 && previousPosition == pages.size - 1) {
-                    ViewUtils.showView(binding.buttonNext)
-                }
-
-                previousPosition = position
+                updateNavigationButtons(position)
             }
         })
+
+        homeViewModel.setNavigationVisibility(visible = false, animated = false)
+
+        requireActivity().onBackPressedDispatcher.addCallback(
+            viewLifecycleOwner,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    if (binding.viewPager2.currentItem > 0) {
+                        pageBackward()
+                    } else {
+                        requireActivity().finish()
+                    }
+                }
+            }
+        )
+
+        requireActivity().window.navigationBarColor =
+            ContextCompat.getColor(requireContext(), android.R.color.transparent)
 
         binding.buttonNext.setOnClickListener {
             val index = binding.viewPager2.currentItem
@@ -479,29 +459,23 @@ class SetupFragment : Fragment() {
         }
         binding.buttonBack.setOnClickListener { pageBackward() }
 
-        if (savedInstanceState != null) {
-            val nextIsVisible = savedInstanceState.getBoolean(KEY_NEXT_VISIBILITY)
-            val backIsVisible = savedInstanceState.getBoolean(KEY_BACK_VISIBILITY)
-            hasBeenWarned = savedInstanceState.getBooleanArray(KEY_HAS_BEEN_WARNED)!!
-
-            if (nextIsVisible) {
-                binding.buttonNext.visibility = View.VISIBLE
-            }
-            if (backIsVisible) {
-                binding.buttonBack.visibility = View.VISIBLE
-            }
-        } else {
+        if (savedInstanceState == null) {
             hasBeenWarned = BooleanArray(pages.size)
+        } else {
+            hasBeenWarned = savedInstanceState.getBooleanArray(KEY_HAS_BEEN_WARNED) ?: BooleanArray(pages.size)
         }
+
+        updateNavigationButtons(binding.viewPager2.currentItem)
 
         setInsets()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        outState.putBoolean(KEY_NEXT_VISIBILITY, binding.buttonNext.isVisible)
-        outState.putBoolean(KEY_BACK_VISIBILITY, binding.buttonBack.isVisible)
-        outState.putBooleanArray(KEY_HAS_BEEN_WARNED, hasBeenWarned)
+
+        if (::hasBeenWarned.isInitialized) {
+            outState.putBooleanArray(KEY_HAS_BEEN_WARNED, hasBeenWarned)
+        }
     }
 
     override fun onDestroyView() {
@@ -509,17 +483,30 @@ class SetupFragment : Fragment() {
         _binding = null
     }
 
-    private lateinit var pageButtonCallback: SetupCallback
-    private val checkForButtonState: () -> Unit = {
-        val page = pages[binding.viewPager2.currentItem]
-        page.pageButtons?.forEach {
-            if (it.buttonState() == ButtonState.BUTTON_ACTION_COMPLETE) {
-                pageButtonCallback.onStepCompleted(it.titleId, pageFullyCompleted = false)
-            }
+    private fun updateNavigationButtons(position: Int) {
+        if (position == 0) {
+            ViewUtils.hideView(binding.buttonBack)
+        } else {
+            ViewUtils.showView(binding.buttonBack)
+        }
 
-            if (page.pageSteps() == PageState.PAGE_STEPS_COMPLETE) {
-                pageButtonCallback.onStepCompleted(0, pageFullyCompleted = true)
-            }
+        if (position == 0 || position == pages.size - 1) {
+            ViewUtils.hideView(binding.buttonNext)
+        } else {
+            ViewUtils.showView(binding.buttonNext)
+        }
+    }
+
+    private val checkForButtonState: () -> Unit = {
+        val currentIndex = binding.viewPager2.currentItem
+        val page = pages[currentIndex]
+
+        val isPageComplete = page.pageSteps() == PageState.PAGE_STEPS_COMPLETE
+
+        binding.viewPager2.adapter?.notifyItemChanged(currentIndex)
+
+        if (isPageComplete) {
+            ViewUtils.showView(binding.buttonNext)
         }
     }
 
@@ -577,7 +564,8 @@ class SetupFragment : Fragment() {
             }
         }
 
-        CitraDirectoryHelper(requireActivity(), true).showCitraDirectoryDialog(result, pageButtonCallback, checkForButtonState)
+        CitraDirectoryHelper(requireActivity(), true).showCitraDirectoryDialog(result,
+             null, checkForButtonState)
     }
 
     private val getGamesDirectory =

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/SetupFragment.kt
@@ -48,6 +48,7 @@ import org.citra.citra_emu.ui.main.MainActivity
 import org.citra.citra_emu.utils.BuildUtil
 import org.citra.citra_emu.utils.CitraDirectoryHelper
 import org.citra.citra_emu.utils.GameHelper
+import org.citra.citra_emu.utils.Log
 import org.citra.citra_emu.utils.PermissionsHandler
 import org.citra.citra_emu.utils.ViewUtils
 import org.citra.citra_emu.viewmodel.GamesViewModel
@@ -91,6 +92,17 @@ class SetupFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         mainActivity = requireActivity() as MainActivity
+
+        homeViewModel.selectedCitraDirectoryLiveData.observe(viewLifecycleOwner) { uri ->
+            if (uri == null) return@observe
+            onOpenCitraDirectory(uri)
+            homeViewModel.selectedCitraDirectory = null
+        }
+        homeViewModel.selectedGamesDirectoryLiveData.observe(viewLifecycleOwner) { uri ->
+            if (uri == null) return@observe
+            onGetGamesDirectory(uri)
+            homeViewModel.selectedGamesDirectory = null
+        }
 
         pages = mutableListOf()
         pages.apply {
@@ -297,7 +309,7 @@ class SetupFragment : Fragment() {
                                 R.string.select_citra_user_folder,
                                 R.string.select_citra_user_folder_description,
                                 buttonAction = {
-                                    PermissionsHandler.compatibleSelectDirectory(openCitraDirectory)
+                                    PermissionsHandler.compatibleSelectDirectory(mainActivity.setupOpenCitraDirectory)
                                 },
                                 buttonState = {
                                     if (PermissionsHandler.hasWriteAccess(requireContext())) {
@@ -320,7 +332,7 @@ class SetupFragment : Fragment() {
                                 R.string.games,
                                 R.string.games_description,
                                 buttonAction =  {
-                                    getGamesDirectory.launch(
+                                    mainActivity.setupGetGamesDirectory.launch(
                                         Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).data
                                     )
                                 },
@@ -548,13 +560,7 @@ class SetupFragment : Fragment() {
             showPermissionDeniedSnackbar()
         }
 
-    private val openCitraDirectory = registerForActivityResult<Uri, Uri>(
-        ActivityResultContracts.OpenDocumentTree()
-    ) { result: Uri? ->
-        if (result == null) {
-            return@registerForActivityResult
-        }
-
+    private fun onOpenCitraDirectory(result: Uri) {
         if (!BuildUtil.isGooglePlayBuild) {
             if (NativeLibrary.getNativePath(result) == "") {
                 SelectUserDirectoryDialogFragment.newInstance(
@@ -562,7 +568,7 @@ class SetupFragment : Fragment() {
                     R.string.invalid_selection,
                     R.string.invalid_user_directory
                 ).show(mainActivity.supportFragmentManager, SelectUserDirectoryDialogFragment.TAG)
-                return@registerForActivityResult
+                return
             }
         }
 
@@ -570,27 +576,22 @@ class SetupFragment : Fragment() {
              null, checkForButtonState)
     }
 
-    private val getGamesDirectory =
-        registerForActivityResult(ActivityResultContracts.OpenDocumentTree()) { result ->
-            if (result == null) {
-                return@registerForActivityResult
-            }
+    private fun onGetGamesDirectory(result: Uri) {
+        requireActivity().contentResolver.takePersistableUriPermission(
+            result,
+            Intent.FLAG_GRANT_READ_URI_PERMISSION
+        )
 
-            requireActivity().contentResolver.takePersistableUriPermission(
-                result,
-                Intent.FLAG_GRANT_READ_URI_PERMISSION
-            )
+        // When a new directory is picked, we currently will reset the existing games
+        // database. This effectively means that only one game directory is supported.
+        preferences.edit()
+            .putString(GameHelper.KEY_GAME_PATH, result.toString())
+            .apply()
 
-            // When a new directory is picked, we currently will reset the existing games
-            // database. This effectively means that only one game directory is supported.
-            preferences.edit()
-                .putString(GameHelper.KEY_GAME_PATH, result.toString())
-                .apply()
+        homeViewModel.setGamesDir(requireActivity(), result.path!!)
 
-            homeViewModel.setGamesDir(requireActivity(), result.path!!)
-
-            checkForButtonState.invoke()
-        }
+        checkForButtonState.invoke()
+    }
 
     private fun finishSetup() {
         preferences.edit()

--- a/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
@@ -76,6 +76,10 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
 
     override var themeId: Int = 0
 
+    companion object {
+        const val KEY_SETUP_CURRENT_PAGE = "SetupCurrentPage"
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         RefreshRateUtil.enforceRefreshRate(this)
 
@@ -136,7 +140,7 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
 
         val navHostFragment =
             supportFragmentManager.findFragmentById(R.id.fragment_container) as NavHostFragment
-        setUpNavigation(navHostFragment.navController)
+        setUpNavigation(savedInstanceState, navHostFragment.navController)
         (binding.navigationView as NavigationBarView).setOnItemReselectedListener {
             when (it.itemId) {
                 R.id.gamesFragment -> {
@@ -186,6 +190,14 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
         }
 
         setInsets()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        // Save the user's current game state.
+        outState.putInt(KEY_SETUP_CURRENT_PAGE, homeViewModel.setupCurrentPage)
+
+        // Always call the superclass so it can save the view hierarchy state.
+        super.onSaveInstanceState(outState)
     }
 
     override fun onResume() {
@@ -263,11 +275,12 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
         (binding.navigationView as NavigationBarView).setupWithNavController(navController)
     }
 
-    private fun setUpNavigation(navController: NavController) {
+    private fun setUpNavigation(savedInstanceState: Bundle?, navController: NavController) {
         val firstTimeSetup = PreferenceManager.getDefaultSharedPreferences(applicationContext)
             .getBoolean(Settings.PREF_FIRST_APP_LAUNCH, true)
 
         if (firstTimeSetup && !homeViewModel.navigatedToSetup) {
+            homeViewModel.setupCurrentPage = savedInstanceState?.getInt(KEY_SETUP_CURRENT_PAGE) ?: 0
             navController.navigate(R.id.firstTimeSetupFragment)
             homeViewModel.navigatedToSetup = true
         } else {

--- a/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
@@ -21,7 +21,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
-import androidx.core.net.toUri
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
@@ -62,7 +61,6 @@ import org.citra.citra_emu.utils.CitraDirectoryUtils
 import org.citra.citra_emu.utils.DirectoryInitialization
 import org.citra.citra_emu.utils.FileBrowserHelper
 import org.citra.citra_emu.utils.InsetsHelper
-import org.citra.citra_emu.utils.Log
 import org.citra.citra_emu.utils.RefreshRateUtil
 import org.citra.citra_emu.utils.PermissionsHandler
 import org.citra.citra_emu.utils.ThemeUtil
@@ -80,7 +78,6 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
 
     companion object {
         const val KEY_SETUP_CURRENT_PAGE = "SetupCurrentPage"
-        const val KEY_SELECTED_CITRA_DIRECTORY = "SelectedCitraDirectory"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -198,7 +195,6 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
     override fun onSaveInstanceState(outState: Bundle) {
         // Save the user's current game state.
         outState.putInt(KEY_SETUP_CURRENT_PAGE, homeViewModel.setupCurrentPage)
-        outState.putString(KEY_SELECTED_CITRA_DIRECTORY, homeViewModel.selectedCitraDirectory.toString())
 
         // Always call the superclass so it can save the view hierarchy state.
         super.onSaveInstanceState(outState)
@@ -285,12 +281,6 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
 
         if (firstTimeSetup && !homeViewModel.navigatedToSetup) {
             homeViewModel.setupCurrentPage = savedInstanceState?.getInt(KEY_SETUP_CURRENT_PAGE) ?: 0
-            homeViewModel.selectedCitraDirectory =
-                savedInstanceState?.getString(KEY_SELECTED_CITRA_DIRECTORY)?.toUri()
-            if (homeViewModel.selectedCitraDirectory.toString() == "null") {
-                // Why is this necessary lol
-                homeViewModel.selectedCitraDirectory = null
-            }
             navController.navigate(R.id.firstTimeSetupFragment)
             homeViewModel.navigatedToSetup = true
         } else {

--- a/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
@@ -21,6 +21,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
@@ -61,6 +62,7 @@ import org.citra.citra_emu.utils.CitraDirectoryUtils
 import org.citra.citra_emu.utils.DirectoryInitialization
 import org.citra.citra_emu.utils.FileBrowserHelper
 import org.citra.citra_emu.utils.InsetsHelper
+import org.citra.citra_emu.utils.Log
 import org.citra.citra_emu.utils.RefreshRateUtil
 import org.citra.citra_emu.utils.PermissionsHandler
 import org.citra.citra_emu.utils.ThemeUtil
@@ -78,6 +80,7 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
 
     companion object {
         const val KEY_SETUP_CURRENT_PAGE = "SetupCurrentPage"
+        const val KEY_SELECTED_CITRA_DIRECTORY = "SelectedCitraDirectory"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -195,6 +198,7 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
     override fun onSaveInstanceState(outState: Bundle) {
         // Save the user's current game state.
         outState.putInt(KEY_SETUP_CURRENT_PAGE, homeViewModel.setupCurrentPage)
+        outState.putString(KEY_SELECTED_CITRA_DIRECTORY, homeViewModel.selectedCitraDirectory.toString())
 
         // Always call the superclass so it can save the view hierarchy state.
         super.onSaveInstanceState(outState)
@@ -281,6 +285,12 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
 
         if (firstTimeSetup && !homeViewModel.navigatedToSetup) {
             homeViewModel.setupCurrentPage = savedInstanceState?.getInt(KEY_SETUP_CURRENT_PAGE) ?: 0
+            homeViewModel.selectedCitraDirectory =
+                savedInstanceState?.getString(KEY_SELECTED_CITRA_DIRECTORY)?.toUri()
+            if (homeViewModel.selectedCitraDirectory.toString() == "null") {
+                // Why is this necessary lol
+                homeViewModel.selectedCitraDirectory = null
+            }
             navController.navigate(R.id.firstTimeSetupFragment)
             homeViewModel.navigatedToSetup = true
         } else {
@@ -436,5 +446,17 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
                 .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                 .build()
         )
+    }
+
+    val setupOpenCitraDirectory = registerForActivityResult(
+        ActivityResultContracts.OpenDocumentTree(),
+    ) { result: Uri? ->
+        homeViewModel.selectedCitraDirectory = result
+    }
+
+    val setupGetGamesDirectory = registerForActivityResult(
+        ActivityResultContracts.OpenDocumentTree()
+    ) { result: Uri? ->
+        homeViewModel.selectedGamesDirectory = result
     }
 }

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/ViewUtils.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/ViewUtils.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/ViewUtils.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/ViewUtils.kt
@@ -9,6 +9,10 @@ import android.view.ViewGroup
 
 object ViewUtils {
     fun showView(view: View, length: Long = 300) {
+        if (view.visibility == View.VISIBLE) {
+            return
+        }
+
         view.apply {
             alpha = 0f
             visibility = View.VISIBLE

--- a/src/android/app/src/main/java/org/citra/citra_emu/viewmodel/HomeViewModel.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/viewmodel/HomeViewModel.kt
@@ -7,6 +7,8 @@ package org.citra.citra_emu.viewmodel
 import android.content.res.Resources
 import android.net.Uri
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.preference.PreferenceManager
@@ -63,6 +65,18 @@ class HomeViewModel : ViewModel() {
     var navigatedToSetup = false
 
     var setupCurrentPage = 0
+
+    private val _selectedCitraDirectory = MutableLiveData<Uri?>()
+    val selectedCitraDirectoryLiveData: LiveData<Uri?> = _selectedCitraDirectory
+    var selectedCitraDirectory: Uri?
+        get() = _selectedCitraDirectory.value
+        set(value) { _selectedCitraDirectory.value = value }
+
+    private val _selectedGamesDirectory = MutableLiveData<Uri?>()
+    val selectedGamesDirectoryLiveData: LiveData<Uri?> = _selectedGamesDirectory
+    var selectedGamesDirectory: Uri?
+        get() = _selectedGamesDirectory.value
+        set(value) { _selectedGamesDirectory.value = value }
 
     fun setNavigationVisibility(visible: Boolean, animated: Boolean) {
         if (_navigationVisible.value.first == visible) {

--- a/src/android/app/src/main/java/org/citra/citra_emu/viewmodel/HomeViewModel.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/viewmodel/HomeViewModel.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -61,6 +61,8 @@ class HomeViewModel : ViewModel() {
     var copyInProgress = false
 
     var navigatedToSetup = false
+
+    var setupCurrentPage = 0
 
     fun setNavigationVisibility(visible: Boolean, animated: Boolean) {
         if (_navigationVisible.value.first == visible) {


### PR DESCRIPTION
The entire logic of `SetupFragment` assumes the activity will persist during the user folder/application directory picking. This doesn't have to be the case, as Android may kill the activity in the background. This causes crashes on some devices such as the Google Pixel 9 Pro and 10 Pro, making the emulator unusable on them.

This PR attempts to fix it, but due to the complexity of the Android UI stuff (which I'm not familiar with), I'm asking for help to complete it. The crash itself has been fixed (was caused by `pageButtonCallback` losing its contents) but there is a new issue of the progress reseting to the "welcome" screen after picking the user directory.

**In order to test this, you need to enable the "Don't keep activities" option in Android developer settings!** Also try to rotate the screen while selecting the permissions and the user folder, which also forces activity destruction.