### PR TITLE
android: Handle asynchronous screen disconnects

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/display/SecondaryDisplay.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/display/SecondaryDisplay.kt
@@ -6,18 +6,15 @@ package org.citra.citra_emu.display
 
 import android.app.Presentation
 import android.content.Context
-import android.graphics.SurfaceTexture
 import android.hardware.display.DisplayManager
 import android.hardware.display.VirtualDisplay
 import android.os.Bundle
 import android.view.Display
 import android.view.MotionEvent
-import android.view.Surface
 import android.view.SurfaceHolder
 import android.view.SurfaceView
 import android.view.WindowManager
 import org.citra.citra_emu.features.settings.model.IntSetting
-import org.citra.citra_emu.display.SecondaryDisplayLayout
 import org.citra.citra_emu.NativeLibrary
 
 class SecondaryDisplay(val context: Context) : DisplayManager.DisplayListener {
@@ -66,6 +63,11 @@ class SecondaryDisplay(val context: Context) : DisplayManager.DisplayListener {
     }
 
     fun updateDisplay() {
+        // return early if the parent context is dead or dying
+        if (context is android.app.Activity && (context.isFinishing || context.isDestroyed)) {
+            return
+        }
+
         // decide if we are going to the external display or the internal one
         var display = getExternalDisplay(context)
         if (display == null ||
@@ -78,12 +80,25 @@ class SecondaryDisplay(val context: Context) : DisplayManager.DisplayListener {
 
         // otherwise, make a new presentation
         releasePresentation()
-        pres = SecondaryDisplayPresentation(context, display!!, this)
-        pres?.show()
+
+        try {
+            pres = SecondaryDisplayPresentation(context, display!!, this)
+            pres?.show()
+        }
+        // catch BadTokenException and InvalidDisplayException,
+        // the display became invalid asynchronously, so we can assign to null
+        // until onDisplayAdded/Removed/Changed is called and logic retriggered
+        catch (_: WindowManager.BadTokenException) {
+            pres = null
+        } catch (_: WindowManager.InvalidDisplayException) {
+            pres = null
+        }
     }
 
     fun releasePresentation() {
-        pres?.dismiss()
+        try {
+            pres?.dismiss()
+        } catch (_: Exception) { }
         pres = null
     }
 


### PR DESCRIPTION
When a secondary screen becomes invalid, it may do so in the middle of the `updateDisplay()` method. This causes `pres?.show()` to throw a `BadTokenException`. We need to catch that exception and do nothing, as `updateDisplay()` will get called shortly after again by a screen disconnect event.

Fixes the app crashing on screen disconnect flukes (which according to Android vitals happens relatively frequently).