### PR TITLE
force android emu_window to update height and width on surface change…

### DIFF
--- a/src/android/app/src/main/jni/emu_window/emu_window.cpp
+++ b/src/android/app/src/main/jni/emu_window/emu_window.cpp
@@ -25,6 +25,8 @@ bool EmuWindow_Android::OnSurfaceChanged(ANativeWindow* surface) {
     render_window = surface;
     window_info.type = Frontend::WindowSystemType::Android;
     window_info.render_surface = surface;
+    window_width = ANativeWindow_getWidth(surface);
+    window_height = ANativeWindow_getHeight(surface);
 
     StopPresenting();
     OnFramebufferSizeChanged();


### PR DESCRIPTION
The android emulation window was not updating the window width and window height on surface changes. This resulted in a bug where if a secondary display was not connected on android, and then a secondary display was added with anything other than a 16:9 aspect ratio, the aspect ratio would be wrong.

This fixes that.

(there is a chance I also fixed this in one of the extent secondary screen PRs, I'm not sure, but it's two lines of code and solves a known problem so it's here separately)
