### PR TITLE
Critical bugfix: nullptr check on update_surface

### DIFF
--- a/src/android/app/src/main/jni/emu_window/emu_window.cpp
+++ b/src/android/app/src/main/jni/emu_window/emu_window.cpp
@@ -25,9 +25,10 @@ bool EmuWindow_Android::OnSurfaceChanged(ANativeWindow* surface) {
     render_window = surface;
     window_info.type = Frontend::WindowSystemType::Android;
     window_info.render_surface = surface;
-    window_width = ANativeWindow_getWidth(surface);
-    window_height = ANativeWindow_getHeight(surface);
-
+    if (surface != nullptr) {
+        window_width = ANativeWindow_getWidth(surface);
+        window_height = ANativeWindow_getHeight(surface);
+    }
     StopPresenting();
     OnFramebufferSizeChanged();
     return true;


### PR DESCRIPTION
Fix the bug introduced by #1907 that led to crashes if a nullptr is passed to Update_Surface on android which happens during some orientation changes.