### PR TITLE
android: Fixed native path intent URIs not launching apps correctly

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
@@ -143,14 +143,17 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
         }
         if (intentUri != null) {
             if (!BuildUtil.isGooglePlayBuild) {
+                val intentUriString = intentUri.toString()
                 // We need to build a special path as the incoming URI may be SAF exclusive
                 Log.warning("[EmulationFragment] Cannot determine native path of URI \"" +
-                        intentUri.toString() + "\", using file descriptor instead.")
-                gameFd = requireContext().contentResolver.openFileDescriptor(intentUri, "r")?.detachFd()
-                intentUri = if (gameFd != null) {
-                    Uri.parse("fd://" + gameFd.toString())
-                } else {
-                    null
+                            intentUriString + "\", using file descriptor instead.")
+                if (!intentUriString.startsWith("!")) {
+                    gameFd = requireContext().contentResolver.openFileDescriptor(intentUri, "r")?.detachFd()
+                    intentUri = if (gameFd != null) {
+                        Uri.parse("fd://" + gameFd.toString())
+                    } else {
+                        null
+                    }
                 }
             }
             intentGame =

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.kt
@@ -547,7 +547,7 @@ object FileUtil {
     }
 
     @JvmStatic
-    fun isNativePath(path: String): Boolean =
+    fun isNativePath(path: String): Boolean = // FIXME: This function name is bullshit -OS
         try {
             path[0] == '/'
         } catch (e: StringIndexOutOfBoundsException) {

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/GameHelper.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/GameHelper.kt
@@ -72,7 +72,7 @@ object GameHelper {
         val filePath = uri.toString()
         var nativePath: String? = null
         var gameInfo: GameInfo?
-        if (BuildUtil.isGooglePlayBuild || FileUtil.isNativePath(filePath)) {
+        if (BuildUtil.isGooglePlayBuild || FileUtil.isNativePath(filePath) || filePath.startsWith("!")) {
             gameInfo = GameInfo(filePath)
         } else {
             nativePath = if (uri.scheme == "fd") {
@@ -94,7 +94,8 @@ object GameHelper {
             valid,
             (gameInfo?.getTitle() ?: FileUtil.getFilename(uri)).replace("[\\t\\n\\r]+".toRegex(), " "),
             filePath.replace("\n", " "),
-            if (BuildUtil.isGooglePlayBuild || FileUtil.isNativePath(filePath)) {
+            // TODO: This next line can be deduplicated but I don't want to right now -OS
+            if (BuildUtil.isGooglePlayBuild || FileUtil.isNativePath(filePath) || filePath.startsWith("!")) {
                 filePath
             } else {
                 nativePath!!


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.

The intent URI handling code for the vanilla build assumed that all passed URIs were in the form of a content URI. Because of this, the native URIs used by our game shortcuts weren't being handled properly. This PR addresses that.