### PR TITLE
Fixes to Android file loading when system files are not set up.

### DIFF
--- a/src/android/app/src/main/jni/game_info.cpp
+++ b/src/android/app/src/main/jni/game_info.cpp
@@ -75,7 +75,7 @@ GameInfoData* GetNewGameInfoData(const std::string& path) {
         result = update_loader->ReadIcon(update_smdh);
         if (result != Loader::ResultStatus::Success) {
             is_encrypted = result == Loader::ResultStatus::ErrorEncrypted;
-            return {};
+            return original_smdh;
         }
         return update_smdh;
     }();

--- a/src/core/loader/3dsx.cpp
+++ b/src/core/loader/3dsx.cpp
@@ -261,15 +261,15 @@ AppLoader_THREEDSX::AppLoader_THREEDSX(Core::System& system_, FileUtil::IOFile&&
 }
 
 FileType AppLoader_THREEDSX::IdentifyType(FileUtil::IOFile* file) {
-    u32 magic;
-    file->Seek(0, SEEK_SET);
-    if (1 != file->ReadArray<u32>(&magic, 1))
-        return FileType::Error;
+    u32 magic{};
 
-    if (MakeMagic('3', 'D', 'S', 'X') == magic ||
-        (MakeMagic('Z', '3', 'D', 'S') == magic &&
-         FileUtil::Z3DSReadIOFile::GetUnderlyingFileMagic(file) == MakeMagic('3', 'D', 'S', 'X')))
-        return FileType::THREEDSX;
+    if (file->Seek(0, SEEK_SET) && 1 == file->ReadArray<u32>(&magic, 1)) {
+        if (MakeMagic('3', 'D', 'S', 'X') == magic ||
+            (MakeMagic('Z', '3', 'D', 'S') == magic &&
+             FileUtil::Z3DSReadIOFile::GetUnderlyingFileMagic(file) ==
+                 MakeMagic('3', 'D', 'S', 'X')))
+            return FileType::THREEDSX;
+    }
 
     return FileType::Error;
 }

--- a/src/core/loader/elf.cpp
+++ b/src/core/loader/elf.cpp
@@ -357,13 +357,12 @@ SectionID ElfReader::GetSectionByName(const char* name, int firstSection) const 
 namespace Loader {
 
 FileType AppLoader_ELF::IdentifyType(FileUtil::IOFile* file) {
-    u32 magic;
-    file->Seek(0, SEEK_SET);
-    if (1 != file->ReadArray<u32>(&magic, 1))
-        return FileType::Error;
+    u32 magic{};
 
-    if (MakeMagic('\x7f', 'E', 'L', 'F') == magic)
-        return FileType::ELF;
+    if (file->Seek(0, SEEK_SET) && 1 == file->ReadArray<u32>(&magic, 1)) {
+        if (MakeMagic('\x7f', 'E', 'L', 'F') == magic)
+            return FileType::ELF;
+    }
 
     return FileType::Error;
 }

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -37,40 +37,40 @@ static constexpr u64 UPDATE_TID_HIGH = 0x0004000e00000000;
 static constexpr u64 DLP_CHILD_TID_HIGH = 0x0004000100000000;
 
 FileType AppLoader_NCCH::IdentifyType(FileUtil::IOFile* file) {
-    u32 magic;
-    file->Seek(0x100, SEEK_SET);
-    if (1 != file->ReadArray<u32>(&magic, 1))
-        return FileType::Error;
-
-    if (MakeMagic('N', 'C', 'S', 'D') == magic)
-        return FileType::CCI;
-
-    if (MakeMagic('N', 'C', 'C', 'H') == magic)
-        return FileType::CXI;
+    u32 magic{};
 
     std::unique_ptr<FileUtil::IOFile> file_crypto = HW::UniqueData::OpenUniqueCryptoFile(
         file->Filename(), "rb", HW::UniqueData::UniqueCryptoFileID::NCCH);
 
-    file_crypto->Seek(0x100, SEEK_SET);
-    if (1 != file_crypto->ReadArray<u32>(&magic, 1))
-        return FileType::Error;
-
-    if (MakeMagic('N', 'C', 'S', 'D') == magic)
-        return FileType::CCI;
-
-    if (MakeMagic('N', 'C', 'C', 'H') == magic)
-        return FileType::CXI;
-
+    // Check compressed NCCH file
     std::optional<u32> magic_zstd = FileUtil::Z3DSReadIOFile::GetUnderlyingFileMagic(file);
     if (!magic_zstd.has_value()) {
+        // Handle compressed and crypto NCCH file
         magic_zstd = FileUtil::Z3DSReadIOFile::GetUnderlyingFileMagic(file_crypto.get());
     }
-
     if (magic_zstd.has_value()) {
         if (MakeMagic('N', 'C', 'S', 'D') == magic_zstd)
             return FileType::CCI;
 
         if (MakeMagic('N', 'C', 'C', 'H') == magic_zstd)
+            return FileType::CXI;
+    }
+
+    // Check normal NCCH file
+    if (file->Seek(0x100, SEEK_SET) && 1 == file->ReadArray<u32>(&magic, 1)) {
+        if (MakeMagic('N', 'C', 'S', 'D') == magic)
+            return FileType::CCI;
+
+        if (MakeMagic('N', 'C', 'C', 'H') == magic)
+            return FileType::CXI;
+    }
+
+    // Check crypto NCCH file
+    if (file_crypto->Seek(0x100, SEEK_SET) && 1 == file_crypto->ReadArray<u32>(&magic, 1)) {
+        if (MakeMagic('N', 'C', 'S', 'D') == magic)
+            return FileType::CCI;
+
+        if (MakeMagic('N', 'C', 'C', 'H') == magic)
             return FileType::CXI;
     }
 


### PR DESCRIPTION
Fixes two issues related to file loading, which have been present for a long time.
- Fix identifying `.zcci` and `.zcxi` files when system files were not set up. This was caused by an early return incorrectly being taken in the identify code.
    - Fixes some actions with compressed files such as inserting cartridges and booting the files when the extensions didn't match.
- On Android, fix the icon for an application not showing if its update title failed to be loaded.