### PR TITLE
libretro: Replace `render_touchscreen` setting with `enable_touch_pointer_timeout`

### DIFF
--- a/CMakeModules/GenerateSettingKeys.cmake
+++ b/CMakeModules/GenerateSettingKeys.cmake
@@ -253,7 +253,7 @@ if (ENABLE_LIBRETRO)
         "analog_deadzone"
         "enable_mouse_touchscreen"
         "enable_touch_touchscreen"
-        "render_touchscreen"
+        "enable_touch_pointer_timeout"
         "enable_motion"
         "motion_sensitivity"
     )

--- a/src/citra_libretro/core_settings.cpp
+++ b/src/citra_libretro/core_settings.cpp
@@ -87,7 +87,8 @@ static constexpr const char* enable_mouse_touchscreen =
     citra_setting(BaseKeys::enable_mouse_touchscreen);
 static constexpr const char* enable_touch_touchscreen =
     citra_setting(BaseKeys::enable_touch_touchscreen);
-static constexpr const char* render_touchscreen = citra_setting(BaseKeys::render_touchscreen);
+static constexpr const char* enable_touch_pointer_timeout =
+    citra_setting(BaseKeys::enable_touch_pointer_timeout);
 static constexpr const char* enable_motion = citra_setting(BaseKeys::enable_motion);
 static constexpr const char* motion_sensitivity = citra_setting(BaseKeys::motion_sensitivity);
 } // namespace input
@@ -609,10 +610,10 @@ static constexpr retro_core_option_v2_definition option_definitions[] = {
         config::enabled
     },
     {
-        config::input::render_touchscreen,
-        "Show Touch Interactions",
-        "Show Touch",
-        "Visually indicate touchscreen interactions on screen.",
+        config::input::enable_touch_pointer_timeout,
+        "Touch Pointer Timeout",
+        "Touch Pointer Timeout",
+        "Whether or not the touchscreen pointer should disappear during inactivity.",
         nullptr,
         config::category::input,
         {
@@ -620,7 +621,7 @@ static constexpr retro_core_option_v2_definition option_definitions[] = {
             { config::disabled, "Disabled" },
             { nullptr, nullptr }
         },
-        config::disabled
+        config::enabled
     },
     {
         config::input::enable_motion,
@@ -1025,9 +1026,10 @@ static void ParseInputOptions(void) {
         LibRetro::FetchVariable(config::input::enable_touch_touchscreen, config::enabled) ==
         config::enabled;
 
-    LibRetro::settings.render_touchscreen =
-        LibRetro::FetchVariable(config::input::render_touchscreen, config::disabled) ==
+    LibRetro::settings.enable_touch_pointer_timeout =
+        LibRetro::FetchVariable(config::input::enable_touch_pointer_timeout, config::enabled) ==
         config::enabled;
+
     LibRetro::settings.enable_motion =
         LibRetro::FetchVariable(config::input::enable_motion, config::enabled) == config::enabled;
     auto motion_sens = LibRetro::FetchVariable(config::input::motion_sensitivity, "1.0");

--- a/src/citra_libretro/core_settings.h
+++ b/src/citra_libretro/core_settings.h
@@ -25,7 +25,7 @@ struct CoreSettings {
 
     bool enable_touch_touchscreen;
 
-    bool render_touchscreen;
+    bool enable_touch_pointer_timeout;
 
     std::string swap_screen_mode;
 

--- a/src/citra_libretro/emu_window/libretro_window.cpp
+++ b/src/citra_libretro/emu_window/libretro_window.cpp
@@ -341,7 +341,7 @@ void EmuWindow_LibRetro::DestroyContext() {
 }
 
 Frontend::EmuWindow::CursorInfo EmuWindow_LibRetro::GetCursorInfo() const {
-    if (enableEmulatedPointer && tracker && LibRetro::settings.render_touchscreen) {
+    if (enableEmulatedPointer && tracker) {
         return tracker->GetCursorInfo();
     }
     return {};

--- a/src/citra_libretro/input/mouse_tracker.cpp
+++ b/src/citra_libretro/input/mouse_tracker.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <memory>
 
@@ -112,6 +113,8 @@ MouseTracker::MouseTracker() {
         cursor_renderer = std::make_unique<SoftwareCursorRenderer>();
         break;
     }
+
+    last_moved = std::chrono::steady_clock::time_point::min();
 }
 
 MouseTracker::~MouseTracker() = default;
@@ -129,6 +132,7 @@ void MouseTracker::Restrict(int minX, int minY, int maxX, int maxY) {
 void MouseTracker::Update(int bufferWidth, int bufferHeight,
                           const Layout::FramebufferLayout& layout) {
     bool state = false;
+    bool wasMoved = false;
 
     if (LibRetro::settings.enable_mouse_touchscreen) {
         // Check mouse input
@@ -203,14 +207,18 @@ void MouseTracker::Update(int bufferWidth, int bufferHeight,
              INT16_MAX);
 
         // Deadzone the controller inputs
-        float smoothedX = std::abs(controllerX);
-        float smoothedY = std::abs(controllerY);
+        float magnitudeX = std::abs(controllerX);
+        float magnitudeY = std::abs(controllerY);
 
-        if (smoothedX < LibRetro::settings.analog_deadzone) {
+        if (magnitudeX < LibRetro::settings.analog_deadzone) {
             controllerX = 0;
         }
-        if (smoothedY < LibRetro::settings.analog_deadzone) {
+        if (magnitudeY < LibRetro::settings.analog_deadzone) {
             controllerY = 0;
+        }
+
+        if (controllerX != 0 || controllerY != 0) {
+            wasMoved = true;
         }
 
         OnMouseMove(static_cast<int>(controllerX * widthSpeed),
@@ -225,11 +233,15 @@ void MouseTracker::Update(int bufferWidth, int bufferHeight,
 
     isPressed = state;
 
+    if (wasMoved) {
+        last_moved = std::chrono::steady_clock::now();
+    }
+
     this->framebuffer_layout = layout;
 }
 
 void MouseTracker::Render(int bufferWidth, int bufferHeight, void* framebuffer_data) {
-    if (!LibRetro::settings.render_touchscreen) {
+    if (GetCursorInfo().visible == false) {
         return;
     }
 
@@ -243,6 +255,18 @@ void MouseTracker::Render(int bufferWidth, int bufferHeight, void* framebuffer_d
         cursor_renderer->Render(bufferWidth, bufferHeight, abs_x, abs_y, ratio, framebuffer_layout,
                                 framebuffer_data);
     }
+}
+
+Frontend::EmuWindow::CursorInfo MouseTracker::GetCursorInfo() {
+    bool visible = true;
+    auto current = std::chrono::steady_clock::now();
+    uint64_t since_last_moved =
+        std::chrono::duration_cast<std::chrono::seconds>(current - last_moved).count();
+    constexpr auto timeout_secs = 4; // TODO: Make this configurable maybe? -OS
+    if (LibRetro::settings.enable_touch_pointer_timeout && since_last_moved >= timeout_secs) {
+        visible = false;
+    }
+    return {visible, projectedX, projectedY};
 }
 
 #ifdef ENABLE_OPENGL

--- a/src/citra_libretro/input/mouse_tracker.h
+++ b/src/citra_libretro/input/mouse_tracker.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <chrono>
 #include "common/math_util.h"
 #include "core/frontend/emu_window.h"
 #include "core/frontend/framebuffer_layout.h"
@@ -55,9 +56,7 @@ public:
     }
 
     /// Get cursor rendering state for external renderers (e.g. Vulkan).
-    Frontend::EmuWindow::CursorInfo GetCursorInfo() const {
-        return {true, projectedX, projectedY};
-    }
+    Frontend::EmuWindow::CursorInfo GetCursorInfo();
 
 private:
     int x;
@@ -69,6 +68,7 @@ private:
     float projectedX;
     float projectedY;
 
+    std::chrono::steady_clock::time_point last_moved;
     bool isPressed;
 
     Layout::FramebufferLayout framebuffer_layout;


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.

This PR replaces the previous 'Show Touch Interactions' settings with a new 'Touch Pointer Timeout'

Touch pointer rendering is now always enabled, but unless a controller is being used to move the touchscreen pointer, it will be hidden due to the timeout which is also enabled by default.

The timeout is currently hardcoded at 4 seconds since the last time the pointer was moved.