### PR TITLE
android: Fix visibility check of hidden system titles

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/viewmodel/GamesViewModel.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/viewmodel/GamesViewModel.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -78,8 +78,9 @@ class GamesViewModel : ViewModel() {
         val filteredList = sortedList.filter {
             if (it.isSystemTitle) {
                 it.isVisibleSystemTitle
+            } else {
+                true
             }
-            true
         }
 
         _games.value = filteredList


### PR DESCRIPTION
Fixes hidden (unbootable) system titles being shown on the application list on Android due to a typo in the kotlin code. One of the hidden titles had a "Home Menu" icon (it's actually the manual viewer) which made users think booting the Home Menu was broken.