### PR TITLE
ci: Merge standalone macOS CI/CD jobs into single runner

### DIFF
--- a/.ci/macos-universal.sh
+++ b/.ci/macos-universal.sh
@@ -2,13 +2,14 @@
 
 ARTIFACTS_LIST=($ARTIFACTS)
 
-BUNDLE_DIR=build/bundle
-mkdir build
+BUILD_DIR=build
+UNIVERSAL_DIR=$BUILD_DIR/universal
+BUNDLE_DIR=$UNIVERSAL_DIR/bundle
+OTHER_BUNDLE_DIR=$BUILD_DIR/x86_64/bundle
 
-# Set up the base artifact to combine into.
-BASE_ARTIFACT=${ARTIFACTS_LIST[0]}
-BASE_ARTIFACT_ARCH="${BASE_ARTIFACT##*-}"
-mv $BASE_ARTIFACT $BUNDLE_DIR
+# Set up the base bundle to combine into.
+mkdir $UNIVERSAL_DIR
+cp -a $BUILD_DIR/arm64/bundle $UNIVERSAL_DIR
 
 # Executable binary paths that need to be combined.
 BIN_PATHS=(Azahar.app/Contents/MacOS/azahar)
@@ -19,21 +20,18 @@ DYLIB_PATHS=($(cd $BUNDLE_DIR && find . -name '*.dylib'))
 unset IFS
 
 # Combine all of the executable binaries and dylibs.
-for OTHER_ARTIFACT in "${ARTIFACTS_LIST[@]:1}"; do
-    OTHER_ARTIFACT_ARCH="${OTHER_ARTIFACT##*-}"
+for BIN_PATH in "${BIN_PATHS[@]}"; do
+    lipo -create -output $BUNDLE_DIR/$BIN_PATH $BUNDLE_DIR/$BIN_PATH $OTHER_BUNDLE_DIR/$BIN_PATH
+done
 
-    for BIN_PATH in "${BIN_PATHS[@]}"; do
-        lipo -create -output $BUNDLE_DIR/$BIN_PATH $BUNDLE_DIR/$BIN_PATH $OTHER_ARTIFACT/$BIN_PATH
-    done
+for DYLIB_PATH in "${DYLIB_PATHS[@]}"; do
+    # Only merge if the libraries do not have conflicting arches, otherwise it will fail.
+    DYLIB_INFO=`file $BUNDLE_DIR/$DYLIB_PATH`
 
-    for DYLIB_PATH in "${DYLIB_PATHS[@]}"; do
-        # Only merge if the libraries do not have conflicting arches, otherwise it will fail.
-        DYLIB_INFO=`file $BUNDLE_DIR/$DYLIB_PATH`
-        OTHER_DYLIB_INFO=`file $OTHER_ARTIFACT/$DYLIB_PATH`
-        if ! [[ "$DYLIB_INFO" =~ "$OTHER_ARTIFACT_ARCH" ]] && ! [[ "$OTHER_DYLIB_INFO" =~ "$BASE_ARTIFACT_ARCH" ]]; then
-            lipo -create -output $BUNDLE_DIR/$DYLIB_PATH $BUNDLE_DIR/$DYLIB_PATH $OTHER_ARTIFACT/$DYLIB_PATH
-        fi
-    done
+    OTHER_DYLIB_INFO=`file $OTHER_BUNDLE_DIR/$DYLIB_PATH`
+    if ! [[ "$DYLIB_INFO" =~ "x86_64" ]] && ! [[ "$OTHER_DYLIB_INFO" =~ "arm64" ]]; then
+        lipo -create -output $BUNDLE_DIR/$DYLIB_PATH $BUNDLE_DIR/$DYLIB_PATH $OTHER_BUNDLE_DIR/$DYLIB_PATH
+    fi
 done
 
 # Remove leftover libs so that they aren't distributed

--- a/.ci/macos.sh
+++ b/.ci/macos.sh
@@ -4,12 +4,10 @@ if [ "$GITHUB_REF_TYPE" == "tag" ]; then
 	export EXTRA_CMAKE_FLAGS=(-DENABLE_QT_UPDATE_CHECKER=ON)
 fi
 
-mkdir build && cd build
-cmake .. -GNinja \
+mkdir -p build/$BUILD_ARCH && cd build/$BUILD_ARCH
+cmake ../.. -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_OSX_ARCHITECTURES="$TARGET" \
-    -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_OSX_ARCHITECTURES="$BUILD_ARCH" \
     -DENABLE_QT_TRANSLATION=ON \
     -DENABLE_ROOM_STANDALONE=OFF \
     -DUSE_DISCORD_PRESENCE=ON \
@@ -18,9 +16,8 @@ ninja
 ninja bundle
 mv ./bundle/azahar.app ./bundle/Azahar.app # TODO: Can this be done in CMake?
 
-ccache -s -v
 
 CURRENT_ARCH=`arch`
-if [ "$TARGET" = "$CURRENT_ARCH" ]; then
+if [ "$BUILD_ARCH" = "$CURRENT_ARCH" ]; then
   ctest -VV -C Release
 fi

--- a/.ci/pack.sh
+++ b/.ci/pack.sh
@@ -3,20 +3,21 @@
 # Determine the full revision name.
 GITDATE="`git show -s --date=short --format='%ad' | sed 's/-//g'`"
 GITREV="`git show -s --format='%h'`"
-REV_NAME="azahar-$OS-$TARGET-$GITDATE-$GITREV"
-
-# Determine the name of the release being built.
-if [ "$GITHUB_REF_TYPE" = "tag" ]; then
-    RELEASE_NAME=azahar-$GITHUB_REF_NAME
-    REV_NAME="azahar-$OS-$TARGET-$GITHUB_REF_NAME"
-else
-    RELEASE_NAME=azahar-head
-fi
 
 # Archive and upload the artifacts.
 mkdir -p artifacts
 
 function pack_artifacts() {
+    REV_NAME="azahar-$OS-$TARGET-$GITDATE-$GITREV"
+
+    # Determine the name of the release being built.
+    if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+        RELEASE_NAME=azahar-$GITHUB_REF_NAME
+        REV_NAME="azahar-$OS-$TARGET-$GITHUB_REF_NAME"
+    else
+        RELEASE_NAME=azahar-head
+    fi
+
     ARTIFACTS_PATH="$1"
 
     # Set up root directory for archive.
@@ -56,11 +57,23 @@ if [ -n "$UNPACKED" ]; then
         FILENAME=$(basename "$ARTIFACT")
         EXTENSION="${FILENAME##*.}"
 
+        # TODO: Deduplicate
+        REV_NAME="azahar-$OS-$TARGET-$GITDATE-$GITREV"
+
+        # Determine the name of the release being built.
+        if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            RELEASE_NAME=azahar-$GITHUB_REF_NAME
+            REV_NAME="azahar-$OS-$TARGET-$GITHUB_REF_NAME"
+        else
+            RELEASE_NAME=azahar-head
+        fi
+
         mv "$ARTIFACT" "artifacts/$REV_NAME.$EXTENSION"
     done
 elif [ -n "$PACK_INDIVIDUALLY" ]; then
     # Pack and upload the artifacts one-by-one.
     for ARTIFACT in build/bundle/*; do
+        TARGET=$(basename "$ARTIFACT")
         pack_artifacts "$ARTIFACT"
     done
 else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,17 +101,12 @@ jobs:
         run: ./.ci/linux.sh
 
   macos:
-    runs-on: ${{ (matrix.target == 'x86_64' && 'macos-26-intel') || 'macos-26' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        target: ["x86_64", "arm64"]
+    runs-on: 'macos-26'
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       CCACHE_COMPILERCHECK: content
       CCACHE_SLOPPINESS: time_macros
       OS: macos
-      TARGET: ${{ matrix.target }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -120,58 +115,31 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}
+          key: ${{ runner.os }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.target }}-
+            ${{ runner.os }}-
       - name: Install tools
         run: brew install ccache ninja spirv-tools
-      - name: Build
-        run: ./.ci/macos.sh
-      - name: Prepare outputs for caching
-        run: cp -R build/bundle $OS-$TARGET
-      - name: Cache outputs for universal build
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ env.OS }}-${{ env.TARGET }}
-          key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
-      - name: Pack
-        run: ./.ci/pack.sh
-      - name: Upload
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.OS }}-${{ env.TARGET }}
-          path: artifacts/
-
-  macos-universal:
-    runs-on: macos-26
-    needs: macos
-    env:
-      OS: macos
-      TARGET: universal
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download x86_64 build from cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ env.OS }}-x86_64
-          key: ${{ runner.os }}-x86_64-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
-          fail-on-cache-miss: true
-      - name: Download ARM64 build from cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ env.OS }}-arm64
-          key: ${{ runner.os }}-arm64-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
-          fail-on-cache-miss: true
+      - name: Build (x86_64)
+        run: BUILD_ARCH=x86_64 ./.ci/macos.sh
+      - name: Build (arm64)
+        run: BUILD_ARCH=arm64 ./.ci/macos.sh
       - name: Create universal app
         run: ./.ci/macos-universal.sh
-        env:
-          ARTIFACTS: ${{ env.OS }}-x86_64 ${{ env.OS }}-arm64
+      - name: Prepare for packing
+        run: |
+          mkdir build/bundle
+          cp -r build/x86_64/bundle build/bundle/x86_64
+          cp -r build/arm64/bundle build/bundle/arm64
+          cp -r build/universal/bundle build/bundle/universal
       - name: Pack
+        env:
+          PACK_INDIVIDUALLY: 1
         run: ./.ci/pack.sh
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.OS }}-${{ env.TARGET }}
+          name: ${{ env.OS }}
           path: artifacts/
 
   windows:


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.

Closes #1869

This PR aims to address some shortcomings in our current macOS CI process. The following primary benefits are intended:

- Reduce disproportionate backlogs of macOS build jobs accumulating when large numbers of workflow runs are queued. (see https://docs.github.com/en/actions/reference/limits)
- Increase reliability of macOS universal build process by removing dependency on previously cached builds not having been wiped while waiting for an available runner.

### Testing:
- [x] arm64
- universal
  - [x] arm64
  - [x] x86_64
- [x] x86_64