### PR TITLE
android: Convert bgColor default values to Int

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -1275,7 +1275,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                 override val section = null
                 override val isRuntimeEditable = false
                 override val valueAsString = int.toString()
-                override val defaultValue = FloatSetting.BACKGROUND_RED.defaultValue
+                override val defaultValue = FloatSetting.BACKGROUND_RED.defaultValue.toInt()
             }
             add(
                 SliderSetting(
@@ -1298,7 +1298,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                 override val section = null
                 override val isRuntimeEditable = false
                 override val valueAsString = int.toString()
-                override val defaultValue = FloatSetting.BACKGROUND_GREEN.defaultValue
+                override val defaultValue = FloatSetting.BACKGROUND_GREEN.defaultValue.toInt()
             }
             add(
                 SliderSetting(
@@ -1321,7 +1321,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                 override val section = null
                 override val isRuntimeEditable = false
                 override val valueAsString = int.toString()
-                override val defaultValue = FloatSetting.BACKGROUND_BLUE.defaultValue
+                override val defaultValue = FloatSetting.BACKGROUND_BLUE.defaultValue.toInt()
             }
             add(
                 SliderSetting(


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.

Fixes a crash caused by using a default float value for AbstractIntSetting without converting to Int when resetting bgColor values on Android.