### PR TITLE
android : Fix emulation exit showing an Invalid Rom Format error + Small UI fix

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
@@ -504,8 +504,9 @@ object NativeLibrary {
             const val ErrorSystemFiles = 8
             const val ErrorSavestate = 9
             const val ErrorArticDisconnected = 10
-            const val ShutdownRequested = 11
-            const val ErrorUnknown = 12
+            const val ErrorN3DSApplication = 11
+            const val ShutdownRequested = 12
+            const val ErrorUnknown = 13
 
             fun newInstance(resultCode: Int): EmulationErrorDialogFragment {
                 val args = Bundle()

--- a/src/android/app/src/main/res/layout/fragment_system_files.xml
+++ b/src/android/app/src/main/res/layout/fragment_system_files.xml
@@ -5,13 +5,13 @@
     android:id="@+id/coordinator_about"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:background="?attr/colorSurface">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar_about"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:fitsSystemWindows="true">
+        android:layout_height="wrap_content">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar_system_files"


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.

When exiting the emulation activity on Android (for example, via homebrew that returns exit code 0), the App was incorrectly showing the "Invalid Rom Format" error dialog.

This was caused by a mismatch between the native error enum values and the Java ones. 
``ShutdownRequested`` became ``ErrorUnknown``, and the error code handling defaulted to displaying this message.

Also includes a small fix : In the system files tab, previously if the user had the 3-buttons navigation bar enabled, this bar would have rendered on top of the "Show Home Menu Apps" toggle, making it difficult to toggle the option.
