### PR TITLE
shader_jit: Optimize GeometryEmitter SETEMIT state

### DIFF
--- a/src/tests/video_core/shader.cpp
+++ b/src/tests/video_core/shader.cpp
@@ -481,6 +481,39 @@ SHADER_TEST_CASE("RSQ", "[video_core][shader]") {
     REQUIRE(shader.Run({0.0625f}).x == Catch::Approx(4.0f).margin(0.004f));
 }
 
+SHADER_TEST_CASE("SETEMIT", "[video_core][shader]") {
+    Pica::GeometryEmitter geometry_emitter;
+
+    for (u8 winding = 0; winding <= 1; ++winding) {
+        for (u8 prim_emit = 0; prim_emit <= 1; ++prim_emit) {
+            for (u8 vertex_id = 0; vertex_id <= 3; ++vertex_id) {
+                auto shader_setup = CompileShaderSetup({
+                    {OpCode::Id::NOP}, // setemit
+                    {OpCode::Id::END},
+                });
+
+                // nihstro does not support the SETEMIT instructions, so the instruction-binary must
+                // be manually
+                // inserted here:
+                nihstro::Instruction SETEMIT = {};
+                SETEMIT.opcode = nihstro::OpCode(nihstro::OpCode::Id::SETEMIT);
+                SETEMIT.setemit.winding.Assign(winding);
+                SETEMIT.setemit.prim_emit.Assign(prim_emit);
+                SETEMIT.setemit.vertex_id.Assign(vertex_id);
+                shader_setup->UpdateProgramCode(0, SETEMIT.hex);
+
+                auto shader = TestType(std::move(shader_setup));
+                Pica::ShaderUnit shader_unit(&geometry_emitter);
+                shader.Run(shader_unit, 1.0f);
+
+                REQUIRE(geometry_emitter.emit_state.winding == winding);
+                REQUIRE(geometry_emitter.emit_state.prim_emit == prim_emit);
+                REQUIRE(geometry_emitter.emit_state.vertex_id == vertex_id);
+            }
+        }
+    }
+}
+
 SHADER_TEST_CASE("Uniform Read", "[video_core][shader]") {
     const auto sh_input = SourceRegister::MakeInput(0);
     const auto sh_c0 = SourceRegister::MakeFloat(0);

--- a/src/video_core/pica/shader_unit.cpp
+++ b/src/video_core/pica/shader_unit.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -29,15 +29,15 @@ void ShaderUnit::WriteOutput(const ShaderRegs& config, AttributeBuffer& buffer) 
 }
 
 void GeometryEmitter::Emit(std::span<Common::Vec4<f24>, 16> output_regs) {
-    ASSERT(vertex_id < 3);
+    ASSERT(emit_state.vertex_id < 3);
 
     u32 output_index{};
     for (u32 reg : Common::BitSet<u32>(output_mask)) {
-        buffer[vertex_id][output_index++] = output_regs[reg];
+        buffer[emit_state.vertex_id][output_index++] = output_regs[reg];
     }
 
-    if (prim_emit) {
-        if (winding) {
+    if (emit_state.prim_emit) {
+        if (emit_state.winding) {
             handlers->winding_setter();
         }
         for (std::size_t i = 0; i < buffer.size(); ++i) {

--- a/src/video_core/pica/shader_unit.h
+++ b/src/video_core/pica/shader_unit.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -75,11 +75,18 @@ struct GeometryEmitter {
     void Emit(std::span<Common::Vec4<f24>, 16> output_regs);
 
 public:
-    std::array<AttributeBuffer, 3> buffer;
-    u8 vertex_id;
-    bool prim_emit;
-    bool winding;
+    union EmitState {
+        struct {
+            bool winding : 1;
+            bool prim_emit : 1;
+            u8 vertex_id : 2;
+        };
+        u8 raw;
+    } emit_state;
+    static_assert(sizeof(emit_state) == 1);
+
     u32 output_mask;
+    std::array<AttributeBuffer, 3> buffer;
     Handlers* handlers;
 
 private:
@@ -87,9 +94,7 @@ private:
     template <class Archive>
     void serialize(Archive& ar, const u32 file_version) {
         ar & buffer;
-        ar & vertex_id;
-        ar & prim_emit;
-        ar & winding;
+        ar & emit_state.raw;
         ar & output_mask;
     }
 };

--- a/src/video_core/shader/shader_interpreter.cpp
+++ b/src/video_core/shader/shader_interpreter.cpp
@@ -671,9 +671,9 @@ static void RunInterpreter(const ShaderSetup& setup, ShaderUnit& state,
             case OpCode::Id::SETEMIT: {
                 auto* emitter = state.emitter_ptr;
                 ASSERT_MSG(emitter, "Execute SETEMIT on VS");
-                emitter->vertex_id = instr.setemit.vertex_id;
-                emitter->prim_emit = instr.setemit.prim_emit != 0;
-                emitter->winding = instr.setemit.winding != 0;
+                emitter->emit_state.vertex_id = instr.setemit.vertex_id;
+                emitter->emit_state.prim_emit = instr.setemit.prim_emit != 0;
+                emitter->emit_state.winding = instr.setemit.winding != 0;
                 break;
             }
 

--- a/src/video_core/shader/shader_jit_a64_compiler.cpp
+++ b/src/video_core/shader/shader_jit_a64_compiler.cpp
@@ -865,12 +865,13 @@ void JitShader::Compile_SETE(Instruction instr) {
 
     l(have_emitter);
 
-    MOV(XSCRATCH1.toW(), instr.setemit.vertex_id);
-    STRB(XSCRATCH1.toW(), XSCRATCH0, u32(offsetof(GeometryEmitter, vertex_id)));
-    MOV(XSCRATCH1.toW(), instr.setemit.prim_emit);
-    STRB(XSCRATCH1.toW(), XSCRATCH0, u32(offsetof(GeometryEmitter, prim_emit)));
-    MOV(XSCRATCH1.toW(), instr.setemit.winding);
-    STRB(XSCRATCH1.toW(), XSCRATCH0, u32(offsetof(GeometryEmitter, winding)));
+    const GeometryEmitter::EmitState new_state{
+        .winding = instr.setemit.winding != 0,
+        .prim_emit = instr.setemit.prim_emit != 0,
+        .vertex_id = static_cast<uint8_t>(instr.setemit.vertex_id),
+    };
+    MOV(XSCRATCH1.toW(), new_state.raw);
+    STRB(XSCRATCH1.toW(), XSCRATCH0, u32(offsetof(GeometryEmitter, emit_state)));
 
     l(end);
 }

--- a/src/video_core/shader/shader_jit_x64_compiler.cpp
+++ b/src/video_core/shader/shader_jit_x64_compiler.cpp
@@ -905,9 +905,12 @@ void JitShader::Compile_SETE(Instruction instr) {
     jmp(end);
 
     L(have_emitter);
-    mov(byte[rax + offsetof(GeometryEmitter, vertex_id)], instr.setemit.vertex_id);
-    mov(byte[rax + offsetof(GeometryEmitter, prim_emit)], instr.setemit.prim_emit);
-    mov(byte[rax + offsetof(GeometryEmitter, winding)], instr.setemit.winding);
+    const GeometryEmitter::EmitState new_state{
+        .winding = instr.setemit.winding != 0,
+        .prim_emit = instr.setemit.prim_emit != 0,
+        .vertex_id = static_cast<uint8_t>(instr.setemit.vertex_id),
+    };
+    mov(byte[rax + offsetof(GeometryEmitter, emit_state)], new_state.raw);
     L(end);
 }
 


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.

The `SETEMIT`/`SETE` instruction only actually encodes 4 bits of possible state,
but this is currently expanded into three separate bytes of
data(four with padding) and requires three separate byte-writes for the x64 and
a64 JITs to write into. These 4 bits from the instruction can instead be
compacted into a singular 1-byte write from the JIT by encoding these 4 bits of
state into a singular byte at JIT-time, and unpacking this data is instead done
by `GeometryEmitter::Emit`. This also allows the serializer to use a singular
byte for all 3 fields now as well.