### PR TITLE
cmake: Allow Catch test discovery

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -60,6 +60,7 @@ if (ENABLE_TESTS)
         add_subdirectory(catch2)
     endif()
     target_link_libraries(catch2 INTERFACE Catch2::Catch2WithMain)
+    include(Catch)
 endif()
 
 # Crypto++

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -36,6 +36,10 @@ if (ENABLE_LIBRETRO)
 endif()
 
 add_test(NAME tests COMMAND tests)
+if(NOT ANDROID)
+    catch_discover_tests(tests)
+endif()
+
 
 if (CITRA_USE_PRECOMPILED_HEADERS)
     target_precompile_headers(tests PRIVATE precompiled_headers.h)


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.

Allows individual unit-tests to be discovered, tested, and debugged by IDEs without having to run _all_ of the unit-tests just to debug one specific test.

<img width="427" height="947" alt="image" src="https://github.com/user-attachments/assets/a061b3db-f5a8-4f57-9c66-b3eda4e8ea59" />

<img width="1376" height="845" alt="image" src="https://github.com/user-attachments/assets/afe7cca4-f37f-46c7-9ba8-3fe094a3b8eb" />
