### PR TITLE
libretro: vulkan: wait before ticking

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -140,6 +140,7 @@ RasterizerVulkan::RasterizerVulkan(Memory::MemorySystem& memory, Pica::PicaCore&
 RasterizerVulkan::~RasterizerVulkan() = default;
 
 void RasterizerVulkan::TickFrame() {
+    scheduler.WaitWorker();
     res_cache.TickFrame();
 }
 


### PR DESCRIPTION
Ensure the scheduler worker thread has finished processing all dispatched command chunks before the rasterizer cache's garbage collector destroys sentenced surfaces.

- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.