### PR TITLE
Core: Move location of where is_powered_on variable is updated to fix Discord Rich Presence not updating correctly

### DIFF
--- a/src/citra_qt/discord_impl.cpp
+++ b/src/citra_qt/discord_impl.cpp
@@ -37,6 +37,7 @@ void DiscordImpl::Update() {
     std::string title;
     const bool is_powered_on = system.IsPoweredOn();
     if (is_powered_on) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(2000));
         system.GetAppLoader().ReadTitle(title);
     }
 

--- a/src/citra_qt/discord_impl.cpp
+++ b/src/citra_qt/discord_impl.cpp
@@ -37,7 +37,6 @@ void DiscordImpl::Update() {
     std::string title;
     const bool is_powered_on = system.IsPoweredOn();
     if (is_powered_on) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(2000));
         system.GetAppLoader().ReadTitle(title);
     }
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -511,6 +511,8 @@ System::ResultStatus System::Init(Frontend::EmuWindow& emu_window,
                                   Kernel::MemoryMode memory_mode, u32 num_cores) {
     LOG_DEBUG(HW_Memory, "initialized OK");
 
+    is_powered_on = true;
+
     memory = std::make_unique<Memory::MemorySystem>(*this);
 
     timing = std::make_unique<Timing>(num_cores, Settings::values.cpu_clock_percentage.GetValue(),
@@ -591,8 +593,6 @@ System::ResultStatus System::Init(Frontend::EmuWindow& emu_window,
     }
 
     LOG_DEBUG(Core, "Initialized OK");
-
-    is_powered_on = true;
 
     return ResultStatus::Success;
 }
@@ -687,9 +687,6 @@ void System::RegisterImageInterface(std::shared_ptr<Frontend::ImageInterface> im
 
 void System::Shutdown(bool is_deserializing) {
 
-    // Shutdown emulation session
-    is_powered_on = false;
-
     gpu.reset();
     if (!is_deserializing) {
         lle_modules.clear();
@@ -721,6 +718,9 @@ void System::Shutdown(bool is_deserializing) {
     memory.reset();
 
     LOG_DEBUG(Core, "Shutdown OK");
+
+    // Shutdown emulation session
+    is_powered_on = false;
 }
 
 void System::Reset() {


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.

This PR needs to be tested by other users to confirm if the problem is resolved or not, but I tested and can no longer break Discord RPC on my end (might just be a fluke that I didn't get it at all, but we'll see)