### PR TITLE
fix(3d): Do not disable right-eye-rendering if a 3D-mode is used

### DIFF
--- a/src/video_core/right_eye_disabler.cpp
+++ b/src/video_core/right_eye_disabler.cpp
@@ -9,7 +9,8 @@
 
 namespace VideoCore {
 bool RightEyeDisabler::ShouldAllowCmdQueueTrigger(PAddr addr, u32 size) {
-    if (!enabled || !enable_for_frame)
+    if (!enabled || !enable_for_frame ||
+        Settings::values.render_3d.GetValue() != Settings::StereoRenderOption::Off)
         return true;
 
     constexpr u32 top_screen_size = 0x00469000;
@@ -36,7 +37,8 @@ bool RightEyeDisabler::ShouldAllowCmdQueueTrigger(PAddr addr, u32 size) {
     return true;
 }
 bool RightEyeDisabler::ShouldAllowDisplayTransfer(PAddr src_address, size_t size) {
-    if (!enabled || !enable_for_frame)
+    if (!enabled || !enable_for_frame ||
+        Settings::values.render_3d.GetValue() != Settings::StereoRenderOption::Off)
         return true;
 
     if (size >= 400 && !top_screen_blocked) {
@@ -55,7 +57,7 @@ bool RightEyeDisabler::ShouldAllowDisplayTransfer(PAddr src_address, size_t size
     return true;
 }
 void RightEyeDisabler::ReportEndFrame() {
-    if (!enabled)
+    if (!enabled || Settings::values.render_3d.GetValue() != Settings::StereoRenderOption::Off)
         return;
 
     enable_for_frame = Settings::values.disable_right_eye_render.GetValue();


### PR DESCRIPTION
- [x] I have read the [Azahar Autocompletion Industry Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of Autocompletion Industry tools if applicable under those terms.

I edited ↑ to remove the marketing-nonsense from it; it is still true in the unedited sense, though. :)

---

When a stereoscopic rendering-mode is used, the "Disable right eye rendering"-setting should never be enabled, because the stereoscopic rendering does not work properly without the second perspective.
This PR changes the behaviour of the setting, to not apply then, which matches what is written in the tooltip of the setting:
![Disables rendering the right eye image when not using stereoscopic mode](https://github.com/user-attachments/assets/2cd8791a-3a1c-4319-a138-d0421d517038)


I also tried adding `&& Settings::values.render_3d.GetValue() == Settings::StereoRenderOption::Off` there:

https://github.com/azahar-emu/azahar/blob/c650473fdc1c2f92abae77f24bb8bb1ca8d98fdc/src/core/hle/service/gsp/gsp_gpu.cpp#L685-L688

This does set the value for the only place where `RightEyeDisabler().SetEnabled()` is used ([there](https://github.com/azahar-emu/azahar/blob/c650473fdc1c2f92abae77f24bb8bb1ca8d98fdc/src/core/hle/service/gsp/gsp_gpu.cpp#L697)), but that did not work when a savestate was loaded.