### PR TITLE
qt: Properly fix discord rich presence

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -366,7 +366,7 @@ GMainWindow::GMainWindow(Core::System& system_)
 
 #ifdef USE_DISCORD_PRESENCE
     SetDiscordEnabled(UISettings::values.enable_discord_presence.GetValue());
-    discord_rpc->Update();
+    discord_rpc->Update(false);
 #endif
 
     play_time_manager = std::make_unique<PlayTime::PlayTimeManager>();
@@ -975,7 +975,7 @@ void GMainWindow::OnAppFocusStateChanged(Qt::ApplicationState state) {
             OnPauseGame();
         } else if (!emu_thread->IsRunning() && auto_paused && state == Qt::ApplicationActive) {
             auto_paused = false;
-            OnStartGame();
+            OnResumeGame(false);
         }
     }
     if (UISettings::values.mute_when_in_background) {
@@ -1530,7 +1530,7 @@ void GMainWindow::BootGame(const QString& filename) {
         ShowFullscreen();
     }
 
-    OnStartGame();
+    OnResumeGame(true);
 }
 
 void GMainWindow::ShutdownGame() {
@@ -1583,7 +1583,7 @@ void GMainWindow::ShutdownGame() {
     OnCloseMovie();
 
 #ifdef USE_DISCORD_PRESENCE
-    discord_rpc->Update();
+    discord_rpc->Update(false);
 #endif
 #ifdef __unix__
     Common::Linux::StopGamemode();
@@ -2508,7 +2508,7 @@ void GMainWindow::OnMenuRecentFile() {
     }
 }
 
-void GMainWindow::OnStartGame() {
+void GMainWindow::OnResumeGame(bool first_start) {
     qt_cameras->ResumeCameras();
 
     PreventOSSleep();
@@ -2525,9 +2525,12 @@ void GMainWindow::OnStartGame() {
     play_time_manager->SetProgramId(game_title_id);
     play_time_manager->Start();
 
+    if (first_start) {
 #ifdef USE_DISCORD_PRESENCE
-    discord_rpc->Update();
+        discord_rpc->Update(true);
 #endif
+    }
+
 #ifdef __unix__
     Common::Linux::StartGamemode();
 #endif
@@ -2563,7 +2566,7 @@ void GMainWindow::OnPauseContinueGame() {
         if (emu_thread->IsRunning() && !system.frame_limiter.IsFrameAdvancing()) {
             OnPauseGame();
         } else {
-            OnStartGame();
+            OnResumeGame(false);
         }
     }
 }
@@ -2865,6 +2868,7 @@ void GMainWindow::OnConfigure() {
 #ifdef USE_DISCORD_PRESENCE
         if (UISettings::values.enable_discord_presence.GetValue() != old_discord_presence) {
             SetDiscordEnabled(UISettings::values.enable_discord_presence.GetValue());
+            discord_rpc->Update(system.IsPoweredOn());
         }
 #endif
 #ifdef __unix__
@@ -3032,7 +3036,7 @@ void GMainWindow::OnCloseMovie() {
         }
 
         if (was_running) {
-            OnStartGame();
+            OnResumeGame(false);
         }
     }
 
@@ -3054,7 +3058,7 @@ void GMainWindow::OnSaveMovie() {
     }
 
     if (was_running) {
-        OnStartGame();
+        OnResumeGame(false);
     }
 }
 
@@ -3098,7 +3102,7 @@ void GMainWindow::OnCaptureScreenshot() {
         screenshot_window->CaptureScreenshot(
             UISettings::values.screenshot_resolution_factor.GetValue(),
             QString::fromStdString(path));
-        OnStartGame();
+        OnResumeGame(false);
     }
 }
 
@@ -3501,7 +3505,7 @@ void GMainWindow::OnStopVideoDumping() {
                 ShutdownGame();
             } else if (game_paused_for_dumping) {
                 game_paused_for_dumping = false;
-                OnStartGame();
+                OnResumeGame(false);
             }
         });
         future_watcher->setFuture(future);
@@ -4235,7 +4239,6 @@ void GMainWindow::SetDiscordEnabled([[maybe_unused]] bool state) {
     } else {
         discord_rpc = std::make_unique<DiscordRPC::NullImpl>();
     }
-    discord_rpc->Update();
 }
 #endif
 

--- a/src/citra_qt/citra_qt.h
+++ b/src/citra_qt/citra_qt.h
@@ -231,7 +231,7 @@ private:
     void ShowFFmpegErrorMessage();
 
 private slots:
-    void OnStartGame();
+    void OnResumeGame(bool first_start);
     void OnRestartGame();
     void OnPauseGame();
     void OnPauseContinueGame();

--- a/src/citra_qt/discord.h
+++ b/src/citra_qt/discord.h
@@ -1,4 +1,4 @@
-// Copyright 2018 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -11,7 +11,7 @@ public:
     virtual ~DiscordInterface() = default;
 
     virtual void Pause() = 0;
-    virtual void Update() = 0;
+    virtual void Update(bool is_powered_on) = 0;
 };
 
 class NullImpl : public DiscordInterface {
@@ -19,7 +19,7 @@ public:
     ~NullImpl() = default;
 
     void Pause() override {}
-    void Update() override {}
+    void Update(bool is_powered_on) override {}
 };
 
 } // namespace DiscordRPC

--- a/src/citra_qt/discord_impl.cpp
+++ b/src/citra_qt/discord_impl.cpp
@@ -34,9 +34,17 @@ void DiscordImpl::Update(bool is_powered_on) {
     s64 start_time = std::chrono::duration_cast<std::chrono::seconds>(
                          std::chrono::system_clock::now().time_since_epoch())
                          .count();
+    auto truncate = [](const std::string& str, std::size_t maxLen = 128) -> std::string {
+        if (str.length() <= maxLen) {
+            return str;
+        }
+        return str.substr(0, maxLen - 3) + "...";
+    };
+
     std::string title;
     if (is_powered_on) {
         system.GetAppLoader().ReadTitle(title);
+        title = truncate("Playing: " + title);
     }
 
     DiscordRichPresence presence{};
@@ -44,9 +52,6 @@ void DiscordImpl::Update(bool is_powered_on) {
     presence.largeImageText = "An open source emulator for the Nintendo 3DS";
     if (is_powered_on) {
         presence.state = title.c_str();
-        presence.details = "Currently in game";
-    } else {
-        presence.details = "Not in game";
     }
     presence.startTimestamp = start_time;
     Discord_UpdatePresence(&presence);

--- a/src/citra_qt/discord_impl.cpp
+++ b/src/citra_qt/discord_impl.cpp
@@ -30,12 +30,11 @@ void DiscordImpl::Pause() {
     Discord_ClearPresence();
 }
 
-void DiscordImpl::Update() {
+void DiscordImpl::Update(bool is_powered_on) {
     s64 start_time = std::chrono::duration_cast<std::chrono::seconds>(
                          std::chrono::system_clock::now().time_since_epoch())
                          .count();
     std::string title;
-    const bool is_powered_on = system.IsPoweredOn();
     if (is_powered_on) {
         system.GetAppLoader().ReadTitle(title);
     }

--- a/src/citra_qt/discord_impl.h
+++ b/src/citra_qt/discord_impl.h
@@ -1,4 +1,4 @@
-// Copyright 2018 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -18,7 +18,7 @@ public:
     ~DiscordImpl() override;
 
     void Pause() override;
-    void Update() override;
+    void Update(bool is_powered_on) override;
 
 private:
     const Core::System& system;

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -511,8 +511,6 @@ System::ResultStatus System::Init(Frontend::EmuWindow& emu_window,
                                   Kernel::MemoryMode memory_mode, u32 num_cores) {
     LOG_DEBUG(HW_Memory, "initialized OK");
 
-    is_powered_on = true;
-
     memory = std::make_unique<Memory::MemorySystem>(*this);
 
     timing = std::make_unique<Timing>(num_cores, Settings::values.cpu_clock_percentage.GetValue(),
@@ -595,6 +593,8 @@ System::ResultStatus System::Init(Frontend::EmuWindow& emu_window,
     SetInfoLEDColor({});
 
     LOG_DEBUG(Core, "Initialized OK");
+
+    is_powered_on = true;
 
     return ResultStatus::Success;
 }
@@ -689,6 +689,9 @@ void System::RegisterImageInterface(std::shared_ptr<Frontend::ImageInterface> im
 
 void System::Shutdown(bool is_deserializing) {
 
+    // Shutdown emulation session
+    is_powered_on = false;
+
     gpu.reset();
     if (!is_deserializing) {
         lle_modules.clear();
@@ -722,9 +725,6 @@ void System::Shutdown(bool is_deserializing) {
     SetInfoLEDColor({});
 
     LOG_DEBUG(Core, "Shutdown OK");
-
-    // Shutdown emulation session
-    is_powered_on = false;
 }
 
 void System::Reset() {


### PR DESCRIPTION
This PR reverts the changes made in #2013 and properly addresses Discord Rich Presence issues on QT frontend. The issue was caused by a race condition between the emulation thread setting the `is_powered_on` variable and the rich presence code checking said variable. Fixed it by making the rich presence code not check for power on by itself, but take an argument.

Furthermore, the way the information is displayed has been changed to make it more clean.