### PR TITLE
Changes and fixes to support compilation in an MXE build environment

### DIFF
--- a/.ci/mxe.sh
+++ b/.ci/mxe.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -ex
+
+# TODO: Why doesn't the CI environment use the PATH set in the Dockerimage?
+#       It works fine when using the image locally.
+export PATH="/mxe/usr/bin:${PATH}"
+
+mkdir build && cd build
+
+if [ "$GITHUB_REF_TYPE" == "tag" ]; then
+	export EXTRA_CMAKE_FLAGS=(-DENABLE_QT_UPDATE_CHECKER=ON)
+fi
+
+x86_64-w64-mingw32.shared-cmake .. \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    -DENABLE_QT_TRANSLATION=ON \
+    -DUSE_DISCORD_PRESENCE=ON \
+    -DUSE_SYSTEM_BOOST=ON \
+    -DUSE_SYSTEM_CRYPTOPP=ON \
+	"${EXTRA_CMAKE_FLAGS[@]}"
+x86_64-w64-mingw32.shared-cmake --build . -- -j$(nproc)
+x86_64-w64-mingw32.shared-strip -s bin/Release/*.exe
+make bundle
+
+ccache -s -v

--- a/.ci/pack.sh
+++ b/.ci/pack.sh
@@ -36,10 +36,10 @@ function pack_artifacts() {
     fi
 
     # Create .zip/.tar.gz
-    if [ "$OS" = "windows" ]; then
+    if [ "$OS" = "windows" ] && [ "$TARGET" != "mxe" ]; then
         ARCHIVE_FULL_NAME="$ARCHIVE_NAME.zip"
         powershell Compress-Archive "$REV_NAME" "$ARCHIVE_FULL_NAME"
-    elif [ "$OS" = "android" ] || [ "$OS" = "macos" ]; then
+    elif [ "$OS" = "android" ] || [ "$OS" = "macos" ] || [ "$TARGET" = "mxe" ]; then
         ARCHIVE_FULL_NAME="$ARCHIVE_NAME.zip"
         zip -r "$ARCHIVE_FULL_NAME" "$REV_NAME"
     else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,11 +143,21 @@ jobs:
           path: artifacts/
 
   windows:
-    runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
-        target: ["msvc", "msys2"]
+        include:
+        - target: msvc
+          os: windows-latest
+        - target: msys2
+          os: windows-latest
+        - target: mxe
+          os: ubuntu-latest
+          container:
+            image: opensauce04/azahar-build-environment:latest
+            options: -u 1001
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
     defaults:
       run:
         shell: ${{ (matrix.target == 'msys2' && 'msys2') || 'bash' }} {0}
@@ -195,23 +205,35 @@ jobs:
         with:
           args: install ptime wget
       - name: Install NSIS
-        if: ${{ github.ref_type == 'tag' }}
+        if: ${{ github.ref_type == 'tag' && matrix.target != 'mxe' }}
         run: |
           wget https://download.sourceforge.net/project/nsis/NSIS%203/3.11/nsis-3.11-setup.exe -O D:/a/_temp/nsis-setup.exe
           ptime D:/a/_temp/nsis-setup.exe /S
         shell: pwsh
       - name: Disable line ending translation
         run: git config --global core.autocrlf input
-      - name: Build
+      - name: Build (Native)
+        if: ${{ matrix.target != 'mxe' }}
         run: ./.ci/windows.sh
-      - name: Generate installer
-        if: ${{ github.ref_type == 'tag' }}
+      - name: Build (MXE)
+        if: ${{ matrix.target == 'mxe' }}
+        run: ./.ci/mxe.sh
+      - name: Generate installer (Native)
+        if: ${{ github.ref_type == 'tag' && matrix.target != 'mxe' }}
         run: |
           cd src\installer
           "C:\Program Files (x86)\NSIS\makensis.exe" /DPRODUCT_VARIANT=${{ matrix.target }} /DPRODUCT_VERSION=${{ github.ref_name }} citra.nsi
           mkdir ..\..\artifacts 2> NUL
           move /y *.exe ..\..\artifacts\
         shell: cmd
+      - name: Generate installer (MXE)
+        if: ${{ github.ref_type == 'tag' && matrix.target == 'mxe' }}
+        run: |
+          export PATH="/mxe/usr/bin:${PATH}" # TODO: Why do we have to do this if it's in the image?
+          cd src/installer
+          x86_64-w64-mingw32.shared-makensis -DPRODUCT_VARIANT=${{ matrix.target }} -DPRODUCT_VERSION=${{ github.ref_name }} citra.nsi
+          mkdir -p ../../artifacts
+          mv ./*.exe ../../artifacts/
       - name: Pack
         run: ./.ci/pack.sh
       - name: Upload

--- a/.gitmodules
+++ b/.gitmodules
@@ -106,3 +106,6 @@
 [submodule "externals/libretro-common"]
 	path = externals/libretro-common/libretro-common
 	url = https://github.com/libretro/libretro-common.git
+[submodule "dllwalker"]
+	path = externals/dllwalker
+	url = https://github.com/azahar-emu/dllwalker

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,11 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR CMAKE_SYSTEM_NAME STREQUAL "iOS")
     enable_language(OBJC OBJCXX)
 endif()
 
+if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" AND MINGW)
+    string(TOLOWER ${LIBTYPE} LIBTYPE_LOWER)
+    set(CMAKE_AR x86_64-w64-mingw32.${LIBTYPE_LOWER}-gcc-ar)
+endif()
+
 if (BSD STREQUAL "OpenBSD")
     add_link_options(-z wxneeded)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ cmake_policy(SET CMP0063 NEW)
 cmake_policy(SET CMP0127 NEW)
 set(CMAKE_POLICY_DEFAULT_CMP0063 NEW)
 
+# Prefer building bundled dependencies as static instead of shared
+set(BUILD_SHARED_LIBS OFF)
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/externals/cmake-modules")
 include(DownloadExternals)

--- a/CMakeModules/BundleTarget.cmake
+++ b/CMakeModules/BundleTarget.cmake
@@ -198,6 +198,10 @@ if (BUNDLE_TARGET_EXECUTE)
 
     # On Linux, always bundle an AppImage.
     if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
+        if (IS_MINGW)
+            return()
+        endif()
+
         if (IN_PLACE)
             message(FATAL_ERROR "Cannot bundle for Linux in-place.")
         endif()
@@ -273,15 +277,23 @@ else()
 
         # On Linux, add a command to prepare linuxdeploy and any required plugins before any bundling occurs.
         if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
-            add_custom_command(
-                TARGET bundle
-                COMMAND ${CMAKE_COMMAND}
-                "-DBUNDLE_TARGET_DOWNLOAD_LINUXDEPLOY=1"
-                "-DLINUXDEPLOY_PATH=${CMAKE_BINARY_DIR}/externals/linuxdeploy"
-                "-DLINUXDEPLOY_ARCH=${CMAKE_HOST_SYSTEM_PROCESSOR}"
-                -P "${CMAKE_SOURCE_DIR}/CMakeModules/BundleTarget.cmake"
-                WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
-                POST_BUILD)
+            if (MINGW)
+                add_custom_command(
+                        TARGET bundle
+                        # The target here is arbitrary
+                        COMMAND cp -r "$<TARGET_FILE_DIR:citra_meta>/*" "${CMAKE_BINARY_DIR}/bundle/"
+                        POST_BUILD)
+            else()
+                add_custom_command(
+                    TARGET bundle
+                    COMMAND ${CMAKE_COMMAND}
+                    "-DBUNDLE_TARGET_DOWNLOAD_LINUXDEPLOY=1"
+                    "-DLINUXDEPLOY_PATH=${CMAKE_BINARY_DIR}/externals/linuxdeploy"
+                    "-DLINUXDEPLOY_ARCH=${CMAKE_HOST_SYSTEM_PROCESSOR}"
+                    -P "${CMAKE_SOURCE_DIR}/CMakeModules/BundleTarget.cmake"
+                    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+                    POST_BUILD)
+            endif()
         endif()
     endfunction()
 
@@ -291,6 +303,11 @@ else()
         # Create base bundle target if it does not exist.
         if (NOT in_place AND NOT TARGET bundle)
             create_base_bundle_target()
+        endif()
+
+        if (CMAKE_HOST_SYSTEM STREQUAL "Linux" AND MINGW)
+            # We don't really need to "bundle" MXE builds, so don't do anything
+            return()
         endif()
 
         set(bundle_executable_path "$<TARGET_FILE:${target_name}>")
@@ -331,6 +348,7 @@ else()
             "-DBUNDLE_LIBRARY_PATHS=\"${bundle_library_paths}\""
             "-DBUNDLE_QT=${bundle_qt}"
             "-DIN_PLACE=${in_place}"
+            "-DIS_MINGW=${MINGW}"
             "-DLINUXDEPLOY=${CMAKE_BINARY_DIR}/externals/linuxdeploy/squashfs-root/AppRun"
             -P "${CMAKE_SOURCE_DIR}/CMakeModules/BundleTarget.cmake"
             WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -327,12 +327,8 @@ endif()
 # OpenSSL
 if (USE_SYSTEM_OPENSSL)
     find_package(OpenSSL 1.1)
-    if (OPENSSL_FOUND)
-        set(OPENSSL_LIBRARIES OpenSSL::SSL OpenSSL::Crypto)
-    endif()
-endif()
-
-if (NOT OPENSSL_FOUND)
+    set(OPENSSL_LIBRARIES OpenSSL::SSL OpenSSL::Crypto)
+else()
     # LibreSSL
     set(LIBRESSL_SKIP_INSTALL ON CACHE BOOL "")
     set(OPENSSLDIR "/etc/ssl/")

--- a/src/citra_meta/CMakeLists.txt
+++ b/src/citra_meta/CMakeLists.txt
@@ -48,7 +48,7 @@ if (APPLE)
     endif()
 endif()
 
-if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" AND WIN32 AND MINGW)
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" AND MINGW)
     # TODO: Do this for all executables, not just citra_meta
     # TODO: Don't hardcode MXE directory to root?
     set(dllwalker_command "${CMAKE_SOURCE_DIR}/externals/dllwalker/dllwalker.rb"

--- a/src/citra_meta/CMakeLists.txt
+++ b/src/citra_meta/CMakeLists.txt
@@ -48,6 +48,22 @@ if (APPLE)
     endif()
 endif()
 
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" AND WIN32 AND MINGW)
+    # TODO: This is placeholder bullshit, we need to find out a way to do actual dependency resolution.
+    #       Can we use Wine maybe? -OS
+    set(EXTRA_LIBS /mxe/usr/x86_64-w64-mingw32.shared/bin/*.dll )
+    add_custom_command(TARGET citra_meta POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:citra_meta> ${EXTRA_LIBS} $<TARGET_FILE_DIR:citra_meta>
+        COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:citra_meta>/plugins/"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory /mxe/usr/x86_64-w64-mingw32.shared/qt6/plugins/ "$<TARGET_FILE_DIR:citra_meta>/plugins/"
+        COMMAND_EXPAND_LISTS
+    )
+    add_custom_command(TARGET citra_meta POST_BUILD
+        COMMAND_EXPAND_LISTS
+    )
+    unset(EXTRA_LIBS)
+endif()
+
 target_link_libraries(citra_meta PRIVATE citra_common fmt)
 
 if (ENABLE_QT)

--- a/src/citra_meta/CMakeLists.txt
+++ b/src/citra_meta/CMakeLists.txt
@@ -49,19 +49,23 @@ if (APPLE)
 endif()
 
 if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" AND WIN32 AND MINGW)
-    # TODO: This is placeholder bullshit, we need to find out a way to do actual dependency resolution.
-    #       Can we use Wine maybe? -OS
-    set(EXTRA_LIBS /mxe/usr/x86_64-w64-mingw32.shared/bin/*.dll )
+    # TODO: Do this for all executables, not just citra_meta
+    # TODO: Don't hardcode MXE directory to root?
+    set(dllwalker_command "${CMAKE_SOURCE_DIR}/externals/dllwalker/dllwalker.rb"
+                          $<TARGET_FILE:citra_meta>
+                          /mxe/usr/x86_64-w64-mingw32.shared/bin/
+                          /mxe/usr/x86_64-w64-mingw32.shared/qt6/bin/)
+    set(dll_list_filename "${CMAKE_CURRENT_BINARY_DIR}/required_dlls_list.txt")
     add_custom_command(TARGET citra_meta POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:citra_meta> ${EXTRA_LIBS} $<TARGET_FILE_DIR:citra_meta>
+        COMMAND ${dllwalker_command} > ${dll_list_filename}
+    )
+    add_custom_command(TARGET citra_meta POST_BUILD
+        COMMAND cat ${dll_list_filename} | xargs -I {} ${CMAKE_COMMAND} -E copy {} $<TARGET_FILE_DIR:citra_meta>
         COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:citra_meta>/plugins/"
         COMMAND ${CMAKE_COMMAND} -E copy_directory /mxe/usr/x86_64-w64-mingw32.shared/qt6/plugins/ "$<TARGET_FILE_DIR:citra_meta>/plugins/"
         COMMAND_EXPAND_LISTS
+        DEPENDS ${dll_list_filename}
     )
-    add_custom_command(TARGET citra_meta POST_BUILD
-        COMMAND_EXPAND_LISTS
-    )
-    unset(EXTRA_LIBS)
 endif()
 
 target_link_libraries(citra_meta PRIVATE citra_common fmt)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -36,7 +36,7 @@ if (ENABLE_LIBRETRO)
 endif()
 
 add_test(NAME tests COMMAND tests)
-if(NOT ANDROID)
+if(NOT ANDROID AND (CMAKE_SYSTEM_NAME STREQUAL CMAKE_HOST_SYSTEM_NAME))
     catch_discover_tests(tests)
 endif()
 


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---

Recently, I have begun experimenting with a project named [MXE](https://github.com/mxe/mxe), which is an environment that makes cross-compiling from Linux to Windows via MinGW relatively straight-forward and, notably, gives us complete control over our build environment.

Due to several issues we've encountered over time while using MSYS2, most notably its bleeding-edge rolling-release nature, we are currently investigating MXE as a potential alternative environment for our non-MSVC CI/CD jobs and binary distribution, replacing MSYS2.

Currently, compiling through MXE presents some issues which need to be resolved before we can seriously evaluate its use in production. Several of these issues have already been addressed in the initial commits of this PR, and the issues which are known of and still currently present and are listed below:

- [x] OpenAL causes compilation to fail, currently making `-DENABLE_OPENAL=OFF` necessary.
- [x] The Vulkan renderer causes compilation to fail, currently making `-DENABLE_VULKAN=OFF` necesssary.
- [x] LTO causes the linking process to fail, currently making `-DENABLE_LTO=OFF` necessary.
- [x] We currently have no solution for cross-platform DLL resolution implemented. As a result, the build process currently copies all cross-compiled DLLs from a hard-coded path, which is obviously not ideal and results in wasted space.

Other todos:

- [x] NSIS installer generation
- [x] Implement CI job
- [x] Make dllwalker produce errors when things go wrong