### PR TITLE
replace powf with pow in status LED code

### DIFF
--- a/src/citra_qt/notification_led.cpp
+++ b/src/citra_qt/notification_led.cpp
@@ -53,7 +53,7 @@ QColor LedWidget::blendLedColor(int r, int g, int b) const {
     // are not linear.
     constexpr float gamma = 2.4f;
     float pwm = max_c / 255.0;
-    float t = std::powf(pwm, 1.f / gamma);
+    float t = std::pow(pwm, 1.f / gamma);
 
     return lerpColor(off_color, lit_color, t * 0.8f);
 }


### PR DESCRIPTION
solves a build issue a ***lot*** of [L4T Megascript](https://github.com/cobalt2727/L4T-Megascript) users were reporting to me on Linux. C++ is definitely not my strong suit, but per https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/pow-powf-powl?view=msvc-170#remarks `pow` has identical behavior in C++ projects. no clue why `powf` worked fine on your environment when developing this but not other people's.

```cmake
[ 98%] Building CXX object src/citra_qt/CMakeFiles/citra_qt.dir/qt_image_interface.cpp.o
/home/runner/azahar/src/citra_qt/notification_led.cpp:56:15: error: no member named 'powf' in namespace 'std'; did you mean simply 'powf'?
   56 |     float t = std::powf(pwm, 1.f / gamma);
      |               ^~~~~~~~~
      |               powf
/usr/include/aarch64-linux-gnu/bits/mathcalls.h:140:1: note: 'powf' declared here
  140 | __MATHCALL_VEC (pow,, (_Mdouble_ __x, _Mdouble_ __y));
      | ^
/usr/include/math.h:280:3: note: expanded from macro '__MATHCALL_VEC'
  280 |   __MATHCALL (function, suffix, args)
      |   ^
/usr/include/math.h:287:3: note: expanded from macro '__MATHCALL'
  287 |   __MATHDECL (_Mdouble_,function,suffix, args)
      |   ^
/usr/include/math.h:289:3: note: expanded from macro '__MATHDECL'
  289 |   __MATHDECL_1(type, function,suffix, args); \
      |   ^
note: (skipping 1 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)
/usr/include/math.h:297:15: note: expanded from macro '__MATHDECL_1_IMPL'
  297 |   extern type __MATH_PRECNAME(function,suffix) args __THROW
      |               ^
/usr/include/math.h:326:34: note: expanded from macro '__MATH_PRECNAME'
  326 | # define __MATH_PRECNAME(name,r) name##f##r
      |                                  ^
<scratch space>:97:1: note: expanded from here
   97 | powf
      | ^
1 error generated.
make[2]: *** [src/citra_qt/CMakeFiles/citra_qt.dir/build.make:1573: src/citra_qt/CMakeFiles/citra_qt.dir/notification_led.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:3481: src/citra_qt/CMakeFiles/citra_qt.dir/all] Error 2
make: *** [Makefile:166: all] Error 2
```

- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.

---
<!--
If you are contributing to Azahar for the first time please
keep the block of text between `---` and write your 
PR description below it. Do not write anything inside 
or change this block of text!

If you are a recurrent contributor, remove this entire
block of text and proceed as normal.
-->

![Ignore Until Your PR has been created!](../blob/master/.github/ignore_unless_human.png?raw=true)
---
