### PR TITLE
OpenBSD build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR CMAKE_SYSTEM_NAME STREQUAL "iOS")
     enable_language(OBJC OBJCXX)
 endif()
 
+if (BSD STREQUAL "OpenBSD")
+    add_link_options(-z wxneeded)
+endif()
+
 option(ENABLE_LIBRETRO "Build as a LibRetro core" OFF)
 
 # Some submodules like to pick their own default build type if not specified.

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -508,6 +508,10 @@ if (ENABLE_VULKAN)
             # prefix location. -OS
             target_include_directories(vulkan-headers INTERFACE
                 /usr/pkg/share/x11-links/include)
+        elseif (BSD STREQUAL "OpenBSD")
+            # This is fine to hardcode because it'll never change
+            target_include_directories(vulkan-headers INTERFACE
+                /usr/X11R6/include)
         endif()
     endif()
 


### PR DESCRIPTION
- [ ] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---

- Specify OpenBSD's X11 include directory
- Add OpenBSD-specific linker flag to allow W|X