### PR TITLE
Android: Adding entire touch from button functionality to Android

### DIFF
--- a/CMakeModules/GenerateSettingKeys.cmake
+++ b/CMakeModules/GenerateSettingKeys.cmake
@@ -138,6 +138,8 @@ foreach(KEY IN ITEMS
     "udp_input_address"
     "udp_input_port"
     "udp_pad_index"
+    "use_touch_from_button"
+    "touch_from_button_map"
     "record_frame_times"
     "language" # FIXME: DUPLICATE KEY (libretro equivalent: language_value)
     "web_api_url"

--- a/src/android/app/src/main/AndroidManifest.xml
+++ b/src/android/app/src/main/AndroidManifest.xml
@@ -85,6 +85,12 @@
             android:exported="false"
             android:theme="@style/Theme.Citra.Main"
             android:label="@string/cheats"/>
+
+        <activity
+            android:name="org.citra.citra_emu.features.settings.ui.TouchFromButtonMapActivity"
+            android:exported="false"
+            android:theme="@style/Theme.Citra.Main"
+            android:label="@string/edit_touch_from_button_maps"/>
     </application>
 
 </manifest>

--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
@@ -124,6 +124,12 @@ object NativeLibrary {
 
     external fun reloadSettings()
 
+    external fun getTouchFromButtonMapCount(): Int
+    external fun getTouchFromButtonMapName(index: Int): String
+    external fun getTouchFromButtonMapBinds(index: Int): Array<String>
+    external fun setTouchFromButtonMaps(mapNames: Array<String>, mapBinds: Array<Array<String>>)
+    external fun reloadTouchFromButtonMaps()
+
     external fun getTitleId(filename: String): Long
 
     external fun getIsSystemTitle(path: String): Boolean
@@ -965,6 +971,17 @@ object NativeLibrary {
         const val BUTTON_GPIO14 = 782
         const val BUTTON_SWAP = 800
         const val BUTTON_TURBO = 801
+        // Touch-from-button: dedicated button IDs for touch-only mappings
+        const val TOUCH_ONLY_1 = 900
+        const val TOUCH_ONLY_2 = 901
+        const val TOUCH_ONLY_3 = 902
+        const val TOUCH_ONLY_4 = 903
+        const val TOUCH_ONLY_5 = 904
+        const val TOUCH_ONLY_6 = 905
+        const val TOUCH_ONLY_7 = 906
+        const val TOUCH_ONLY_8 = 907
+        const val TOUCH_ONLY_9 = 908
+        const val TOUCH_ONLY_10 = 909
     }
 
     /**

--- a/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.kt
@@ -379,10 +379,17 @@ class EmulationActivity : AppCompatActivity() {
         var isTriggerPressedR = false
         var isTriggerPressedZL = false
         var isTriggerPressedZR = false
+        val touchOnlyAxisState = mutableMapOf<Int, Boolean>()
         for (range in motions) {
             val axis = range.axis
             val origValue = event.getAxisValue(axis)
             var value = ControllerMappingHelper.scaleAxis(input, axis, origValue)
+            val touchButton = preferences.getInt(
+                InputBindingSetting.getInputAxisButtonKey(axis) + "_Touch", -1
+            )
+            if (touchButton != -1) {
+                touchOnlyAxisState[touchButton] = kotlin.math.abs(value) > 0.5f
+            }
             val nextMapping =
                 preferences.getInt(InputBindingSetting.getInputAxisButtonKey(axis), -1)
             val guestOrientation =
@@ -490,6 +497,14 @@ class EmulationActivity : AppCompatActivity() {
                 } else {
                     NativeLibrary.ButtonState.RELEASED
                 }
+            )
+        }
+        for ((touchButtonType, pressed) in touchOnlyAxisState) {
+            NativeLibrary.onGamePadEvent(
+                NativeLibrary.TouchScreenDevice,
+                touchButtonType,
+                if (pressed) NativeLibrary.ButtonState.PRESSED
+                else NativeLibrary.ButtonState.RELEASED
             )
         }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/SettingKeys.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/SettingKeys.kt
@@ -122,6 +122,8 @@ object SettingKeys {
     external fun udp_input_address(): String
     external fun udp_input_port(): String
     external fun udp_pad_index(): String
+    external fun use_touch_from_button(): String
+    external fun touch_from_button_map(): String
     external fun record_frame_times(): String
 
     // Android

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
@@ -52,6 +52,7 @@ enum class BooleanSetting(
     DEBUG_RENDERER(SettingKeys.renderer_debug(), Settings.SECTION_DEBUG, false),
     DISABLE_RIGHT_EYE_RENDER(SettingKeys.disable_right_eye_render(), Settings.SECTION_RENDERER, false),
     USE_ARTIC_BASE_CONTROLLER(SettingKeys.use_artic_base_controller(), Settings.SECTION_CONTROLS, false),
+    USE_TOUCH_FROM_BUTTON(SettingKeys.use_touch_from_button(), Settings.SECTION_CONTROLS, false),
     UPRIGHT_SCREEN(SettingKeys.upright_screen(), Settings.SECTION_LAYOUT, false),
     COMPRESS_INSTALLED_CIA_CONTENT(SettingKeys.compress_cia_installs(), Settings.SECTION_STORAGE, false),
     ANDROID_HIDE_IMAGES(SettingKeys.android_hide_images(), Settings.SECTION_MISC, false),

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
@@ -56,7 +56,8 @@ enum class IntSetting(
     TURBO_LIMIT(SettingKeys.turbo_limit(), Settings.SECTION_CORE, 200),
     PERFORMANCE_OVERLAY_POSITION(SettingKeys.performance_overlay_position(), Settings.SECTION_LAYOUT, 0),
     RENDER_3D_WHICH_DISPLAY(SettingKeys.render_3d_which_display(),Settings.SECTION_RENDERER,0),
-    ASPECT_RATIO(SettingKeys.aspect_ratio(), Settings.SECTION_LAYOUT, 0);
+    ASPECT_RATIO(SettingKeys.aspect_ratio(), Settings.SECTION_LAYOUT, 0),
+    TOUCH_FROM_BUTTON_MAP(SettingKeys.touch_from_button_map(), Settings.SECTION_CONTROLS, 0);
 
     override var int: Int = defaultValue
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/InputBindingSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/InputBindingSetting.kt
@@ -549,7 +549,7 @@ class InputBindingSetting(
             return buttonCodes.mapNotNull { it.toIntOrNull() }.toMutableSet()
         }
 
-        private fun getInputButtonKey(keyId: Int): String = "${INPUT_MAPPING_PREFIX}_HostAxis_${keyId}"
+        fun getInputButtonKey(keyId: Int): String = "${INPUT_MAPPING_PREFIX}_HostAxis_${keyId}"
 
         /** Falls back to the scan code when keyCode is KEYCODE_UNKNOWN. */
         fun getInputButtonKey(event: KeyEvent): String = getInputButtonKey(translateEventToKeyId(event))

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -839,6 +839,31 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     BooleanSetting.USE_ARTIC_BASE_CONTROLLER.defaultValue
                 )
             )
+            add(HeaderSetting(R.string.touch_from_button))
+            add(
+                SwitchSetting(
+                    BooleanSetting.USE_TOUCH_FROM_BUTTON,
+                    R.string.use_touch_from_button,
+                    R.string.use_touch_from_button_description,
+                    BooleanSetting.USE_TOUCH_FROM_BUTTON.key,
+                    BooleanSetting.USE_TOUCH_FROM_BUTTON.defaultValue
+                )
+            )
+            add(
+                RunnableSetting(
+                    R.string.edit_touch_from_button_maps,
+                    R.string.edit_touch_from_button_maps_description,
+                    false,
+                    R.drawable.ic_controller,
+                    {
+                        val intent = android.content.Intent(
+                            settingsActivity,
+                            org.citra.citra_emu.features.settings.ui.TouchFromButtonMapActivity::class.java
+                        )
+                        settingsActivity.startActivity(intent)
+                    }
+                )
+            )
         }
     }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/TouchButtonPollingDialogFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/TouchButtonPollingDialogFragment.kt
@@ -1,0 +1,146 @@
+// Copyright Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+package org.citra.citra_emu.features.settings.ui
+
+import android.os.Bundle
+import android.view.InputDevice
+import android.view.KeyEvent
+import android.view.LayoutInflater
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import org.citra.citra_emu.databinding.DialogTouchButtonPollingBinding
+import kotlin.math.abs
+
+/**
+ * Result of a button polling operation.
+ * For key events: keyEvent is set, axisId is -1.
+ * For axis events: keyEvent is null, axisId is the motion axis.
+ */
+data class PollingResult(val keyEvent: KeyEvent?, val axisId: Int)
+
+class TouchButtonPollingDialogFragment : BottomSheetDialogFragment() {
+    private var _binding: DialogTouchButtonPollingBinding? = null
+    private val binding get() = _binding!!
+
+    private var onButtonCaptured: ((PollingResult) -> Unit)? = null
+    private var onCancelled: (() -> Unit)? = null
+
+    private val previousValues = ArrayList<Float>()
+    private var prevDeviceId = 0
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (onButtonCaptured == null) {
+            dismiss()
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = DialogTouchButtonPollingBinding.inflate(inflater)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        BottomSheetBehavior.from<View>(view.parent as View).state =
+            BottomSheetBehavior.STATE_EXPANDED
+
+        isCancelable = false
+        view.requestFocus()
+        view.setOnFocusChangeListener { v, hasFocus -> if (!hasFocus) v.requestFocus() }
+
+        // Intercept key events at the dialog level — before view navigation
+        dialog?.setOnKeyListener { _, _, event -> onKeyEvent(event) }
+
+        // Intercept axis/motion events on the root view
+        binding.root.setOnGenericMotionListener { _, event -> onMotionEvent(event) }
+
+        binding.buttonCancel.setOnClickListener {
+            onCancelled?.invoke()
+            dismiss()
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun onKeyEvent(event: KeyEvent): Boolean {
+        if (event.action == KeyEvent.ACTION_DOWN && isGamepadButton(event.keyCode)) {
+            onButtonCaptured?.invoke(PollingResult(event, -1))
+            dismiss()
+            return true
+        }
+        return false
+    }
+
+    private fun onMotionEvent(event: MotionEvent): Boolean {
+        if (event.source and InputDevice.SOURCE_CLASS_JOYSTICK == 0 &&
+            event.source and InputDevice.SOURCE_GAMEPAD == 0) return false
+        if (event.action != MotionEvent.ACTION_MOVE) return false
+
+        val input = event.device ?: return false
+        val motionRanges = input.motionRanges
+
+        if (input.id != prevDeviceId) {
+            previousValues.clear()
+        }
+        prevDeviceId = input.id
+        val firstEvent = previousValues.isEmpty()
+
+        for (i in motionRanges.indices) {
+            val range = motionRanges[i]
+            val axis = range.axis
+            val origValue = event.getAxisValue(axis)
+            if (firstEvent) {
+                previousValues.add(origValue)
+            } else {
+                val previousValue = previousValues[i]
+                if (abs(origValue) > 0.5f && origValue != previousValue) {
+                    // Significant axis movement — capture this axis
+                    onButtonCaptured?.invoke(PollingResult(null, axis))
+                    dismiss()
+                    return true
+                }
+            }
+            if (i < previousValues.size) {
+                previousValues[i] = origValue
+            } else {
+                previousValues.add(origValue)
+            }
+        }
+        return true
+    }
+
+    private fun isGamepadButton(keyCode: Int): Boolean {
+        return keyCode in KeyEvent.KEYCODE_BUTTON_A..KeyEvent.KEYCODE_BUTTON_MODE ||
+                keyCode == KeyEvent.KEYCODE_DPAD_UP ||
+                keyCode == KeyEvent.KEYCODE_DPAD_DOWN ||
+                keyCode == KeyEvent.KEYCODE_DPAD_LEFT ||
+                keyCode == KeyEvent.KEYCODE_DPAD_RIGHT
+    }
+
+    companion object {
+        const val TAG = "TouchButtonPollingDialogFragment"
+
+        fun newInstance(
+            onButtonCaptured: (PollingResult) -> Unit,
+            onCancelled: () -> Unit
+        ): TouchButtonPollingDialogFragment {
+            return TouchButtonPollingDialogFragment().apply {
+                this.onButtonCaptured = onButtonCaptured
+                this.onCancelled = onCancelled
+            }
+        }
+    }
+}

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/TouchFromButtonMapActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/TouchFromButtonMapActivity.kt
@@ -1,0 +1,555 @@
+// Copyright Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+package org.citra.citra_emu.features.settings.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewGroup.MarginLayoutParams
+import android.widget.ArrayAdapter
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
+import androidx.preference.PreferenceManager
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.textfield.MaterialAutoCompleteTextView
+import org.citra.citra_emu.CitraApplication
+import org.citra.citra_emu.NativeLibrary
+import org.citra.citra_emu.R
+import org.citra.citra_emu.databinding.ActivityTouchFromButtonBinding
+import org.citra.citra_emu.databinding.ItemTouchBindingBinding
+import org.citra.citra_emu.features.settings.model.view.InputBindingSetting
+import org.citra.citra_emu.features.settings.utils.SettingsFile
+import org.citra.citra_emu.utils.ThemeUtil
+import org.ini4j.Wini
+
+/**
+ * Activity for editing Touch From Button mapping profiles.
+ * Allows creating/deleting/renaming profiles and adding button→touch coordinate bindings.
+ */
+class TouchFromButtonMapActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityTouchFromButtonBinding
+
+    companion object {
+        const val MAX_TOUCH_BINDINGS = 10
+
+        /**
+         * Register all touch-from-button bindings for the active map profile
+         * into SharedPreferences. Call this on emulation start to ensure the
+         * dispatch loop can fire TOUCH_ONLY_N events.
+         */
+        @JvmStatic
+        fun registerActiveMapBindings() {
+            val preferences = PreferenceManager.getDefaultSharedPreferences(
+                CitraApplication.appContext
+            )
+            val mapCount = NativeLibrary.getTouchFromButtonMapCount()
+            if (mapCount == 0) return
+            // Use map index 0 (active map is stored in settings, default 0)
+            val activeIndex = 0.coerceIn(0, mapCount - 1)
+            val bindsArray = NativeLibrary.getTouchFromButtonMapBinds(activeIndex)
+            val editor = preferences.edit()
+            for (bindStr in bindsArray) {
+                val params = mutableMapOf<String, String>()
+                for (part in bindStr.split(",")) {
+                    val kv = part.split(":", limit = 2)
+                    if (kv.size == 2) params[kv[0]] = kv[1]
+                }
+                val code = params["code"]?.toIntOrNull() ?: continue
+                val srcKey = params["src_key"]?.toIntOrNull() ?: -1
+                val srcAxis = params["src_axis"]?.toIntOrNull() ?: -1
+                if (srcKey >= 0) {
+                    val prefKey = InputBindingSetting.getInputButtonKey(srcKey)
+                    val existing = try {
+                        preferences.getStringSet(prefKey, mutableSetOf())?.toMutableSet()
+                            ?: mutableSetOf()
+                    } catch (e: ClassCastException) {
+                        mutableSetOf()
+                    }
+                    existing.add(code.toString())
+                    editor.putStringSet(prefKey, existing)
+                } else if (srcAxis >= 0) {
+                    val prefKey =
+                        InputBindingSetting.getInputAxisButtonKey(srcAxis) + "_Touch"
+                    editor.putInt(prefKey, code)
+                }
+            }
+            editor.apply()
+        }
+    }
+
+    // Data: list of map profiles, each containing a name and list of bindings
+    // srcKey: Android KeyEvent keyCode that triggers this binding (-1 if axis-based)
+    // srcAxis: Android MotionEvent axis ID that triggers this binding (-1 if key-based)
+    // touchOnlySlot: the TOUCH_ONLY_N slot (1-10) allocated for this binding
+    data class TouchBinding(
+        val touchOnlySlot: Int,
+        var x: Int,
+        var y: Int,
+        val srcKey: Int = -1,
+        val srcAxis: Int = -1
+    )
+    data class TouchMap(var name: String, val bindings: MutableList<TouchBinding>)
+
+    private val maps = mutableListOf<TouchMap>()
+    private var currentMapIndex = 0
+
+    private lateinit var bindingsAdapter: BindingsAdapter
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        ThemeUtil.setTheme(this)
+        super.onCreate(savedInstanceState)
+
+        binding = ActivityTouchFromButtonBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+
+        binding.toolbar.setNavigationOnClickListener { onBackPressedDispatcher.onBackPressed() }
+
+        setInsets()
+
+        loadMaps()
+        registerCurrentMapBindings()
+        setupMapSelector()
+        setupBindingsList()
+        setupPreview()
+        setupButtons()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        saveMaps()
+        unregisterAllTouchBindings()
+        registerCurrentMapBindings()
+    }
+
+    private fun loadMaps() {
+        maps.clear()
+        val mapCount = NativeLibrary.getTouchFromButtonMapCount()
+        for (i in 0 until mapCount) {
+            val name = NativeLibrary.getTouchFromButtonMapName(i)
+            val bindsArray = NativeLibrary.getTouchFromButtonMapBinds(i)
+            val bindings = mutableListOf<TouchBinding>()
+            for (bindStr in bindsArray) {
+                val binding = parseBinding(bindStr)
+                if (binding != null) {
+                    bindings.add(binding)
+                }
+            }
+            maps.add(TouchMap(name, bindings))
+        }
+        if (maps.isEmpty()) {
+            maps.add(TouchMap("default", mutableListOf()))
+        }
+        currentMapIndex = currentMapIndex.coerceIn(0, maps.size - 1)
+    }
+
+    private fun saveMaps() {
+        val names = maps.map { it.name }.toTypedArray()
+        val binds = maps.map { map ->
+            map.bindings.map { serializeBinding(it) }.toTypedArray()
+        }.toTypedArray()
+        NativeLibrary.setTouchFromButtonMaps(names, binds)
+
+        saveToConfigIni()
+
+        NativeLibrary.reloadTouchFromButtonMaps()
+    }
+
+    private fun saveToConfigIni() {
+        try {
+            val configFile = SettingsFile.getSettingsFile(SettingsFile.FILE_NAME_CONFIG)
+            val context = applicationContext
+            val inputStream = context.contentResolver.openInputStream(configFile.uri)
+            val writer = Wini(inputStream)
+            inputStream?.close()
+
+            writer.put("Controls", "touch_from_button_map_count", maps.size)
+            for (i in maps.indices) {
+                writer.put("Controls", "touch_from_button_map_${i}_name", maps[i].name)
+                writer.put("Controls", "touch_from_button_map_${i}_bind_count", maps[i].bindings.size)
+                for (j in maps[i].bindings.indices) {
+                    writer.put(
+                        "Controls",
+                        "touch_from_button_map_${i}_bind_${j}",
+                        serializeBinding(maps[i].bindings[j])
+                    )
+                }
+            }
+
+            val outputStream = context.contentResolver.openOutputStream(configFile.uri, "wt")
+            writer.store(outputStream)
+            outputStream?.flush()
+            outputStream?.close()
+        } catch (e: Exception) {
+            Toast.makeText(this, "Error saving touch maps: ${e.message}", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun parseBinding(str: String): TouchBinding? {
+        // Format: "engine:gamepad,code:<TOUCH_ONLY_N>,x:<x>,y:<y>,src_key:<keyId>"
+        //     or: "engine:gamepad,code:<TOUCH_ONLY_N>,x:<x>,y:<y>,src_axis:<axisId>"
+        val params = mutableMapOf<String, String>()
+        for (part in str.split(",")) {
+            val kv = part.split(":", limit = 2)
+            if (kv.size == 2) {
+                params[kv[0]] = kv[1]
+            }
+        }
+        val code = params["code"]?.toIntOrNull() ?: return null
+        val x = params["x"]?.toIntOrNull() ?: 160
+        val y = params["y"]?.toIntOrNull() ?: 120
+        val srcKey = params["src_key"]?.toIntOrNull() ?: -1
+        val srcAxis = params["src_axis"]?.toIntOrNull() ?: -1
+        // Derive the slot number from the code (900 → 1, 901 → 2, etc.)
+        val slot = code - NativeLibrary.ButtonType.TOUCH_ONLY_1 + 1
+        return TouchBinding(slot.coerceIn(1, MAX_TOUCH_BINDINGS), x, y, srcKey, srcAxis)
+    }
+
+    private fun serializeBinding(binding: TouchBinding): String {
+        val code = NativeLibrary.ButtonType.TOUCH_ONLY_1 + binding.touchOnlySlot - 1
+        val sb = StringBuilder("engine:gamepad,code:$code,x:${binding.x},y:${binding.y}")
+        if (binding.srcKey >= 0) sb.append(",src_key:${binding.srcKey}")
+        if (binding.srcAxis >= 0) sb.append(",src_axis:${binding.srcAxis}")
+        return sb.toString()
+    }
+
+    private fun setupMapSelector() {
+        updateMapSelector()
+    }
+
+    private fun updateMapSelector() {
+        val adapter = ArrayAdapter(this, android.R.layout.simple_dropdown_item_1line,
+            maps.map { it.name })
+        (binding.mapSelector as MaterialAutoCompleteTextView).apply {
+            setAdapter(adapter)
+            setText(maps.getOrNull(currentMapIndex)?.name ?: "", false)
+            setOnItemClickListener { _, _, position, _ ->
+                unregisterAllTouchBindings()
+                currentMapIndex = position
+                registerCurrentMapBindings()
+                refreshBindings()
+            }
+        }
+    }
+
+    private fun setupButtons() {
+        binding.buttonNewMap.setOnClickListener { showNewMapDialog() }
+        binding.buttonRenameMap.setOnClickListener { showRenameMapDialog() }
+        binding.buttonDeleteMap.setOnClickListener { showDeleteMapDialog() }
+        binding.fabAddBinding.setOnClickListener { startAddBinding() }
+    }
+
+    private fun showNewMapDialog() {
+        val input = android.widget.EditText(this)
+        input.hint = getString(R.string.touch_from_button_enter_map_name)
+        MaterialAlertDialogBuilder(this)
+            .setTitle(R.string.touch_from_button_new_map)
+            .setView(input)
+            .setPositiveButton(android.R.string.ok) { _, _ ->
+                val name = input.text.toString().trim()
+                if (name.isNotEmpty()) {
+                    maps.add(TouchMap(name, mutableListOf()))
+                    currentMapIndex = maps.size - 1
+                    updateMapSelector()
+                    refreshBindings()
+                    saveMaps()
+                }
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun showRenameMapDialog() {
+        if (maps.isEmpty()) return
+        val input = android.widget.EditText(this)
+        input.setText(maps[currentMapIndex].name)
+        MaterialAlertDialogBuilder(this)
+            .setTitle(R.string.touch_from_button_rename_map)
+            .setView(input)
+            .setPositiveButton(android.R.string.ok) { _, _ ->
+                val name = input.text.toString().trim()
+                if (name.isNotEmpty()) {
+                    maps[currentMapIndex].name = name
+                    updateMapSelector()
+                    saveMaps()
+                }
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun showDeleteMapDialog() {
+        if (maps.size <= 1) {
+            Toast.makeText(this, "Cannot delete the last map", Toast.LENGTH_SHORT).show()
+            return
+        }
+        MaterialAlertDialogBuilder(this)
+            .setTitle(R.string.touch_from_button_delete_map)
+            .setMessage(R.string.touch_from_button_delete_confirm)
+            .setPositiveButton(android.R.string.ok) { _, _ ->
+                unregisterAllTouchBindings()
+                maps.removeAt(currentMapIndex)
+                currentMapIndex = currentMapIndex.coerceIn(0, maps.size - 1)
+                registerCurrentMapBindings()
+                updateMapSelector()
+                refreshBindings()
+                saveMaps()
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun startAddBinding() {
+        val currentBindings = maps.getOrNull(currentMapIndex)?.bindings ?: emptyList()
+        if (currentBindings.size >= MAX_TOUCH_BINDINGS) {
+            Toast.makeText(this, "Maximum $MAX_TOUCH_BINDINGS bindings reached", Toast.LENGTH_SHORT).show()
+            return
+        }
+        TouchButtonPollingDialogFragment.newInstance(
+            onButtonCaptured = { result ->
+                promptTapPosition(result)
+            },
+            onCancelled = { /* nothing to do */ }
+        ).show(supportFragmentManager, TouchButtonPollingDialogFragment.TAG)
+    }
+
+    private fun promptTapPosition(result: PollingResult) {
+        Toast.makeText(this, R.string.touch_from_button_tap_position, Toast.LENGTH_LONG).show()
+        binding.touchScreenPreview.enableTapMode()
+        binding.touchScreenPreview.onPointAdded = { x, y ->
+            binding.touchScreenPreview.onPointAdded = null
+            addBindingToCurrentMap(result, x, y)
+        }
+    }
+
+    private fun addBindingToCurrentMap(result: PollingResult, x: Int, y: Int) {
+        if (maps.isEmpty()) return
+        val slot = allocateTouchOnlySlot()
+        if (slot == -1) {
+            Toast.makeText(this, "Maximum $MAX_TOUCH_BINDINGS bindings reached", Toast.LENGTH_SHORT).show()
+            return
+        }
+        val srcKey = if (result.keyEvent != null)
+            InputBindingSetting.translateEventToKeyId(result.keyEvent) else -1
+        val srcAxis = result.axisId
+        val touchBinding = TouchBinding(slot, x, y, srcKey, srcAxis)
+        maps[currentMapIndex].bindings.add(touchBinding)
+        registerBinding(touchBinding)
+        refreshBindings()
+        saveMaps()
+    }
+
+    /** Allocate the next available TOUCH_ONLY slot (1-10) in the current map. */
+    private fun allocateTouchOnlySlot(): Int {
+        val usedSlots = maps.getOrNull(currentMapIndex)?.bindings?.map { it.touchOnlySlot }?.toSet()
+            ?: emptySet()
+        for (slot in 1..MAX_TOUCH_BINDINGS) {
+            if (slot !in usedSlots) return slot
+        }
+        return -1
+    }
+
+    /**
+     * Register a single touch binding in SharedPreferences so that the emulation
+     * dispatch loop can fire the corresponding TOUCH_ONLY_N button event.
+     */
+    private fun registerBinding(binding: TouchBinding) {
+        val preferences = PreferenceManager.getDefaultSharedPreferences(CitraApplication.appContext)
+        val editor = preferences.edit()
+        val touchOnlyButtonType = NativeLibrary.ButtonType.TOUCH_ONLY_1 + binding.touchOnlySlot - 1
+        if (binding.srcKey >= 0) {
+            // Key-based: append TOUCH_ONLY_N to the existing StringSet for this keycode
+            val prefKey = InputBindingSetting.getInputButtonKey(binding.srcKey)
+            val existing = try {
+                preferences.getStringSet(prefKey, mutableSetOf())?.toMutableSet() ?: mutableSetOf()
+            } catch (e: ClassCastException) {
+                mutableSetOf()
+            }
+            existing.add(touchOnlyButtonType.toString())
+            editor.putStringSet(prefKey, existing)
+        } else if (binding.srcAxis >= 0) {
+            // Axis-based: write to a separate "_Touch" key to avoid overwriting 3DS axis mapping
+            val prefKey = InputBindingSetting.getInputAxisButtonKey(binding.srcAxis) + "_Touch"
+            editor.putInt(prefKey, touchOnlyButtonType)
+        }
+        editor.apply()
+    }
+
+    private fun unregisterBinding(binding: TouchBinding) {
+        val preferences = PreferenceManager.getDefaultSharedPreferences(CitraApplication.appContext)
+        val editor = preferences.edit()
+        val touchOnlyButtonType = NativeLibrary.ButtonType.TOUCH_ONLY_1 + binding.touchOnlySlot - 1
+        if (binding.srcKey >= 0) {
+            val prefKey = InputBindingSetting.getInputButtonKey(binding.srcKey)
+            val existing = try {
+                preferences.getStringSet(prefKey, mutableSetOf())?.toMutableSet() ?: mutableSetOf()
+            } catch (e: ClassCastException) {
+                mutableSetOf()
+            }
+            existing.remove(touchOnlyButtonType.toString())
+            editor.putStringSet(prefKey, existing)
+        } else if (binding.srcAxis >= 0) {
+            val prefKey = InputBindingSetting.getInputAxisButtonKey(binding.srcAxis) + "_Touch"
+            editor.remove(prefKey)
+        }
+        editor.apply()
+    }
+
+    private fun unregisterAllTouchBindings() {
+        val preferences = PreferenceManager.getDefaultSharedPreferences(CitraApplication.appContext)
+        val editor = preferences.edit()
+        // Remove TOUCH_ONLY values from all button StringSets
+        for (map in maps) {
+            for (b in map.bindings) {
+                val touchType = NativeLibrary.ButtonType.TOUCH_ONLY_1 + b.touchOnlySlot - 1
+                if (b.srcKey >= 0) {
+                    val prefKey = InputBindingSetting.getInputButtonKey(b.srcKey)
+                    val existing = try {
+                        preferences.getStringSet(prefKey, mutableSetOf())?.toMutableSet()
+                            ?: mutableSetOf()
+                    } catch (e: ClassCastException) {
+                        mutableSetOf()
+                    }
+                    existing.remove(touchType.toString())
+                    editor.putStringSet(prefKey, existing)
+                } else if (b.srcAxis >= 0) {
+                    val prefKey = InputBindingSetting.getInputAxisButtonKey(b.srcAxis) + "_Touch"
+                    editor.remove(prefKey)
+                }
+            }
+        }
+        editor.apply()
+    }
+
+    /** Register all bindings from the current map profile in SharedPreferences. */
+    private fun registerCurrentMapBindings() {
+        val currentBindings = maps.getOrNull(currentMapIndex)?.bindings ?: return
+        for (b in currentBindings) {
+            registerBinding(b)
+        }
+    }
+
+    private fun setupBindingsList() {
+        bindingsAdapter = BindingsAdapter()
+        binding.bindingsList.layoutManager = LinearLayoutManager(this)
+        binding.bindingsList.adapter = bindingsAdapter
+        refreshBindings()
+    }
+
+    private fun refreshBindings() {
+        val currentBindings = maps.getOrNull(currentMapIndex)?.bindings ?: emptyList()
+        bindingsAdapter.submitList(currentBindings.toList())
+        updatePreviewPoints()
+    }
+
+    private fun setupPreview() {
+        binding.touchScreenPreview.onPointMoved = { index, x, y ->
+            if (currentMapIndex in maps.indices) {
+                val bindings = maps[currentMapIndex].bindings
+                if (index in bindings.indices) {
+                    bindings[index].x = x
+                    bindings[index].y = y
+                    bindingsAdapter.notifyItemChanged(index)
+                    saveMaps()
+                }
+            }
+        }
+        binding.touchScreenPreview.onPointSelected = { index ->
+            bindingsAdapter.setSelectedIndex(index)
+        }
+        updatePreviewPoints()
+    }
+
+    private fun updatePreviewPoints() {
+        val currentBindings = maps.getOrNull(currentMapIndex)?.bindings ?: emptyList()
+        val points = currentBindings.map {
+            TouchScreenPreviewView.TouchPoint(it.x, it.y, it.touchOnlySlot)
+        }
+        binding.touchScreenPreview.setPoints(points)
+    }
+
+    private fun setInsets() {
+        ViewCompat.setOnApplyWindowInsetsListener(binding.appbar) { view, windowInsets ->
+            val barInsets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            val cutoutInsets = windowInsets.getInsets(WindowInsetsCompat.Type.displayCutout())
+            val mlp = view.layoutParams as MarginLayoutParams
+            mlp.topMargin = barInsets.top
+            mlp.leftMargin = barInsets.left + cutoutInsets.left
+            mlp.rightMargin = barInsets.right + cutoutInsets.right
+            view.layoutParams = mlp
+
+            val mlpShade = binding.navigationBarShade.layoutParams as MarginLayoutParams
+            mlpShade.height = barInsets.bottom
+            binding.navigationBarShade.layoutParams = mlpShade
+
+            windowInsets
+        }
+    }
+
+    inner class BindingsAdapter : RecyclerView.Adapter<BindingsAdapter.ViewHolder>() {
+        private var items = listOf<TouchBinding>()
+        private var selectedIndex = -1
+
+        fun submitList(newItems: List<TouchBinding>) {
+            items = newItems
+            notifyDataSetChanged()
+        }
+
+        fun setSelectedIndex(index: Int) {
+            val old = selectedIndex
+            selectedIndex = index
+            if (old >= 0 && old < items.size) notifyItemChanged(old)
+            if (index >= 0 && index < items.size) notifyItemChanged(index)
+        }
+
+        inner class ViewHolder(val binding: ItemTouchBindingBinding) :
+            RecyclerView.ViewHolder(binding.root)
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+            val itemBinding = ItemTouchBindingBinding.inflate(
+                LayoutInflater.from(parent.context), parent, false
+            )
+            return ViewHolder(itemBinding)
+        }
+
+        override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+            val item = items[position]
+            val srcLabel = when {
+                item.srcKey >= 0 -> "Key ${item.srcKey}"
+                item.srcAxis >= 0 -> "Axis ${item.srcAxis}"
+                else -> "?"
+            }
+            holder.binding.textBindingInfo.text =
+                getString(R.string.touch_from_button_binding_format, srcLabel, item.x, item.y)
+
+            holder.itemView.isSelected = position == selectedIndex
+            holder.itemView.alpha = if (position == selectedIndex) 1.0f else 0.8f
+
+            holder.itemView.setOnClickListener {
+                this@TouchFromButtonMapActivity.binding.touchScreenPreview.setSelectedIndex(position)
+                setSelectedIndex(position)
+            }
+
+            holder.binding.buttonDeleteBinding.setOnClickListener {
+                if (currentMapIndex in maps.indices) {
+                    val removed = maps[currentMapIndex].bindings.removeAt(position)
+                    unregisterBinding(removed)
+                    refreshBindings()
+                    saveMaps()
+                }
+            }
+        }
+
+        override fun getItemCount() = items.size
+    }
+}

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/TouchScreenPreviewView.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/TouchScreenPreviewView.kt
@@ -1,0 +1,233 @@
+// Copyright Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+package org.citra.citra_emu.features.settings.ui
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.RectF
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.view.View
+
+/**
+ * A custom View that renders a preview of the 3DS bottom screen (320x240)
+ * with draggable dots representing mapped touch points.
+ */
+class TouchScreenPreviewView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : View(context, attrs, defStyleAttr) {
+
+    companion object {
+        const val SCREEN_WIDTH = 320
+        const val SCREEN_HEIGHT = 240
+        private const val DOT_RADIUS = 12f
+        private const val DRAG_THRESHOLD = 30f
+    }
+
+    data class TouchPoint(var x: Int, var y: Int, val buttonId: Int)
+
+    private val points = mutableListOf<TouchPoint>()
+    private var selectedIndex = -1
+    private var draggingIndex = -1
+    private var tapMode = false
+
+    private val screenRect = RectF()
+
+    private val screenPaint = Paint().apply {
+        color = Color.BLACK
+        style = Paint.Style.FILL
+    }
+    private val borderPaint = Paint().apply {
+        color = Color.GRAY
+        style = Paint.Style.STROKE
+        strokeWidth = 2f
+    }
+    private val dotPaint = Paint().apply {
+        color = Color.RED
+        style = Paint.Style.FILL
+        isAntiAlias = true
+    }
+    private val selectedDotPaint = Paint().apply {
+        color = Color.YELLOW
+        style = Paint.Style.FILL
+        isAntiAlias = true
+    }
+    private val textPaint = Paint().apply {
+        color = Color.WHITE
+        textSize = 24f
+        textAlign = Paint.Align.CENTER
+        isAntiAlias = true
+    }
+
+    var onPointAdded: ((x: Int, y: Int) -> Unit)? = null
+    var onPointMoved: ((index: Int, x: Int, y: Int) -> Unit)? = null
+    var onPointSelected: ((index: Int) -> Unit)? = null
+
+    fun setPoints(newPoints: List<TouchPoint>) {
+        points.clear()
+        points.addAll(newPoints)
+        invalidate()
+    }
+
+    fun addPoint(point: TouchPoint) {
+        points.add(point)
+        invalidate()
+    }
+
+    fun removePoint(index: Int) {
+        if (index in points.indices) {
+            points.removeAt(index)
+            if (selectedIndex == index) selectedIndex = -1
+            else if (selectedIndex > index) selectedIndex--
+            invalidate()
+        }
+    }
+
+    fun setSelectedIndex(index: Int) {
+        selectedIndex = index
+        invalidate()
+    }
+
+    fun enableTapMode() {
+        tapMode = true
+    }
+
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        calculateScreenRect(w, h)
+    }
+
+    private fun calculateScreenRect(viewWidth: Int, viewHeight: Int) {
+        val aspectRatio = SCREEN_WIDTH.toFloat() / SCREEN_HEIGHT.toFloat()
+        val viewAspect = viewWidth.toFloat() / viewHeight.toFloat()
+
+        val screenW: Float
+        val screenH: Float
+        if (viewAspect > aspectRatio) {
+            screenH = viewHeight.toFloat()
+            screenW = screenH * aspectRatio
+        } else {
+            screenW = viewWidth.toFloat()
+            screenH = screenW / aspectRatio
+        }
+
+        val left = (viewWidth - screenW) / 2f
+        val top = (viewHeight - screenH) / 2f
+        screenRect.set(left, top, left + screenW, top + screenH)
+    }
+
+    private fun screenToView(screenX: Int, screenY: Int): Pair<Float, Float> {
+        val vx = screenRect.left + (screenX.toFloat() / SCREEN_WIDTH) * screenRect.width()
+        val vy = screenRect.top + (screenY.toFloat() / SCREEN_HEIGHT) * screenRect.height()
+        return Pair(vx, vy)
+    }
+
+    private fun viewToScreen(viewX: Float, viewY: Float): Pair<Int, Int> {
+        val sx = ((viewX - screenRect.left) / screenRect.width() * SCREEN_WIDTH)
+            .toInt().coerceIn(0, SCREEN_WIDTH - 1)
+        val sy = ((viewY - screenRect.top) / screenRect.height() * SCREEN_HEIGHT)
+            .toInt().coerceIn(0, SCREEN_HEIGHT - 1)
+        return Pair(sx, sy)
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+
+        // Draw screen background
+        canvas.drawRect(screenRect, screenPaint)
+        canvas.drawRect(screenRect, borderPaint)
+
+        // Draw grid lines for reference
+        val gridPaint = Paint().apply {
+            color = Color.DKGRAY
+            style = Paint.Style.STROKE
+            strokeWidth = 1f
+        }
+        for (i in 1..3) {
+            val x = screenRect.left + screenRect.width() * i / 4f
+            canvas.drawLine(x, screenRect.top, x, screenRect.bottom, gridPaint)
+        }
+        for (i in 1..2) {
+            val y = screenRect.top + screenRect.height() * i / 3f
+            canvas.drawLine(screenRect.left, y, screenRect.right, y, gridPaint)
+        }
+
+        // Draw coordinate label
+        val labelPaint = Paint().apply {
+            color = Color.GRAY
+            textSize = 20f
+            isAntiAlias = true
+        }
+        canvas.drawText("3DS Bottom Screen (320×240)", screenRect.left + 8, screenRect.top + 20, labelPaint)
+
+        // Draw touch points
+        points.forEachIndexed { index, point ->
+            val (vx, vy) = screenToView(point.x, point.y)
+            val paint = if (index == selectedIndex) selectedDotPaint else dotPaint
+            canvas.drawCircle(vx, vy, DOT_RADIUS, paint)
+            canvas.drawText("${index + 1}", vx, vy + 6f, textPaint)
+        }
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        when (event.action) {
+            MotionEvent.ACTION_DOWN -> {
+                val touchX = event.x
+                val touchY = event.y
+
+                if (tapMode) {
+                    if (screenRect.contains(touchX, touchY)) {
+                        val (sx, sy) = viewToScreen(touchX, touchY)
+                        tapMode = false
+                        onPointAdded?.invoke(sx, sy)
+                        return true
+                    }
+                    return true
+                }
+
+                // Check if touching an existing point
+                draggingIndex = -1
+                for (i in points.indices.reversed()) {
+                    val (vx, vy) = screenToView(points[i].x, points[i].y)
+                    val dx = touchX - vx
+                    val dy = touchY - vy
+                    if (dx * dx + dy * dy < DRAG_THRESHOLD * DRAG_THRESHOLD) {
+                        draggingIndex = i
+                        selectedIndex = i
+                        onPointSelected?.invoke(i)
+                        invalidate()
+                        return true
+                    }
+                }
+                return true
+            }
+            MotionEvent.ACTION_MOVE -> {
+                if (draggingIndex >= 0 && screenRect.contains(event.x, event.y)) {
+                    val (sx, sy) = viewToScreen(event.x, event.y)
+                    points[draggingIndex].x = sx
+                    points[draggingIndex].y = sy
+                    invalidate()
+                    return true
+                }
+            }
+            MotionEvent.ACTION_UP -> {
+                if (draggingIndex >= 0) {
+                    val (sx, sy) = viewToScreen(event.x, event.y)
+                    points[draggingIndex].x = sx.coerceIn(0, SCREEN_WIDTH - 1)
+                    points[draggingIndex].y = sy.coerceIn(0, SCREEN_HEIGHT - 1)
+                    onPointMoved?.invoke(draggingIndex, points[draggingIndex].x, points[draggingIndex].y)
+                    draggingIndex = -1
+                    invalidate()
+                    return true
+                }
+            }
+        }
+        return super.onTouchEvent(event)
+    }
+}

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -132,6 +132,45 @@ void Config::ReadValues() {
         static_cast<u16>(android_config->GetInteger("Controls", "udp_input_port",
                                                     InputCommon::CemuhookUDP::DEFAULT_PORT));
 
+    // Touch from button mapping setup
+    Settings::values.current_input_profile.use_touch_from_button =
+        android_config->GetBoolean("Controls", "use_touch_from_button", false);
+    Settings::values.current_input_profile.touch_from_button_map_index =
+        static_cast<int>(android_config->GetInteger("Controls", "touch_from_button_map", 0));
+
+    Settings::values.touch_from_button_maps.clear();
+    int num_touch_maps =
+        static_cast<int>(android_config->GetInteger("Controls", "touch_from_button_map_count", 0));
+    if (num_touch_maps == 0) {
+        Settings::TouchFromButtonMap default_map;
+        default_map.name = "default";
+        Settings::values.touch_from_button_maps.push_back(std::move(default_map));
+    } else {
+        for (int i = 0; i < num_touch_maps; ++i) {
+            Settings::TouchFromButtonMap map;
+            map.name = android_config->GetString(
+                "Controls", "touch_from_button_map_" + std::to_string(i) + "_name", "default");
+            int num_binds = static_cast<int>(android_config->GetInteger(
+                "Controls", "touch_from_button_map_" + std::to_string(i) + "_bind_count", 0));
+            for (int j = 0; j < num_binds; ++j) {
+                std::string bind = android_config->GetString(
+                    "Controls",
+                    "touch_from_button_map_" + std::to_string(i) + "_bind_" + std::to_string(j),
+                    "");
+                if (!bind.empty()) {
+                    map.buttons.push_back(std::move(bind));
+                }
+            }
+            Settings::values.touch_from_button_maps.push_back(std::move(map));
+        }
+    }
+
+    if (Settings::values.current_input_profile.touch_from_button_map_index < 0 ||
+        Settings::values.current_input_profile.touch_from_button_map_index >=
+            static_cast<int>(Settings::values.touch_from_button_maps.size())) {
+        Settings::values.current_input_profile.touch_from_button_map_index = 0;
+    }
+
     ReadSetting("Controls", Settings::values.use_artic_base_controller);
 
     // Core

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -74,6 +74,15 @@ static const char* android_config_default_file_content = (BOOST_HANA_STRING(R"(
 # The pad to request data on. Should be between 0 (Pad 1) and 3 (Pad 4). (Default 0)
 )") DECLARE_KEY(udp_pad_index) BOOST_HANA_STRING(R"(
 
+# Whether to use touch-from-button mapping
+# Maps controller button presses to touch points on the 3DS bottom screen
+# 0 (default): Off, 1: On
+)") DECLARE_KEY(use_touch_from_button) BOOST_HANA_STRING(R"(
+
+# The index of the active touch-from-button map profile
+# Default: 0
+)") DECLARE_KEY(touch_from_button_map) BOOST_HANA_STRING(R"(
+
 # Use Artic Controller when connected to Artic Base Server. (Default 0)
 )") DECLARE_KEY(use_artic_base_controller) BOOST_HANA_STRING(R"(
 

--- a/src/android/app/src/main/jni/input_manager.cpp
+++ b/src/android/app/src/main/jni/input_manager.cpp
@@ -14,6 +14,7 @@
 #include "common/param_package.h"
 #include "input_common/main.h"
 #include "input_common/sdl/sdl.h"
+#include "input_common/touch_from_button.h"
 #include "jni/input_manager.h"
 #include "jni/ndk_motion.h"
 
@@ -318,12 +319,15 @@ void Init() {
     Input::RegisterFactory<Input::ButtonDevice>("gamepad", button);
     Input::RegisterFactory<Input::AnalogDevice>("gamepad", analog);
     Input::RegisterFactory<Input::MotionDevice>("motion_emu", motion);
+    Input::RegisterFactory<Input::TouchDevice>("touch_from_button",
+                                               std::make_shared<InputCommon::TouchFromButtonFactory>());
 }
 
 void Shutdown() {
     Input::UnregisterFactory<Input::ButtonDevice>("gamepad");
     Input::UnregisterFactory<Input::AnalogDevice>("gamepad");
     Input::UnregisterFactory<Input::MotionDevice>("motion_emu");
+    Input::UnregisterFactory<Input::TouchDevice>("touch_from_button");
     button.reset();
     analog.reset();
     motion.reset();

--- a/src/android/app/src/main/jni/input_manager.h
+++ b/src/android/app/src/main/jni/input_manager.h
@@ -39,7 +39,18 @@ enum ButtonType {
     N3DS_TRIGGER_L = 773,
     N3DS_TRIGGER_R = 774,
     N3DS_BUTTON_DEBUG = 781,
-    N3DS_BUTTON_GPIO14 = 782
+    N3DS_BUTTON_GPIO14 = 782,
+    // Dedicated touch buttons used for touch mapping.
+    TOUCH_ONLY_1 = 900,
+    TOUCH_ONLY_2 = 901,
+    TOUCH_ONLY_3 = 902,
+    TOUCH_ONLY_4 = 903,
+    TOUCH_ONLY_5 = 904,
+    TOUCH_ONLY_6 = 905,
+    TOUCH_ONLY_7 = 906,
+    TOUCH_ONLY_8 = 907,
+    TOUCH_ONLY_9 = 908,
+    TOUCH_ONLY_10 = 909
 };
 
 class ButtonList;

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -1170,4 +1170,71 @@ void Java_org_citra_citra_1emu_NativeLibrary_deleteVulkanShaderCache(JNIEnv* env
         });
 }
 
+jint Java_org_citra_citra_1emu_NativeLibrary_getTouchFromButtonMapCount(
+    [[maybe_unused]] JNIEnv* env, [[maybe_unused]] jobject obj) {
+    return static_cast<jint>(Settings::values.touch_from_button_maps.size());
+}
+
+jstring Java_org_citra_citra_1emu_NativeLibrary_getTouchFromButtonMapName(
+    JNIEnv* env, [[maybe_unused]] jobject obj, jint index) {
+    if (index < 0 || index >= static_cast<jint>(Settings::values.touch_from_button_maps.size())) {
+        return env->NewStringUTF("");
+    }
+    return env->NewStringUTF(Settings::values.touch_from_button_maps[index].name.c_str());
+}
+
+jobjectArray Java_org_citra_citra_1emu_NativeLibrary_getTouchFromButtonMapBinds(
+    JNIEnv* env, [[maybe_unused]] jobject obj, jint index) {
+    if (index < 0 || index >= static_cast<jint>(Settings::values.touch_from_button_maps.size())) {
+        return env->NewObjectArray(0, env->FindClass("java/lang/String"), nullptr);
+    }
+    const auto& buttons = Settings::values.touch_from_button_maps[index].buttons;
+    jobjectArray result = env->NewObjectArray(static_cast<jsize>(buttons.size()),
+                                              env->FindClass("java/lang/String"), nullptr);
+    for (jsize i = 0; i < static_cast<jsize>(buttons.size()); ++i) {
+        env->SetObjectArrayElement(result, i, env->NewStringUTF(buttons[i].c_str()));
+    }
+    return result;
+}
+
+void Java_org_citra_citra_1emu_NativeLibrary_setTouchFromButtonMaps(
+    JNIEnv* env, [[maybe_unused]] jobject obj, jobjectArray j_map_names,
+    jobjectArray j_map_binds_arrays) {
+    const jsize map_count = env->GetArrayLength(j_map_names);
+    Settings::values.touch_from_button_maps.clear();
+    for (jsize i = 0; i < map_count; ++i) {
+        Settings::TouchFromButtonMap map;
+        auto j_name = static_cast<jstring>(env->GetObjectArrayElement(j_map_names, i));
+        map.name = GetJString(env, j_name);
+
+        auto j_binds =
+            static_cast<jobjectArray>(env->GetObjectArrayElement(j_map_binds_arrays, i));
+        const jsize bind_count = env->GetArrayLength(j_binds);
+        for (jsize j = 0; j < bind_count; ++j) {
+            auto j_bind = static_cast<jstring>(env->GetObjectArrayElement(j_binds, j));
+            map.buttons.push_back(GetJString(env, j_bind));
+        }
+        Settings::values.touch_from_button_maps.push_back(std::move(map));
+    }
+
+    if (Settings::values.touch_from_button_maps.empty()) {
+        Settings::TouchFromButtonMap default_map;
+        default_map.name = "default";
+        Settings::values.touch_from_button_maps.push_back(std::move(default_map));
+    }
+
+    if (Settings::values.current_input_profile.touch_from_button_map_index >=
+        static_cast<int>(Settings::values.touch_from_button_maps.size())) {
+        Settings::values.current_input_profile.touch_from_button_map_index = 0;
+    }
+}
+
+void Java_org_citra_citra_1emu_NativeLibrary_reloadTouchFromButtonMaps(
+    [[maybe_unused]] JNIEnv* env, [[maybe_unused]] jobject obj) {
+    Core::System& system{Core::System::GetInstance()};
+    if (system.IsPoweredOn()) {
+        system.ApplySettings();
+    }
+}
+
 } // extern "C"

--- a/src/android/app/src/main/res/layout/activity_touch_from_button.xml
+++ b/src/android/app/src/main/res/layout/activity_touch_from_button.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:title="@string/edit_touch_from_button_maps"
+            app:navigationIcon="?attr/homeAsUpIndicator" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <!-- Map profile selector -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:padding="16dp"
+            android:gravity="center_vertical">
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/map_selector_layout"
+                style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:hint="@string/touch_from_button_map_profile">
+
+                <com.google.android.material.textfield.MaterialAutoCompleteTextView
+                    android:id="@+id/map_selector"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="none" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <ImageButton
+                android:id="@+id/button_new_map"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:layout_marginStart="8dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/touch_from_button_new_map"
+                android:src="@android:drawable/ic_input_add"
+                app:tint="?attr/colorOnSurface" />
+
+            <ImageButton
+                android:id="@+id/button_rename_map"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/touch_from_button_rename_map"
+                android:src="@android:drawable/ic_menu_edit"
+                app:tint="?attr/colorOnSurface" />
+
+            <ImageButton
+                android:id="@+id/button_delete_map"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/touch_from_button_delete_map"
+                android:src="@android:drawable/ic_menu_delete"
+                app:tint="?attr/colorOnSurface" />
+
+        </LinearLayout>
+
+        <!-- Touch screen preview -->
+        <org.citra.citra_emu.features.settings.ui.TouchScreenPreviewView
+            android:id="@+id/touch_screen_preview"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:layout_margin="16dp"
+            android:background="@android:color/darker_gray" />
+
+        <!-- Bindings list -->
+        <TextView
+            android:id="@+id/bindings_header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="16dp"
+            android:paddingTop="8dp"
+            android:text="Bindings"
+            android:textAppearance="?attr/textAppearanceTitleMedium" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/bindings_list"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:clipToPadding="false"
+            android:paddingBottom="80dp" />
+
+        <View
+            android:id="@+id/navigation_bar_shade"
+            android:layout_width="match_parent"
+            android:layout_height="1px"
+            android:background="@android:color/transparent" />
+
+    </LinearLayout>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab_add_binding"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="16dp"
+        android:contentDescription="@string/touch_from_button_add_binding"
+        android:src="@android:drawable/ic_input_add"
+        app:tint="?attr/colorOnPrimary" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/src/android/app/src/main/res/layout/dialog_touch_button_polling.xml
+++ b/src/android/app/src/main/res/layout/dialog_touch_button_polling.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingHorizontal="24dp"
+    android:paddingBottom="24dp"
+    android:defaultFocusHighlightEnabled="false"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
+    android:focusedByDefault="true"
+    android:orientation="vertical">
+
+    <com.google.android.material.bottomsheet.BottomSheetDragHandleView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/text_title"
+        style="@style/TextAppearance.Material3.HeadlineSmall"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="@string/touch_from_button_add_binding" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/text_message"
+        style="@style/TextAppearance.Material3.BodyLarge"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:gravity="center"
+        android:text="@string/touch_from_button_press_button" />
+
+    <Button
+        android:id="@+id/button_cancel"
+        style="@style/Widget.Material3.Button.TextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="16dp"
+        android:focusable="false"
+        android:text="@android:string/cancel" />
+
+</LinearLayout>

--- a/src/android/app/src/main/res/layout/item_touch_binding.xml
+++ b/src/android/app/src/main/res/layout/item_touch_binding.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:paddingHorizontal="16dp"
+    android:paddingVertical="12dp">
+
+    <TextView
+        android:id="@+id/text_binding_info"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:textAppearance="?attr/textAppearanceBodyLarge" />
+
+    <ImageButton
+        android:id="@+id/button_delete_binding"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:src="@android:drawable/ic_menu_delete"
+        app:tint="?attr/colorOnSurface"
+        xmlns:app="http://schemas.android.com/apk/res-auto" />
+
+</LinearLayout>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -518,6 +518,25 @@
     <string name="miscellaneous">Miscellaneous</string>
     <string name="use_artic_base_controller">Use Artic Controller when connected to Artic Base Server</string>
     <string name="use_artic_base_controller_description">Use the controls provided by Artic Base Server when connected to it instead of the configured input device.</string>
+
+    <!-- Touch from Button Mapping -->
+    <string name="touch_from_button">Touch From Button</string>
+    <string name="use_touch_from_button">Enable Touch From Button Mapping</string>
+    <string name="use_touch_from_button_description">Map controller buttons to touch points on the 3DS bottom screen</string>
+    <string name="touch_from_button_map_profile">Active Touch Map</string>
+    <string name="edit_touch_from_button_maps">Edit Touch Maps</string>
+    <string name="edit_touch_from_button_maps_description">Configure touch point mappings for controller buttons</string>
+    <string name="touch_from_button_new_map">New Map</string>
+    <string name="touch_from_button_delete_map">Delete Map</string>
+    <string name="touch_from_button_rename_map">Rename Map</string>
+    <string name="touch_from_button_add_binding">Add Binding</string>
+    <string name="touch_from_button_enter_map_name">Enter map name</string>
+    <string name="touch_from_button_press_button">Press a button on your controller…</string>
+    <string name="touch_from_button_tap_position">Tap where you want the touch point on the 3DS bottom screen</string>
+    <string name="touch_from_button_no_maps">No touch maps configured</string>
+    <string name="touch_from_button_delete_confirm">Delete this touch map?</string>
+    <string name="touch_from_button_binding_format">%1$s → (%2$d, %3$d)</string>
+
     <string name="emulation_close_game_message">Are you sure that you would like to close the current game?</string>
     <string name="menu_emulation_amiibo">Amiibo</string>
     <string name="menu_emulation_amiibo_load">Load</string>


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.

---
## Use of AI disclose
I used AI coding assistance in the form of Github Copilot along with Claude Opus 4.6 model to:
- Read the codebase and interpret it.
- Assist on writing code snippets.
- Debugging issues.
- Assisting with writing the most of the Android boilerplate in Kotlin / Java, since I don't have much experience with.

## Feature
Adding a Button to Touch mapping to the Android emulator, similar to what it's already implemented for Desktop. It consists of adding a new setting interface where the users can map controller inputs to 3DS lower screen touches on Android. Once mapped, the inputs are translated into touches in-game.

## Approach
- Importing the current TouchFromButtonFactory in the Android project and forwarding control inputs.
- Added new touch only button types to be used exclusively for this functionality.
- Developed a new interface where users can go to map control inputs to touch coordinates.
<!--
If you are contributing to Azahar for the first time please
keep the block of text between `---` and write your 
PR description below it. Do not write anything inside 
or change this block of text!

If you are a recurrent contributor, remove this entire
block of text and proceed as normal.
-->

![Ignore Until Your PR has been created!](../blob/master/.github/ignore_unless_human.png?raw=true)
---
