### PR TITLE
ci: Override Android SDK Ninja with newer version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,15 +256,18 @@ jobs:
               echo "GIT_TAG_NAME=$GITHUB_REF_NAME" >> $GITHUB_ENV
           fi
           echo $GIT_TAG_NAME
+      - name: Update Android SDK CMake version
+        if: ${{ env.SHOULD_RUN == 'true' }}
+        run: |
+          yes | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "cmake;3.30.3"
       - name: Install tools
         if: ${{ env.SHOULD_RUN == 'true' }}
         run: |
           sudo apt-get update -y
-          sudo apt-get install ccache apksigner -y
-      - name: Update Android SDK CMake version
-        if: ${{ env.SHOULD_RUN == 'true' }}
-        run: |
-          echo "y" | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "cmake;3.30.3"
+          sudo apt-get install -y apksigner ccache
+          echo "Checking ninja version..."
+          /usr/local/bin/ninja --version
+          ln -sf /usr/local/bin/ninja /usr/local/lib/android/sdk/cmake/3.30.3/bin/ninja
       - name: Build
         if: ${{ env.SHOULD_RUN == 'true' }}
         run: JAVA_HOME=$JAVA_HOME_17_X64 ./.ci/android.sh


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

A different PR requires using Ninja version 1.11.0 or newer, but the version bundled in the Ubuntu runner's Android SDK is 1.10.2. To resolve this, the standalone version of Ninja which is bundled into Ubuntu runners is forcefully symlinked into the location where the Android SDK's Ninja is usually located. The new Ninja version is currently 1.13.2.

Replacing the Ninja binary in the SDK like this is seemingly supported, as it was recommended to another user in a similar situation by a Google employee.