### PR TITLE
android: Bump NDK and AGP versions

### DIFF
--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -24,12 +24,11 @@ val abiFilter = listOf("arm64-v8a", "x86_64")
 
 val downloadedJniLibsPath = "${layout.buildDirectory.get().asFile.path}/downloadedJniLibs"
 
-@Suppress("UnstableApiUsage")
 android {
     namespace = "org.citra.citra_emu"
 
     compileSdkVersion = "android-35"
-    ndkVersion = "27.1.12297006"
+    ndkVersion = "27.3.13750724"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/src/android/build.gradle.kts
+++ b/src/android/build.gradle.kts
@@ -4,8 +4,8 @@
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.13.1" apply false
-    id("com.android.library") version "8.13.1" apply false
+    id("com.android.application") version "8.13.2" apply false
+    id("com.android.library") version "8.13.2" apply false
     id("org.jetbrains.kotlin.android") version "2.0.20" apply false
     id("org.jetbrains.kotlin.plugin.serialization") version "2.0.20"
 }


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

The versions are updated as follows:

NDK: 27.1.x --> 27.3.x
AGP: 8.13.1 --> 8.13.2

Notably, this update doesn't include an update to AGP 9.x, as the release of that major version has been extremely messy and it seems like it'll take a bit of effort to move over. See also: #2069 