### PR TITLE
qt: Fixed outdated use of qt_add_lupdate

### DIFF
--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -225,10 +225,13 @@ if (ENABLE_QT_TRANSLATION)
     if (GENERATE_QT_TRANSLATION)
         get_target_property(QT_SRCS citra_qt SOURCES)
         get_target_property(QT_INCLUDES citra_qt INCLUDE_DIRECTORIES)
-        qt_add_lupdate(citra_qt TS_FILES ${CITRA_QT_LANGUAGES}/en.ts
+        qt_add_lupdate(
+            LUPDATE_TARGET citra_qt_lupdate
             SOURCES ${QT_SRCS} ${UIS}
+            TS_FILES ${CITRA_QT_LANGUAGES}/en.ts
             INCLUDE_DIRECTORIES ${QT_INCLUDES}
-            NO_GLOBAL_TARGET)
+            NO_GLOBAL_TARGET
+        )
         add_custom_target(translation ALL DEPENDS citra_qt_lupdate)
     endif()
 


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

This makes it possible to run the commands in `.ci/transifex.sh` in a modern build environment, as opposed to the Debian 12 image we've been using up until now.

See: https://doc.qt.io/qt-6/qtlinguist-cmake-qt-add-lupdate.html#deprecated-command-signature