### PR TITLE
ci: Migrate Transifex runner to `latest` tag

### DIFF
--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   transifex:
     runs-on: ubuntu-latest
-    container: opensauce04/azahar-build-environment:transifex
+    container: opensauce04/azahar-build-environment:latest
     if: ${{ github.repository == 'azahar-emu/azahar' }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

The `transifex` tag has now been removed due to a seperate image no longer being necessary

See #2071 