### PR TITLE
macOS: normalize SDMC directory filenames

### DIFF
--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -1,4 +1,4 @@
-// Copyright 2013 Dolphin Emulator Project / 2014 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -170,12 +170,12 @@ std::u16string UTF8ToUTF16(std::string_view input) {
     return boost::locale::conv::utf_to_utf<char16_t>(input.data(), input.data() + input.size());
 }
 
+#if defined(__APPLE__)
 // macOS filesystems may expose decomposed Unicode names through directory listings.
 // Normalize to NFC before passing names to guest APIs that expect stable text.
-std::string NormalizeUTF8ToNFC(std::string_view input) {
+std::string NormalizeNFDToNFC(std::string_view input) {
     const std::string fallback(input);
 
-#if defined(__APPLE__)
     //Core Foundation string
     CFStringRef source = CFStringCreateWithBytes(
         kCFAllocatorDefault,
@@ -221,10 +221,8 @@ std::string NormalizeUTF8ToNFC(std::string_view input) {
 
     output.resize(std::strlen(output.c_str()));
     return output;
-#else
-    return fallback;
-#endif
 }
+#endif
 
 #ifdef _WIN32
 static std::wstring CPToUTF16(u32 code_page, const std::string& input) {

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -24,8 +24,6 @@
 #include <CoreFoundation/CFString.h>
 #endif
 
-
-
 namespace Common {
 
 /// Make a char lowercase
@@ -176,21 +174,17 @@ std::u16string UTF8ToUTF16(std::string_view input) {
 std::string NormalizeNFDToNFC(std::string_view input) {
     const std::string fallback(input);
 
-    //Core Foundation string
-    CFStringRef source = CFStringCreateWithBytes(
-        kCFAllocatorDefault,
-        reinterpret_cast<const UInt8*>(input.data()),
-        static_cast<CFIndex>(input.size()),
-        kCFStringEncodingUTF8,
-        false);
+    // Core Foundation string
+    CFStringRef source =
+        CFStringCreateWithBytes(kCFAllocatorDefault, reinterpret_cast<const UInt8*>(input.data()),
+                                static_cast<CFIndex>(input.size()), kCFStringEncodingUTF8, false);
 
     if (source == nullptr) {
         return fallback;
     }
 
     // Mutable copy of the source string
-    CFMutableStringRef normalized =
-        CFStringCreateMutableCopy(kCFAllocatorDefault, 0, source);
+    CFMutableStringRef normalized = CFStringCreateMutableCopy(kCFAllocatorDefault, 0, source);
     CFRelease(source);
 
     if (normalized == nullptr) {
@@ -199,19 +193,15 @@ std::string NormalizeNFDToNFC(std::string_view input) {
     // Normalize the string to NFC form
     CFStringNormalize(normalized, kCFStringNormalizationFormC);
 
-    const CFIndex max_size =
-        CFStringGetMaximumSizeForEncoding(
-            CFStringGetLength(normalized),
-            kCFStringEncodingUTF8) + 1; // +1 for null terminator
+    const CFIndex max_size = CFStringGetMaximumSizeForEncoding(CFStringGetLength(normalized),
+                                                               kCFStringEncodingUTF8) +
+                             1; // +1 for null terminator
 
     std::string output(static_cast<std::size_t>(max_size), '\0');
 
     // Convert the normalized string back to UTF-8
-    const bool converted = CFStringGetCString(
-        normalized,
-        &output[0],
-        max_size,
-        kCFStringEncodingUTF8);
+    const bool converted =
+        CFStringGetCString(normalized, &output[0], max_size, kCFStringEncodingUTF8);
 
     CFRelease(normalized);
 

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -20,6 +20,12 @@
 #include <windows.h>
 #endif
 
+#if defined(__APPLE__)
+#include <CoreFoundation/CFString.h>
+#endif
+
+
+
 namespace Common {
 
 /// Make a char lowercase
@@ -162,6 +168,62 @@ std::string UTF16ToUTF8(std::u16string_view input) {
 
 std::u16string UTF8ToUTF16(std::string_view input) {
     return boost::locale::conv::utf_to_utf<char16_t>(input.data(), input.data() + input.size());
+}
+
+// macOS filesystems may expose decomposed Unicode names through directory listings.
+// Normalize to NFC before passing names to guest APIs that expect stable text.
+std::string NormalizeUTF8ToNFC(std::string_view input) {
+    const std::string fallback(input);
+
+#if defined(__APPLE__)
+    //Core Foundation string
+    CFStringRef source = CFStringCreateWithBytes(
+        kCFAllocatorDefault,
+        reinterpret_cast<const UInt8*>(input.data()),
+        static_cast<CFIndex>(input.size()),
+        kCFStringEncodingUTF8,
+        false);
+
+    if (source == nullptr) {
+        return fallback;
+    }
+
+    // Mutable copy of the source string
+    CFMutableStringRef normalized =
+        CFStringCreateMutableCopy(kCFAllocatorDefault, 0, source);
+    CFRelease(source);
+
+    if (normalized == nullptr) {
+        return fallback;
+    }
+    // Normalize the string to NFC form
+    CFStringNormalize(normalized, kCFStringNormalizationFormC);
+
+    const CFIndex max_size =
+        CFStringGetMaximumSizeForEncoding(
+            CFStringGetLength(normalized),
+            kCFStringEncodingUTF8) + 1; // +1 for null terminator
+
+    std::string output(static_cast<std::size_t>(max_size), '\0');
+
+    // Convert the normalized string back to UTF-8
+    const bool converted = CFStringGetCString(
+        normalized,
+        &output[0],
+        max_size,
+        kCFStringEncodingUTF8);
+
+    CFRelease(normalized);
+
+    if (!converted) {
+        return fallback;
+    }
+
+    output.resize(std::strlen(output.c_str()));
+    return output;
+#else
+    return fallback;
+#endif
 }
 
 #ifdef _WIN32

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -49,6 +49,8 @@ void BuildCompleteFilename(std::string& _CompleteFilename, const std::string& _P
 
 [[nodiscard]] std::string UTF16ToUTF8(std::u16string_view input);
 [[nodiscard]] std::u16string UTF8ToUTF16(std::string_view input);
+// Returns UTF-8 normalized to NFC on platforms that need explicit Unicode normalization.
+[[nodiscard]] std::string NormalizeUTF8ToNFC(std::string_view input);
 
 #ifdef _WIN32
 [[nodiscard]] std::string UTF16ToUTF8(const std::wstring& input);

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -50,7 +50,9 @@ void BuildCompleteFilename(std::string& _CompleteFilename, const std::string& _P
 [[nodiscard]] std::string UTF16ToUTF8(std::u16string_view input);
 [[nodiscard]] std::u16string UTF8ToUTF16(std::string_view input);
 // Returns UTF-8 normalized to NFC on platforms that need explicit Unicode normalization.
-[[nodiscard]] std::string NormalizeUTF8ToNFC(std::string_view input);
+#if defined(__APPLE__)
+[[nodiscard]] std::string NormalizeNFDToNFC(std::string_view input);
+#endif
 
 #ifdef _WIN32
 [[nodiscard]] std::string UTF16ToUTF8(const std::wstring& input);

--- a/src/core/file_sys/disk_archive.cpp
+++ b/src/core/file_sys/disk_archive.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/core/file_sys/disk_archive.cpp
+++ b/src/core/file_sys/disk_archive.cpp
@@ -4,10 +4,12 @@
 
 #include <algorithm>
 #include <memory>
+#include <iterator>
 #include "common/archives.h"
 #include "common/common_types.h"
 #include "common/file_util.h"
 #include "common/logging/log.h"
+#include "common/string_util.h"
 #include "core/file_sys/disk_archive.h"
 #include "core/file_sys/errors.h"
 
@@ -62,22 +64,25 @@ u32 DiskDirectory::Read(const u32 count, Entry* entries) {
 
     while (entries_read < count && children_iterator != directory.children.cend()) {
         const FileUtil::FSTEntry& file = *children_iterator;
-        const std::string& filename = file.virtualName;
+        // Directory entries are exposed to the guest as UTF-16. Normalize host UTF-8 names first
+        // so host Unicode normalization differences do not leak into guest-visible SDMC paths.
+        const std::string filename = Common::NormalizeUTF8ToNFC(file.virtualName);
+        const std::u16string filename_utf16 = Common::UTF8ToUTF16(filename);
         Entry& entry = entries[entries_read];
 
         LOG_TRACE(Service_FS, "File {}: size={} dir={}", filename, file.size, file.isDirectory);
 
-        // TODO(Link Mauve): use a proper conversion to UTF-16.
-        for (std::size_t j = 0; j < FILENAME_LENGTH; ++j) {
-            entry.filename[j] = filename[j];
-            if (!filename[j])
-                break;
+        std::fill(std::begin(entry.filename), std::end(entry.filename), u'\0');
+
+        const std::size_t copy_length = std::min(filename_utf16.size(), FILENAME_LENGTH - 1);
+        for (std::size_t j = 0; j < copy_length; ++j) {
+            entry.filename[j] = filename_utf16[j];
         }
 
         FileUtil::SplitFilename83(filename, entry.short_name, entry.extension);
 
         entry.is_directory = file.isDirectory;
-        entry.is_hidden = (filename[0] == '.');
+        entry.is_hidden = (!filename.empty() && filename[0] == '.');
         entry.is_read_only = 0;
         entry.file_size = file.size;
 
@@ -92,5 +97,6 @@ u32 DiskDirectory::Read(const u32 count, Entry* entries) {
     }
     return entries_read;
 }
+
 
 } // namespace FileSys

--- a/src/core/file_sys/disk_archive.cpp
+++ b/src/core/file_sys/disk_archive.cpp
@@ -66,7 +66,11 @@ u32 DiskDirectory::Read(const u32 count, Entry* entries) {
         const FileUtil::FSTEntry& file = *children_iterator;
         // Directory entries are exposed to the guest as UTF-16. Normalize host UTF-8 names first
         // so host Unicode normalization differences do not leak into guest-visible SDMC paths.
-        const std::string filename = Common::NormalizeUTF8ToNFC(file.virtualName);
+#if defined(__APPLE__)
+            const std::string filename = Common::NormalizeNFDToNFC(file.virtualName);
+#else
+            const std::string& filename = file.virtualName;
+#endif
         const std::u16string filename_utf16 = Common::UTF8ToUTF16(filename);
         Entry& entry = entries[entries_read];
 
@@ -97,6 +101,4 @@ u32 DiskDirectory::Read(const u32 count, Entry* entries) {
     }
     return entries_read;
 }
-
-
 } // namespace FileSys

--- a/src/core/file_sys/disk_archive.cpp
+++ b/src/core/file_sys/disk_archive.cpp
@@ -3,8 +3,8 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
-#include <memory>
 #include <iterator>
+#include <memory>
 #include "common/archives.h"
 #include "common/common_types.h"
 #include "common/file_util.h"
@@ -67,9 +67,9 @@ u32 DiskDirectory::Read(const u32 count, Entry* entries) {
         // Directory entries are exposed to the guest as UTF-16. Normalize host UTF-8 names first
         // so host Unicode normalization differences do not leak into guest-visible SDMC paths.
 #if defined(__APPLE__)
-            const std::string filename = Common::NormalizeNFDToNFC(file.virtualName);
+        const std::string filename = Common::NormalizeNFDToNFC(file.virtualName);
 #else
-            const std::string& filename = file.virtualName;
+        const std::string& filename = file.virtualName;
 #endif
         const std::u16string filename_utf16 = Common::UTF8ToUTF16(filename);
         Entry& entry = entries[entries_read];

--- a/src/tests/common/file_util.cpp
+++ b/src/tests/common/file_util.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/tests/common/file_util.cpp
+++ b/src/tests/common/file_util.cpp
@@ -25,13 +25,13 @@ TEST_CASE("SplitFilename83 Sanity", "[common]") {
     REQUIRE(std::memcmp(extension.data(), expected_extension.data(), extension.size()) == 0);
 }
 
-TEST_CASE("NormalizeUTF8ToNFC Sanity", "[common]") {
+TEST_CASE("NormalizeNFDToNFC Sanity", "[common]") {
     const std::string decomposed = "i\xCC\x81";
     const std::string composed = "\xC3\xAD";
 
 #if defined(__APPLE__)
-    REQUIRE(Common::NormalizeUTF8ToNFC(decomposed) == composed);
+    REQUIRE(Common::NormalizeNFDToNFC(decomposed) == composed);
 #else
-    REQUIRE(Common::NormalizeUTF8ToNFC(decomposed) == decomposed);
+    REQUIRE(Common::NormalizeNFDToNFC(decomposed) == decomposed);
 #endif
 }

--- a/src/tests/common/file_util.cpp
+++ b/src/tests/common/file_util.cpp
@@ -25,13 +25,12 @@ TEST_CASE("SplitFilename83 Sanity", "[common]") {
     REQUIRE(std::memcmp(extension.data(), expected_extension.data(), extension.size()) == 0);
 }
 
+#if defined(__APPLE__)
+
 TEST_CASE("NormalizeNFDToNFC Sanity", "[common]") {
     const std::string decomposed = "i\xCC\x81";
     const std::string composed = "\xC3\xAD";
 
-#if defined(__APPLE__)
     REQUIRE(Common::NormalizeNFDToNFC(decomposed) == composed);
-#else
-    REQUIRE(Common::NormalizeNFDToNFC(decomposed) == decomposed);
-#endif
 }
+#endif

--- a/src/tests/common/file_util.cpp
+++ b/src/tests/common/file_util.cpp
@@ -24,3 +24,14 @@ TEST_CASE("SplitFilename83 Sanity", "[common]") {
     REQUIRE(std::memcmp(short_name.data(), expected_short_name.data(), short_name.size()) == 0);
     REQUIRE(std::memcmp(extension.data(), expected_extension.data(), extension.size()) == 0);
 }
+
+TEST_CASE("NormalizeUTF8ToNFC Sanity", "[common]") {
+    const std::string decomposed = "i\xCC\x81";
+    const std::string composed = "\xC3\xAD";
+
+#if defined(__APPLE__)
+    REQUIRE(Common::NormalizeUTF8ToNFC(decomposed) == composed);
+#else
+    REQUIRE(Common::NormalizeUTF8ToNFC(decomposed) == decomposed);
+#endif
+}


### PR DESCRIPTION
- [X] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

---
<!--
If you are contributing to Azahar for the first time please
keep the block of text between `---` and write your 
PR description below it. Do not write anything inside 
or change this block of text!

If you are a recurrent contributor, remove this entire
block of text and proceed as normal.
-->

![Ignore Until Your PR has been created!](../blob/master/.github/ignore_unless_human.png?raw=true)
---

This PR fixes #2079. 

Tested with my homebrew on macOS 15.7.5, and not it works perfectly.

**AI disclosure**: I used ChatGPT/Codex (GPT-5.5 Low) to help me understand the issue, discuss possible locations in the filesystem code, and review some code. The final patch was reviewed, edited and tested manually.