### PR TITLE
Fix build failures w/ OpenAL in environments without access to Ninja 1.11+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,18 +256,15 @@ jobs:
               echo "GIT_TAG_NAME=$GITHUB_REF_NAME" >> $GITHUB_ENV
           fi
           echo $GIT_TAG_NAME
-      - name: Update Android SDK CMake version
-        if: ${{ env.SHOULD_RUN == 'true' }}
-        run: |
-          yes | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "cmake;3.30.3"
       - name: Install tools
         if: ${{ env.SHOULD_RUN == 'true' }}
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y apksigner ccache
-          echo "Checking ninja version..."
-          /usr/local/bin/ninja --version
-          ln -sf /usr/local/bin/ninja /usr/local/lib/android/sdk/cmake/3.30.3/bin/ninja
+          sudo apt-get install ccache apksigner -y
+      - name: Update Android SDK CMake version
+        if: ${{ env.SHOULD_RUN == 'true' }}
+        run: |
+          echo "y" | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "cmake;3.30.3"
       - name: Build
         if: ${{ env.SHOULD_RUN == 'true' }}
         run: JAVA_HOME=$JAVA_HOME_17_X64 ./.ci/android.sh

--- a/.gitmodules
+++ b/.gitmodules
@@ -66,7 +66,7 @@
 	url = https://github.com/septag/dds-ktx
 [submodule "openal-soft"]
 	path = externals/openal-soft
-	url = https://github.com/kcat/openal-soft
+	url = https://github.com/azahar-emu/openal-soft
 [submodule "glslang"]
 	path = externals/glslang
 	url = https://github.com/KhronosGroup/glslang


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

This PR reverts our bundled OpenAL dependency to version 1.24.1, the version we were using before to the most recent upgrade, due to some build issues which were introduced by the jump to 1.25.x. We originally upgraded to 1.25.x to benefit from a specific build fix we needed, so to accommodate for that, this PR uses a forked version of OpenAL 1.24.1 which includes the fix we need.