### PR TITLE
svc: Fix instruction cache invalidation only affecting current core

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -2055,12 +2055,16 @@ Result SVC::GetProcessList(s32* process_count, VAddr out_process_array,
 }
 
 Result SVC::InvalidateInstructionCacheRange(u32 addr, u32 size) {
-    system.GetRunningCore().InvalidateCacheRange(addr, size);
+    for (size_t i = 0; i < system.GetNumCores(); i++) {
+        system.GetCore(i).InvalidateCacheRange(addr, size);
+    }
     return ResultSuccess;
 }
 
 Result SVC::InvalidateEntireInstructionCache() {
-    system.GetRunningCore().ClearInstructionCache();
+    for (size_t i = 0; i < system.GetNumCores(); i++) {
+        system.GetCore(i).ClearInstructionCache();
+    }
     return ResultSuccess;
 }
 


### PR DESCRIPTION
The instruction cache invalidation custom svcs (`svcInvalidateInstructionCacheRange` and `svcInvalidateEntireInstructionCache`) were incorrectly affecting only the current running core instead of all cores. This was found while debugging another issue, and probably doesn't have any impact on any application.