### PR TITLE
renderer_gl: Add `DebugScopes` to rasterizer and texture-runtime

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -541,6 +541,8 @@ void RasterizerOpenGL::DrawTriangles() {
 
 bool RasterizerOpenGL::Draw(bool accelerate, bool is_indexed) {
     MICROPROFILE_SCOPE(OpenGL_Drawing);
+    const DebugScope scope(runtime, Common::Vec4f{}, "RasterizerOpenGL::Draw");
+
     SyncDrawState();
 
     const bool shadow_rendering = regs.framebuffer.IsShadowRendering();

--- a/src/video_core/renderer_opengl/gl_texture_runtime.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_runtime.cpp
@@ -716,7 +716,7 @@ Sampler::Sampler(TextureRuntime&, VideoCore::SamplerParams params) {
 Sampler::~Sampler() = default;
 
 DebugScope::DebugScope(TextureRuntime& runtime, Common::Vec4f, std::string_view label)
-    : local_scope_depth{global_scope_depth++} {
+    : local_scope_depth{Settings::values.renderer_debug ? global_scope_depth++ : 0} {
     if (!Settings::values.renderer_debug) {
         return;
     }

--- a/src/video_core/renderer_opengl/gl_texture_runtime.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_runtime.cpp
@@ -174,6 +174,11 @@ bool TextureRuntime::Reinterpret(Surface& source, Surface& dest,
                                  const VideoCore::TextureCopy& copy) {
     const PixelFormat src_format = source.pixel_format;
     const PixelFormat dst_format = dest.pixel_format;
+
+    const DebugScope scope(*this, Common::Vec4f{}, "TextureRuntime::Reinterpret ({} -> {})",
+                           VideoCore::PixelFormatAsString(src_format),
+                           VideoCore::PixelFormatAsString(dst_format));
+
     ASSERT_MSG(src_format != dst_format, "Reinterpretation with the same format is invalid");
     if (src_format == PixelFormat::D24S8 && dst_format == PixelFormat::RGBA8) {
         blit_helper.ConvertDS24S8ToRGBA8(source, dest, copy);
@@ -190,6 +195,10 @@ bool TextureRuntime::Reinterpret(Surface& source, Surface& dest,
 
 bool TextureRuntime::ClearTextureWithoutFbo(Surface& surface,
                                             const VideoCore::TextureClear& clear) {
+    const DebugScope scope(
+        *this, Common::Vec4f{}, "TextureRuntime::ClearTextureWithoutFbo ({}, {}, {}, {})",
+        clear.value.color.r(), clear.value.color.g(), clear.value.color.b(), clear.value.color.a());
+
     if (!driver.HasArbClearTexture() || driver.HasBug(DriverBug::BrokenClearTexture)) {
         return false;
     }
@@ -219,6 +228,10 @@ bool TextureRuntime::ClearTextureWithoutFbo(Surface& surface,
 }
 
 void TextureRuntime::ClearTexture(Surface& surface, const VideoCore::TextureClear& clear) {
+    const DebugScope scope(*this, Common::Vec4f{}, "TextureRuntime::ClearTexture ({}, {}, {}, {})",
+                           clear.value.color.r(), clear.value.color.g(), clear.value.color.b(),
+                           clear.value.color.a());
+
     if (ClearTextureWithoutFbo(surface, clear)) {
         return;
     }
@@ -262,6 +275,9 @@ void TextureRuntime::ClearTexture(Surface& surface, const VideoCore::TextureClea
 
 bool TextureRuntime::CopyTextures(Surface& source, Surface& dest,
                                   std::span<const VideoCore::TextureCopy> copies) {
+    const DebugScope scope(*this, Common::Vec4f{}, "TextureRuntime::CopyTexture ({} copies)",
+                           copies.size());
+
     const GLenum src_textarget = source.texture_type == VideoCore::TextureType::CubeMap
                                      ? GL_TEXTURE_CUBE_MAP
                                      : GL_TEXTURE_2D;
@@ -279,6 +295,8 @@ bool TextureRuntime::CopyTextures(Surface& source, Surface& dest,
 
 bool TextureRuntime::BlitTextures(Surface& source, Surface& dest,
                                   const VideoCore::TextureBlit& blit) {
+    const DebugScope scope(*this, Common::Vec4f{}, "TextureRuntime::BlitTextures");
+
     OpenGLState state = OpenGLState::GetCurState();
     state.scissor.enabled = false;
     state.draw.read_framebuffer = read_fbos[FboIndex(source.type)].handle;
@@ -302,6 +320,8 @@ bool TextureRuntime::BlitTextures(Surface& source, Surface& dest,
 }
 
 void TextureRuntime::GenerateMipmaps(Surface& surface) {
+    const DebugScope scope(*this, Common::Vec4f{}, "TextureRuntime::GenerateMipmaps");
+
     OpenGLState state = OpenGLState::GetCurState();
 
     const auto generate = [&](u32 index) {
@@ -373,6 +393,8 @@ GLuint Surface::Handle(u32 index) const noexcept {
 }
 
 GLuint Surface::CopyHandle() noexcept {
+    const DebugScope scope(*runtime, Common::Vec4f{}, "Surface::CopyHandle");
+
     if (!copy_texture.handle) {
         copy_texture = MakeHandle(GL_TEXTURE_2D, GetScaledWidth(), GetScaledHeight(), levels, tuple,
                                   DebugName(true));
@@ -390,6 +412,8 @@ GLuint Surface::CopyHandle() noexcept {
 
 void Surface::Upload(const VideoCore::BufferTextureCopy& upload,
                      const VideoCore::StagingData& staging) {
+    const DebugScope scope(*runtime, Common::Vec4f{}, "Surface::Upload");
+
     ASSERT(stride * GetFormatBytesPerPixel(pixel_format) % 4 == 0);
 
     const u32 unscaled_width = upload.texture_rect.GetWidth();
@@ -417,6 +441,8 @@ void Surface::Upload(const VideoCore::BufferTextureCopy& upload,
 }
 
 void Surface::UploadCustom(const VideoCore::Material* material, u32 level) {
+    const DebugScope scope(*runtime, Common::Vec4f{}, "Surface::UploadCustom");
+
     const u32 width = material->width;
     const u32 height = material->height;
     const auto color = material->textures[0];
@@ -459,6 +485,8 @@ void Surface::UploadCustom(const VideoCore::Material* material, u32 level) {
 
 void Surface::Download(const VideoCore::BufferTextureCopy& download,
                        const VideoCore::StagingData& staging) {
+    const DebugScope scope(*runtime, Common::Vec4f{}, "Surface::Download");
+
     ASSERT(stride * GetFormatBytesPerPixel(pixel_format) % 4 == 0);
 
     const u32 unscaled_width = download.texture_rect.GetWidth();
@@ -498,6 +526,8 @@ void Surface::Download(const VideoCore::BufferTextureCopy& download,
 
 bool Surface::DownloadWithoutFbo(const VideoCore::BufferTextureCopy& download,
                                  const VideoCore::StagingData& staging) {
+    const DebugScope scope(*runtime, Common::Vec4f{}, "Surface::DownloadWithoutFbo");
+
     if (driver->IsOpenGLES()) {
         return false;
     }
@@ -557,6 +587,8 @@ void Surface::Attach(GLenum target, u32 level, u32 layer, bool scaled) {
 }
 
 void Surface::ScaleUp(u32 new_scale) {
+    const DebugScope scope(*runtime, Common::Vec4f{}, "Surface::ScaleUp (NewScale:{})", new_scale);
+
     if (res_scale == new_scale || new_scale == 1) {
         return;
     }
@@ -585,6 +617,8 @@ u32 Surface::GetInternalBytesPerPixel() const {
 }
 
 void Surface::BlitScale(const VideoCore::TextureBlit& blit, bool up_scale) {
+    const DebugScope scope(*runtime, Common::Vec4f{}, "Surface::BlitScale (UpScale:{})", up_scale);
+
     const u32 fbo_index = FboIndex(type);
 
     OpenGLState state = OpenGLState::GetCurState();


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Some debug scopes I added while working on https://github.com/azahar-emu/azahar/pull/2053 to help better attribute OpenGL API calls to the particular C++ callstack that called it. Helps greatly for diagnosing rendering issues.

<img width="789" height="827" alt="image" src="https://github.com/user-attachments/assets/bb9ce833-350d-45a5-b50a-4a25575e3ab1" />

<img width="1965" height="803" alt="image" src="https://github.com/user-attachments/assets/908c539c-cf70-4059-bca3-e224343b0693" />
