### PR TITLE
initialize IRQ_CMP

### DIFF
--- a/src/video_core/pica/pica_core.cpp
+++ b/src/video_core/pica/pica_core.cpp
@@ -58,6 +58,7 @@ void PicaCore::InitializeRegs() {
     // Values initialized by GSP
     regs.internal.irq_autostop = 1;
     regs.internal.irq_mask = 0xFFFFFFF0;
+    regs.internal.irq_compare = 0x12345678;
 
     auto& framebuffer_top = regs.framebuffer_config[0];
     auto& framebuffer_sub = regs.framebuffer_config[1];

--- a/src/video_core/pica/pica_core.cpp
+++ b/src/video_core/pica/pica_core.cpp
@@ -58,8 +58,8 @@ void PicaCore::InitializeRegs() {
     // Values initialized by GSP
     regs.internal.irq_autostop = 1;
     regs.internal.irq_mask = 0xFFFFFFF0;
-    // Older versions of libctru didn't initialize this, initialize it here to avoid endless black screen
-    // not needed on actual hardware due to previous software already having set it up
+    // Older versions of libctru didn't initialize this, initialize it here to avoid endless black
+    // screen. Not needed on actual hardware due to previous software already having set it up
     regs.internal.irq_compare = 0x12345678;
 
     auto& framebuffer_top = regs.framebuffer_config[0];

--- a/src/video_core/pica/pica_core.cpp
+++ b/src/video_core/pica/pica_core.cpp
@@ -58,6 +58,8 @@ void PicaCore::InitializeRegs() {
     // Values initialized by GSP
     regs.internal.irq_autostop = 1;
     regs.internal.irq_mask = 0xFFFFFFF0;
+    // Older versions of libctru didn't initialize this, initialize it here to avoid endless black screen
+    // not needed on actual hardware due to previous software already having set it up
     regs.internal.irq_compare = 0x12345678;
 
     auto& framebuffer_top = regs.framebuffer_config[0];


### PR DESCRIPTION
[x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.

Last PR got contaminated with a bunch of tinkering commits I was messing with because I suck at git. This is a second attempt at that.

Initialize IRQ_CMP in case software doesn't set it on it's own to avoid a softlock causing no picture to ever be displayed