### PR TITLE
macos: fix Vulkan/Metal renderer on macOS 26+ and bump MoltenVK

### DIFF
--- a/CMakeModules/DownloadExternals.cmake
+++ b/CMakeModules/DownloadExternals.cmake
@@ -174,7 +174,7 @@ function(download_moltenvk)
     set(MOLTENVK_TAR "${CMAKE_BINARY_DIR}/externals/MoltenVK.tar")
     if (NOT EXISTS "${CMAKE_BINARY_DIR}/externals/MoltenVK")
         if (NOT EXISTS ${MOLTENVK_TAR})
-            file(DOWNLOAD https://github.com/KhronosGroup/MoltenVK/releases/download/v1.2.9/MoltenVK-all.tar
+            file(DOWNLOAD https://github.com/KhronosGroup/MoltenVK/releases/download/v1.4.1/MoltenVK-all.tar
                 ${MOLTENVK_TAR} SHOW_PROGRESS)
         endif()
 

--- a/src/citra_meta/CMakeLists.txt
+++ b/src/citra_meta/CMakeLists.txt
@@ -15,9 +15,11 @@ if (APPLE)
     set(DIST_DIR "../../dist/apple")
     set(APPLE_RESOURCES
         "${DIST_DIR}/azahar.icns"
-        "${DIST_DIR}/LaunchScreen.storyboard"
         "${DIST_DIR}/launch_logo.png"
     )
+    if (IOS)
+        list(APPEND APPLE_RESOURCES "${DIST_DIR}/LaunchScreen.storyboard")
+    endif()
     target_sources(citra_meta PRIVATE ${APPLE_RESOURCES})
 
     # Define app bundle metadata.

--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -202,6 +202,8 @@ if (APPLE)
   target_sources(citra_qt PUBLIC
     qt_swizzle.h
     qt_swizzle.mm
+    util/metal_util.h
+    util/metal_util.mm
   )
 endif()
 

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -37,8 +37,7 @@
 #endif
 
 #if defined(__APPLE__)
-#include <objc/message.h>
-#include <objc/objc.h>
+#include "util/metal_util.h"
 #elif !defined(WIN32)
 #include <qpa/qplatformnativeinterface.h>
 #endif
@@ -420,21 +419,7 @@ static Frontend::EmuWindow::WindowSystemInfo GetWindowSystemInfo(QWindow* window
         // Our Win32 Qt external doesn't have the private API.
         wsi.render_surface = reinterpret_cast<void*>(window->winId());
 #elif defined(__APPLE__)
-        // Qt's MetalSurface QWindow on macOS does not always back the NSView
-        // with a CAMetalLayer immediately; MoltenVK 1.3+ aborts in
-        // MVKSurface::getNaturalExtent() if the layer is not CAMetalLayer.
-        // Force-install a fresh CAMetalLayer on the view.
-        {
-            id view = reinterpret_cast<id>(window->winId());
-            Class metal_layer_class = objc_getClass("CAMetalLayer");
-            id metal_layer = reinterpret_cast<id (*)(Class, SEL)>(objc_msgSend)(
-                metal_layer_class, sel_registerName("layer"));
-            reinterpret_cast<void (*)(id, SEL, id)>(objc_msgSend)(
-                view, sel_registerName("setLayer:"), metal_layer);
-            reinterpret_cast<void (*)(id, SEL, BOOL)>(objc_msgSend)(
-                view, sel_registerName("setWantsLayer:"), YES);
-            wsi.render_surface = reinterpret_cast<void*>(metal_layer);
-        }
+        wsi.render_surface = MetalUtil::CreateMetalLayer(window->winId());
 #else
         QPlatformNativeInterface* pni = QGuiApplication::platformNativeInterface();
         wsi.display_connection = pni->nativeResourceForWindow("display", window);

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -420,8 +420,21 @@ static Frontend::EmuWindow::WindowSystemInfo GetWindowSystemInfo(QWindow* window
         // Our Win32 Qt external doesn't have the private API.
         wsi.render_surface = reinterpret_cast<void*>(window->winId());
 #elif defined(__APPLE__)
-        wsi.render_surface = reinterpret_cast<void* (*)(id, SEL)>(objc_msgSend)(
-            reinterpret_cast<id>(window->winId()), sel_registerName("layer"));
+        // Qt's MetalSurface QWindow on macOS does not always back the NSView
+        // with a CAMetalLayer immediately; MoltenVK 1.3+ aborts in
+        // MVKSurface::getNaturalExtent() if the layer is not CAMetalLayer.
+        // Force-install a fresh CAMetalLayer on the view.
+        {
+            id view = reinterpret_cast<id>(window->winId());
+            Class metal_layer_class = objc_getClass("CAMetalLayer");
+            id metal_layer = reinterpret_cast<id (*)(Class, SEL)>(objc_msgSend)(
+                metal_layer_class, sel_registerName("layer"));
+            reinterpret_cast<void (*)(id, SEL, id)>(objc_msgSend)(
+                view, sel_registerName("setLayer:"), metal_layer);
+            reinterpret_cast<void (*)(id, SEL, BOOL)>(objc_msgSend)(
+                view, sel_registerName("setWantsLayer:"), YES);
+            wsi.render_surface = reinterpret_cast<void*>(metal_layer);
+        }
 #else
         QPlatformNativeInterface* pni = QGuiApplication::platformNativeInterface();
         wsi.display_connection = pni->nativeResourceForWindow("display", window);

--- a/src/citra_qt/util/metal_util.h
+++ b/src/citra_qt/util/metal_util.h
@@ -1,0 +1,11 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#import "qwindowdefs.h"
+
+namespace MetalUtil {
+
+void* CreateMetalLayer(WId window);
+
+}

--- a/src/citra_qt/util/metal_util.mm
+++ b/src/citra_qt/util/metal_util.mm
@@ -1,0 +1,23 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#import <AppKit/AppKit.h>
+#import <QuartzCore/CAMetalLayer.h>
+#import <qwindowdefs.h>
+
+namespace MetalUtil {
+
+void* CreateMetalLayer(WId winId) {
+    // Qt's MetalSurface QWindow on macOS does not always back the NSView
+    // with a CAMetalLayer immediately; MoltenVK 1.3+ aborts in
+    // MVKSurface::getNaturalExtent() if the layer is not CAMetalLayer.
+    // Force-install a fresh CAMetalLayer on the view.
+    CAMetalLayer* metalLayer = [CAMetalLayer layer];
+    NSView* view = (__bridge NSView*)winId;
+    view.wantsLayer = YES;
+    view.layer = metalLayer;
+    return (__bridge void*)metalLayer;
+}
+
+} // namespace MetalUtil

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -451,7 +451,8 @@ bool Instance::CreateDevice() {
     image_format_list = add_extension(VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME);
     shader_stencil_export = add_extension(VK_EXT_SHADER_STENCIL_EXPORT_EXTENSION_NAME);
     external_memory_host = add_extension(VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME);
-    tooling_info = add_extension(VK_EXT_TOOLING_INFO_EXTENSION_NAME);
+    tooling_info = add_extension(VK_EXT_TOOLING_INFO_EXTENSION_NAME, is_moltenvk,
+                                  "function pointer is not exposed by MoltenVK");
     const bool has_timeline_semaphores =
         add_extension(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME, is_qualcomm || is_turnip,
                       "it is broken on Qualcomm drivers");

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -452,7 +452,7 @@ bool Instance::CreateDevice() {
     shader_stencil_export = add_extension(VK_EXT_SHADER_STENCIL_EXPORT_EXTENSION_NAME);
     external_memory_host = add_extension(VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME);
     tooling_info = add_extension(VK_EXT_TOOLING_INFO_EXTENSION_NAME, is_moltenvk,
-                                  "function pointer is not exposed by MoltenVK");
+                                 "function pointer is not exposed by MoltenVK");
     const bool has_timeline_semaphores =
         add_extension(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME, is_qualcomm || is_turnip,
                       "it is broken on Qualcomm drivers");


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

---
<!--
If you are contributing to Azahar for the first time please
keep the block of text between `---` and write your 
PR description below it. Do not write anything inside 
or change this block of text!

If you are a recurrent contributor, remove this entire
block of text and proceed as normal.
-->

![Ignore Until Your PR has been created!](../blob/master/.github/ignore_unless_human.png?raw=true)
---

## AI disclosure

I asked an LLM to help me read the crash reports my own builds were producing on macOS 26.4.1 / Apple Silicon (M4 Max). All three issues were identified by reading the symbolicated backtraces together (MoltenVK aborting in `vkGetPhysicalDeviceSurfaceCapabilitiesKHR` and `MVKSurface::getNaturalExtent()`, the `vulkan-hpp` assertion on `vkGetPhysicalDeviceToolPropertiesEXT`, the CMake Xcode-generator error about the iOS storyboard). The fixes themselves are tiny (one-line version bump, one-line extension guard, ~15-line `objc_msgSend` block to install a `CAMetalLayer`, three-line `if (IOS)` guard) and I verified every one of them locally by rebuilding `citra_meta` on my machine and successfully booting a Vulkan game (Dragon Quest XI JP) to the in-game render — which previously crashed on the very first frame.

## Summary

Four related changes that together let the Vulkan backend boot a game on Apple Silicon Macs running macOS 26.x. Each is needed independently; the combination was tested on a Mac16,6 (M4 Max) running macOS 26.4.1 with Qt 6.11 from Homebrew.

- **Bump bundled MoltenVK from v1.2.9 to v1.4.1** (`CMakeModules/DownloadExternals.cmake`). v1.2.9 does not recognise the macOS 26 surface objects and traps with an Objective-C `unrecognized selector` inside `vkGetPhysicalDeviceSurfaceCapabilitiesKHR`.
- **Disable `VK_EXT_tooling_info` on MoltenVK** (`src/video_core/renderer_vulkan/vk_instance.cpp`). MoltenVK advertises the extension but does not expose `vkGetPhysicalDeviceToolPropertiesEXT` through its dispatcher, so the call inside `CollectToolingInfo()` trips a `vulkan-hpp` assertion in Debug and dereferences NULL in Release.
- **Force a `CAMetalLayer` on the QWindow's NSView before `createMetalSurfaceEXT`** (`src/citra_qt/bootmanager.cpp`). Qt 6.11's `QWindow::MetalSurface` does not always back the view with a `CAMetalLayer` on macOS 26, and MoltenVK 1.3+ aborts in `MVKSurface::getNaturalExtent()` if the layer is not the right class. Implemented via `objc_msgSend` so no `.mm` conversion is needed.
- **Gate `LaunchScreen.storyboard` behind `if (IOS)`** (`src/citra_meta/CMakeLists.txt`). The storyboard is iOS-only and previously broke the Xcode generator on macOS with `iOS storyboards do not support target device type 'mac'`.

## Test plan

- [x] `cmake -G Xcode` configures cleanly on macOS (previously failed on the storyboard).
- [x] Release `citra_meta` builds for arm64 against Qt 6.11 from Homebrew.
- [x] Bundled `libMoltenVK.dylib` reports version 1.4.1 at startup (previously 1.2.9).
- [x] App launches on macOS 26.4.1 / M4 Max without the previous ObjC `unrecognized selector` crash.
- [x] A game (Dragon Quest XI JP) boots into the Vulkan renderer and runs without crashing in `MVKSurface::getNaturalExtent()` / `vkGetPhysicalDeviceSurfaceCapabilitiesKHR`.
