### PR TITLE
qt: Use upstream Qt Base translations where available

### DIFF
--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -218,7 +218,12 @@ if (ENABLE_QT_UPDATE_CHECKER)
 endif()
 
 if (ENABLE_QT_TRANSLATION)
-    set(CITRA_QT_LANGUAGES "${PROJECT_SOURCE_DIR}/dist/languages" CACHE PATH "Path to the translation bundle for the Qt frontend")
+    if (EXISTS "${QT_TARGET_PATH}/translations")
+        set(BASE_QT_LANGUAGES "${QT_TARGET_PATH}/translations" CACHE PATH "Path to Qt base translations")
+    else()
+        set(BASE_QT_LANGUAGES "${QT_TARGET_PATH}/share/qt6/translations" CACHE PATH "Path to Qt base translations")
+    endif()
+    set(CITRA_QT_LANGUAGES "${PROJECT_SOURCE_DIR}/dist/languages" CACHE PATH "Path to Citra translations")
     option(GENERATE_QT_TRANSLATION "Generate en.ts as the translation source file" OFF)
 
     # Update source TS file if enabled
@@ -235,17 +240,23 @@ if (ENABLE_QT_TRANSLATION)
         add_custom_target(translation ALL DEPENDS citra_qt_lupdate)
     endif()
 
-    # Find all TS files except en.ts
-    file(GLOB_RECURSE LANGUAGES_TS ${CITRA_QT_LANGUAGES}/*.ts)
-    list(REMOVE_ITEM LANGUAGES_TS ${CITRA_QT_LANGUAGES}/en.ts)
+    # Find all TS files for Citra translations except en.ts
+    file(GLOB_RECURSE CITRA_LANGUAGES_TS ${CITRA_QT_LANGUAGES}/*.ts)
+    list(REMOVE_ITEM CITRA_LANGUAGES_TS ${CITRA_QT_LANGUAGES}/en.ts)
 
-    # Compile TS files to QM files
-    qt_add_lrelease(citra_qt TS_FILES ${LANGUAGES_TS} NO_GLOBAL_TARGET QM_FILES_OUTPUT_VARIABLE LANGUAGES_QM)
+    # Compile Citra TS files to QM files
+    qt_add_lrelease(citra_qt TS_FILES ${CITRA_LANGUAGES_TS} NO_GLOBAL_TARGET QM_FILES_OUTPUT_VARIABLE CITRA_LANGUAGES_QM)
+
+    # Find all QM files for Qt translations
+    file(GLOB_RECURSE QT_LANGUAGES_QM ${BASE_QT_LANGUAGES}/qtbase_*.qm)
+
+    # Copy base QT QM files into build directory
+    file(COPY ${QT_LANGUAGES_QM} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
     # Build a QRC file from the QM file list
     set(LANGUAGES_QRC ${CMAKE_CURRENT_BINARY_DIR}/languages.qrc)
     file(WRITE ${LANGUAGES_QRC} "<RCC><qresource prefix=\"languages\">\n")
-    foreach (QM ${LANGUAGES_QM})
+    foreach (QM ${QT_LANGUAGES_QM} ${CITRA_LANGUAGES_QM})
         get_filename_component(QM_FILE ${QM} NAME)
         file(APPEND ${LANGUAGES_QRC} "<file>${QM_FILE}</file>\n")
     endforeach (QM)

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <optional>
 #include <thread>
+#include <unordered_map>
 #include <QFileDialog>
 #include <QFutureWatcher>
 #include <QIcon>
@@ -4097,7 +4098,7 @@ void GMainWindow::LoadTranslation() {
                 UISettings::values.language = lang_en;
                 return;
             }
-            loaded = translator.load(lang, languages_dir);
+            loaded = citraTranslator.load(lang, languages_dir);
             if (loaded) {
                 UISettings::values.language = lang;
                 break;
@@ -4110,16 +4111,22 @@ void GMainWindow::LoadTranslation() {
         return;
     }
 
+    const QString qtbase_prefix = QStringLiteral("qtbase_");
     if (UISettings::values.language.isEmpty() && !loaded) {
         // Use the system's default locale
-        loaded = translator.load(QLocale::system(), {}, {}, languages_dir);
+        qtTranslator.load(qtbase_prefix + QLocale::system().name(), {}, {},
+                          QStringLiteral(":/languages/"));
+        loaded = citraTranslator.load(QLocale::system(), {}, {}, QStringLiteral(":/languages/"));
     } else {
         // Otherwise load from the specified file
-        loaded = translator.load(UISettings::values.language, languages_dir);
+        qtTranslator.load(qtbase_prefix + UISettings::values.language,
+                          QStringLiteral(":/languages/"));
+        loaded = citraTranslator.load(UISettings::values.language, QStringLiteral(":/languages/"));
     }
 
     if (loaded) {
-        qApp->installTranslator(&translator);
+        qApp->installTranslator(&qtTranslator);
+        qApp->installTranslator(&citraTranslator);
     } else {
         UISettings::values.language = lang_en;
     }
@@ -4127,7 +4134,8 @@ void GMainWindow::LoadTranslation() {
 
 void GMainWindow::OnLanguageChanged(const QString& locale) {
     if (UISettings::values.language != QStringLiteral("en")) {
-        qApp->removeTranslator(&translator);
+        qApp->removeTranslator(&qtTranslator);
+        qApp->removeTranslator(&citraTranslator);
     }
 
     UISettings::values.language = locale;

--- a/src/citra_qt/citra_qt.h
+++ b/src/citra_qt/citra_qt.h
@@ -439,7 +439,8 @@ private:
     QAction* action_secondary_swap_screen;
     QAction* action_secondary_rotate_screen;
 
-    QTranslator translator;
+    QTranslator qtTranslator;
+    QTranslator citraTranslator;
 
     // stores default icon theme search paths for the platform
     QStringList default_theme_paths;

--- a/src/citra_qt/configuration/configure_ui.cpp
+++ b/src/citra_qt/configuration/configure_ui.cpp
@@ -24,12 +24,17 @@ ConfigureUi::~ConfigureUi() = default;
 
 void ConfigureUi::InitializeLanguageComboBox() {
     ui->language_combobox->addItem(tr("<System>"), QString{});
-    ui->language_combobox->addItem(tr("English"), QStringLiteral("en"));
+    ui->language_combobox->addItem(QStringLiteral("English"), QStringLiteral("en"));
     QDirIterator it(QStringLiteral(":/languages"), QDirIterator::NoIteratorFlags);
     while (it.hasNext()) {
         QString locale = it.next();
         locale.truncate(locale.lastIndexOf(QLatin1Char{'.'}));
         locale.remove(0, locale.lastIndexOf(QLatin1Char{'/'}) + 1);
+        if (locale.startsWith(QStringLiteral("qtbase"))) {
+            // The Qt Base QM translation files are lumped in with ours,
+            // so don't show them in the language list!
+            continue;
+        }
         QString lang = QLocale::languageToString(QLocale(locale).language());
         const QString country = QLocale::territoryToString(QLocale(locale).territory());
         if (locale == QString::fromStdString("ca_ES_valencia")) {


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Closes #1590

This PR allows Azahar to make use of the upstream Qt Base translations for common Qt strings, such as the Ok/ Cancel buttons in dialog boxes or the "Azahar" menubar menu on macOS. Previously, these strings would just fall back to their English versions.

Currently, there are no upstream Qt Base translations for the following languages:

- Greek
- Indonesian
- Norwegian Bokmål
- Lithuanian
- Romanian
- Vietnamese

We would like to look into the possibility of providing our own base translations for these languages in the future.