### PR TITLE
renderer_gl: Fix disabled cubemap texture units

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -666,8 +666,21 @@ void RasterizerOpenGL::SyncTextureUnits(const Framebuffer* framebuffer) {
 
         // If the texture unit is disabled unbind the corresponding gl unit
         if (!texture.enabled) {
-            const Surface& null_surface = res_cache.GetSurface(VideoCore::NULL_SURFACE_ID);
-            state.texture_units[texture_index].texture_2d = null_surface.Handle();
+            switch (texture.config.type.Value()) {
+            case TextureType::TextureCube:
+            case TextureType::ShadowCube: {
+                state.texture_units[texture_index].texture_2d =
+                    res_cache.GetSurface(VideoCore::NULL_SURFACE_CUBE_ID).Handle();
+                state.texture_units[texture_index].target = GL_TEXTURE_CUBE_MAP;
+                break;
+            }
+            default: {
+                state.texture_units[texture_index].texture_2d =
+                    res_cache.GetSurface(VideoCore::NULL_SURFACE_ID).Handle();
+                state.texture_units[texture_index].target = GL_TEXTURE_2D;
+                break;
+            }
+            }
             continue;
         }
 


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Disabled texture units on OpenGL always use a null 2D texture, but there are cases where the null texture should be a null cubemap rather than a 2D texture to match the active texture binding state.

Fixes some errors that occur in `OpenGLState::Apply()` found in Brain Age: Concentration Training.
