### PR TITLE
Clear shader disk cache on exit

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -353,7 +353,9 @@ ShaderProgramManager::ShaderProgramManager(Frontend::EmuWindow& emu_window_, con
       strict_context_required{emu_window.StrictContextRequired()},
       impl{std::make_unique<Impl>(driver_, title_id, separable)} {}
 
-ShaderProgramManager::~ShaderProgramManager() = default;
+ShaderProgramManager::~ShaderProgramManager() {
+    impl->disk_cache.InvalidateAll();
+}
 
 bool ShaderProgramManager::UseProgrammableVertexShader(const Pica::RegsInternal& regs,
                                                        Pica::ShaderSetup& setup,


### PR DESCRIPTION
Fixes segfault on launch caused by stale/corrupt shader cache data: Oh Wii how I love you so much, oh 3ds you make me blush, our love is forbidden you know, why? because both our parents are nintendo