### PR TITLE
Clear shader disk cache on exit to prevent stale cache crashes

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -353,7 +353,9 @@ ShaderProgramManager::ShaderProgramManager(Frontend::EmuWindow& emu_window_, con
       strict_context_required{emu_window.StrictContextRequired()},
       impl{std::make_unique<Impl>(driver_, title_id, separable)} {}
 
-ShaderProgramManager::~ShaderProgramManager() = default;
+ShaderProgramManager::~ShaderProgramManager() {
+    impl->disk_cache.InvalidateAll();
+}
 
 bool ShaderProgramManager::UseProgrammableVertexShader(const Pica::RegsInternal& regs,
                                                        Pica::ShaderSetup& setup,


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------
Used Claude to find where the shader program manager was handled.
---
<!--
If you are contributing to Azahar for the first time please
keep the block of text between `---` and write your 
PR description below it. Do not write anything inside 
or change this block of text!

If you are a recurrent contributor, remove this entire
block of text and proceed as normal.
-->

![Ignore Until Your PR has been created!](../blob/master/.github/ignore_unless_human.png?raw=true)
---

Fixes segfault on launch caused by stale/corrupt shader cache data

Summary:
Was testing out some game compatability while writing a DS homebrewing program, and kept getting seg faults when loading some .nds files, so I ran gdb and got '#1  0x00005555560f9e51 in OpenGL::ShaderProgramManager::LoadDiskCache(std::atomic<bool> const&, std::function<void(VideoCore::LoadCallbackStage, unsigned long, unsigned long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&, bool)::{lambda(unsigned long, unsigned long, Frontend::GraphicsContext*)#1}::operator()(unsigned long, unsigned long, Frontend::GraphicsContext*) const ()'

{insert request to claude} to find where 'ShaderProgramManager' is where shutdown handles disk cache and then I the Human changed the line from defualt to to InvalidateAll on exit for clean shutdown.