### PR TITLE
video_core: Change unimplemented gas stub behavior for Vulkan

### DIFF
--- a/src/video_core/shader/generator/spv_fs_shader_gen.cpp
+++ b/src/video_core/shader/generator/spv_fs_shader_gen.cpp
@@ -72,6 +72,7 @@ void FragmentModule::Generate() {
         break;
     case TexturingRegs::FogMode::Gas:
         WriteGas();
+        // Return early due to unimplemented gas mode
         return;
     default:
         break;
@@ -196,7 +197,12 @@ void FragmentModule::WriteFog() {
 void FragmentModule::WriteGas() {
     // TODO: Implement me
     LOG_CRITICAL(Render, "Unimplemented gas mode");
-    OpKill();
+    // Replace the output color with a transparent pixel,
+    // (just discarding the pixel causes graphical issues
+    // in some MH games).
+    OpStore(color_id, ConstF32(0.f, 0.f, 0.f, 0.f));
+
+    OpReturn();
     OpFunctionEnd();
 }
 


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------
Change the unimplemented gas stub behavior for Vulkan, fixing graphical issues in Monster Hunter games. Based on #1525, which did this for OpenGL. Closes #765

Tested with Ravager Revealed, which is displayed flawlessly with both backends now