### PR TITLE
renderer_vulkan: Fix screenshot color channels on RGBA swapchain formats

### DIFF
--- a/src/citra_libretro/libretro_vk.h
+++ b/src/citra_libretro/libretro_vk.h
@@ -126,6 +126,10 @@ public:
         return static_cast<u32>(frame_pool.size());
     }
 
+    vk::Format GetSurfaceFormat() const noexcept {
+        return output_format;
+    }
+
 private:
     /// Creates the render pass for LibRetro output
     vk::RenderPass CreateRenderpass();

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -1268,6 +1268,15 @@ void RendererVulkan::RenderScreenshotWithStagingCopy() {
     // Copy backing image data to the QImage screenshot buffer
     std::memcpy(settings.screenshot_bits, alloc_info.pMappedData, staging_buffer_info.size);
 
+    // QImage::Format_RGB32 expects BGRA byte order. If the swapchain format is RGBA,
+    // swap R and B channels so the screenshot colors are correct.
+    if (main_present_window.GetSurfaceFormat() == vk::Format::eR8G8B8A8Unorm) {
+        u8* pixels = static_cast<u8*>(settings.screenshot_bits);
+        for (u32 i = 0; i < width * height; i++) {
+            std::swap(pixels[i * 4 + 0], pixels[i * 4 + 2]);
+        }
+    }
+
     // Destroy allocated resources
     vmaDestroyBuffer(instance.GetAllocator(), staging_buffer, allocation);
     vmaDestroyImage(instance.GetAllocator(), frame.image, frame.allocation);
@@ -1422,6 +1431,15 @@ bool RendererVulkan::TryRenderScreenshotWithHostMemory() {
 
     // Ensure the copy is fully completed before saving the screenshot
     scheduler.Finish();
+
+    // QImage::Format_RGB32 expects BGRA byte order. If the swapchain format is RGBA,
+    // swap R and B channels so the screenshot colors are correct.
+    if (main_present_window.GetSurfaceFormat() == vk::Format::eR8G8B8A8Unorm) {
+        u8* pixels = static_cast<u8*>(settings.screenshot_bits);
+        for (u32 i = 0; i < width * height; i++) {
+            std::swap(pixels[i * 4 + 0], pixels[i * 4 + 2]);
+        }
+    }
 
     // Image data has been copied directly to host memory
     device.destroyFramebuffer(frame.framebuffer);

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -1273,6 +1273,15 @@ void RendererVulkan::RenderScreenshotWithStagingCopy() {
     // Copy backing image data to the QImage screenshot buffer
     std::memcpy(settings.screenshot_bits, alloc_info.pMappedData, staging_buffer_info.size);
 
+    // QImage::Format_RGB32 expects BGRA byte order. If the swapchain format is RGBA,
+    // swap R and B channels so the screenshot colors are correct.
+    if (main_present_window.GetSurfaceFormat() == vk::Format::eR8G8B8A8Unorm) {
+        u8* pixels = static_cast<u8*>(settings.screenshot_bits);
+        for (u32 i = 0; i < width * height; i++) {
+            std::swap(pixels[i * 4 + 0], pixels[i * 4 + 2]);
+        }
+    }
+
     // Destroy allocated resources
     vmaDestroyBuffer(instance.GetAllocator(), staging_buffer, allocation);
     vmaDestroyImage(instance.GetAllocator(), frame.image, frame.allocation);
@@ -1427,6 +1436,15 @@ bool RendererVulkan::TryRenderScreenshotWithHostMemory() {
 
     // Ensure the copy is fully completed before saving the screenshot
     scheduler.Finish();
+
+    // QImage::Format_RGB32 expects BGRA byte order. If the swapchain format is RGBA,
+    // swap R and B channels so the screenshot colors are correct.
+    if (main_present_window.GetSurfaceFormat() == vk::Format::eR8G8B8A8Unorm) {
+        u8* pixels = static_cast<u8*>(settings.screenshot_bits);
+        for (u32 i = 0; i < width * height; i++) {
+            std::swap(pixels[i * 4 + 0], pixels[i * 4 + 2]);
+        }
+    }
 
     // Image data has been copied directly to host memory
     device.destroyFramebuffer(frame.framebuffer);

--- a/src/video_core/renderer_vulkan/vk_present_window.h
+++ b/src/video_core/renderer_vulkan/vk_present_window.h
@@ -63,6 +63,10 @@ public:
         return swapchain.GetImageCount();
     }
 
+    vk::Format GetSurfaceFormat() const noexcept {
+        return swapchain.GetSurfaceFormat().format;
+    }
+
 private:
     void PresentThread(std::stop_token token);
 


### PR DESCRIPTION
- [X] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

The swapchain pixel format is driver-dependent, with some platforms preferring BGRA and others RGBA. When taking screenshots, the QImage has Format_RGB32 and expects BGRA. If the platform prefers RGBA, this causes a channel swap  when taking screenshots in the Vulkan renderer (#763).

My fix is to just pass through the swapchain format and swizzle the bytes. It's not the most elegant fix but computationally cheap and to change the QImage format would involve passing information to the frontend. 

Full disclosure, I am on a Mac and MoltenVK prefers BGRA so I forced my pixel format to RGBA to test. It would be good if someone from an affected platform could confirm. Linux Mesa I suspect is one. 