### PR TITLE
fix loadTranslation for QT 6 older than 6.7

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -4098,7 +4098,7 @@ void GMainWindow::LoadTranslation() {
     #else
         languages = QLocale::system().uiLanguages();
         for (auto& lang : languages)
-            lang.replace('-', '_');
+            lang.replace(u'-', u'_');
     #endif
         for (const auto& lang : languages) {
             // If the first language found is English, no need to install any translation

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -4091,7 +4091,15 @@ void GMainWindow::LoadTranslation() {
     //       selected language option? Current behaviour is better than the issue it fixes,
     //       but not ideal.
     if (UISettings::values.language.isEmpty()) {
-        const auto languages = QLocale::system().uiLanguages(QLocale::TagSeparator::Underscore);
+        QStringList languages;
+    #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+        languages =
+            QLocale::system().uiLanguages(QLocale::TagSeparator::Underscore);
+    #else
+        languages = QLocale::system().uiLanguages();
+        for (auto& lang : languages)
+            lang.replace('-', '_');
+    #endif
         for (const auto& lang : languages) {
             // If the first language found is English, no need to install any translation
             if (lang == lang_en) {

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -4092,14 +4092,13 @@ void GMainWindow::LoadTranslation() {
     //       but not ideal.
     if (UISettings::values.language.isEmpty()) {
         QStringList languages;
-    #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
-        languages =
-            QLocale::system().uiLanguages(QLocale::TagSeparator::Underscore);
-    #else
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+        languages = QLocale::system().uiLanguages(QLocale::TagSeparator::Underscore);
+#else
         languages = QLocale::system().uiLanguages();
         for (auto& lang : languages)
             lang.replace(u'-', u'_');
-    #endif
+#endif
         for (const auto& lang : languages) {
             // If the first language found is English, no need to install any translation
             if (lang == lang_en) {


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------
https://doc.qt.io/qt-6/qlocale.html#TagSeparator-enum
---
Tested on my Ubuntu 24.04 laptop, seems to work fine.
<img width="1653" height="766" alt="image" src="https://github.com/user-attachments/assets/5062221f-9265-4627-8a13-92f46ee6739d" />