### PR TITLE
core/memory: Fix undefined behavior and optimize Luma alias path

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -598,8 +598,7 @@ T MemorySystem::Read(const std::shared_ptr<PageTable>& page_table, const VAddr v
         return value;
     }
 
-    // Luma3DS physical address alias (bit 31 set) Bypasses page tables for FCRAM/MMIO
-    // Fixes UB: '1 << 31' is signed integer overflow Use unsigned constant 0x80000000u
+    // Custom Luma3ds mapping (bit 31 set) Bypasses page tables for FCRAM/MMIO
     constexpr VAddr LUMA_ALIAS_BIT = 0x80000000u;
 
     if (vaddr & LUMA_ALIAS_BIT) [[unlikely]] {
@@ -694,8 +693,7 @@ void MemorySystem::Write(const std::shared_ptr<PageTable>& page_table, const VAd
         return;
     }
 
-    // Luma3DS physical address alias (bit 31 set) Bypasses page tables for FCRAM/MMIO
-    // Fixes UB: '1 << 31' is signed integer overflow Use unsigned constant 0x80000000u
+    // Custom Luma3ds mapping (bit 31 set) Bypasses page tables for FCRAM/MMIO
     constexpr VAddr LUMA_ALIAS_BIT = 0x80000000u;
 
     if (vaddr & LUMA_ALIAS_BIT) [[unlikely]] {

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -598,20 +598,28 @@ T MemorySystem::Read(const std::shared_ptr<PageTable>& page_table, const VAddr v
         return value;
     }
 
-    // Custom Luma3ds mapping
-    // Is there a more efficient way to do this?
-    if (vaddr & (1 << 31)) {
-        PAddr paddr = (vaddr & ~(1 << 31));
-        if ((paddr & 0xF0000000) == Memory::FCRAM_PADDR) { // Check FCRAM region
+    // Luma3DS physical address alias (bit 31 set) Bypasses page tables for FCRAM/MMIO
+    // Fixes UB: '1 << 31' is signed integer overflow Use unsigned constant 0x80000000u
+    constexpr VAddr LUMA_ALIAS_BIT = 0x80000000u;
+
+    if (vaddr & LUMA_ALIAS_BIT) [[unlikely]] {
+        const PAddr paddr = vaddr & ~LUMA_ALIAS_BIT;
+
+        // FCRAM (0x2xxxxxxx)
+        if ((paddr & 0xF0000000) == Memory::FCRAM_PADDR) {
             ReadType value;
             std::memcpy(&value, GetFCRAMPointer(paddr - Memory::FCRAM_PADDR), read_size);
             return value;
-        } else if ((paddr & 0xF0000000) == 0x10000000 &&
-                   paddr >= Memory::IO_AREA_PADDR) { // Check MMIO region
+        }
+
+        // MMIO (0x1xxxxxxx, >= IO_AREA_PADDR) - Strictly 32-bit
+        if ((paddr & 0xF0000000) == 0x10000000 && paddr >= Memory::IO_AREA_PADDR) [[unlikely]] {
             return static_cast<ReadType>(impl->system.GPU().ReadReg(
                 static_cast<VAddr>(paddr) - Memory::IO_AREA_PADDR + 0x1EC00000));
         }
+        // Fallthrough: Standard page table lookup
     }
+
 
     PageType type = page_table->attributes[vaddr >> CITRA_PAGE_BITS];
     switch (type) {
@@ -686,22 +694,30 @@ void MemorySystem::Write(const std::shared_ptr<PageTable>& page_table, const VAd
         return;
     }
 
-    // Custom Luma3ds mapping
-    // Is there a more efficient way to do this?
-    if (vaddr & (1 << 31)) {
-        PAddr paddr = (vaddr & ~(1 << 31));
-        if ((paddr & 0xF0000000) == Memory::FCRAM_PADDR) { // Check FCRAM region
+    // Luma3DS physical address alias (bit 31 set) Bypasses page tables for FCRAM/MMIO
+    // Fixes UB: '1 << 31' is signed integer overflow Use unsigned constant 0x80000000u
+    constexpr VAddr LUMA_ALIAS_BIT = 0x80000000u;
+
+    if (vaddr & LUMA_ALIAS_BIT) [[unlikely]] {
+        const PAddr paddr = vaddr & ~LUMA_ALIAS_BIT;
+
+        // FCRAM (0x2xxxxxxx)
+        if ((paddr & 0xF0000000) == Memory::FCRAM_PADDR) {
             std::memcpy(GetFCRAMPointer(paddr - Memory::FCRAM_PADDR), &data, sizeof(T));
             return;
-        } else if ((paddr & 0xF0000000) == 0x10000000 &&
-                   paddr >= Memory::IO_AREA_PADDR) { // Check MMIO region
+        }
+
+        // MMIO (0x1xxxxxxx, >= IO_AREA_PADDR) - Strictly 32-bit
+        if ((paddr & 0xF0000000) == 0x10000000 && paddr >= Memory::IO_AREA_PADDR) [[unlikely]] {
             ASSERT(sizeof(data) == sizeof(u32));
-            impl->system.GPU().WriteReg(static_cast<VAddr>(paddr) - Memory::IO_AREA_PADDR +
-                                            0x1EC00000,
-                                        static_cast<u32>(data));
+            impl->system.GPU().WriteReg(
+                static_cast<VAddr>(paddr) - Memory::IO_AREA_PADDR + 0x1EC00000,
+                static_cast<u32>(data));
             return;
         }
+        // Fallthrough: Standard page table lookup
     }
+
 
     PageType type = page_table->attributes[vaddr >> CITRA_PAGE_BITS];
     switch (type) {

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -619,7 +619,6 @@ T MemorySystem::Read(const std::shared_ptr<PageTable>& page_table, const VAddr v
         // Fallthrough: Standard page table lookup
     }
 
-
     PageType type = page_table->attributes[vaddr >> CITRA_PAGE_BITS];
     switch (type) {
     case PageType::Unmapped: {
@@ -708,14 +707,13 @@ void MemorySystem::Write(const std::shared_ptr<PageTable>& page_table, const VAd
         // MMIO (0x1xxxxxxx, >= IO_AREA_PADDR) - Strictly 32-bit
         if ((paddr & 0xF0000000) == 0x10000000 && paddr >= Memory::IO_AREA_PADDR) [[unlikely]] {
             ASSERT(sizeof(data) == sizeof(u32));
-            impl->system.GPU().WriteReg(
-                static_cast<VAddr>(paddr) - Memory::IO_AREA_PADDR + 0x1EC00000,
-                static_cast<u32>(data));
+            impl->system.GPU().WriteReg(static_cast<VAddr>(paddr) - Memory::IO_AREA_PADDR +
+                                            0x1EC00000,
+                                        static_cast<u32>(data));
             return;
         }
         // Fallthrough: Standard page table lookup
     }
-
 
     PageType type = page_table->attributes[vaddr >> CITRA_PAGE_BITS];
     switch (type) {


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

## Description

This PR fixes a signed integer overflow and optimizes the control flow within the Luma alias memory reading path in `src/core/memory.cpp`

### Changes:
* **UB Fix:** Changed `LUMA_ALIAS_BIT` to an unsigned literal (`0x80000000u`) to guarantee safe bitwise operations and prevent compiler-specific optimization bugs caused by signed overflow
* **Control Flow Optimization:** Removed the redundant `else if` structure. Since the FCRAM hot path ends with an early `return`, flattening the structure allows Clang to generate more linear and optimized assembly
* **Branch Hinting:** Added the `[[unlikely]]` attribute to the MMIO cold path to optimize instruction caching, as MMIO registers are rarely accessed via this alias
