### PR TITLE
qt: Fix <System> selection becoming blank when selected

### DIFF
--- a/src/citra_qt/configuration/configure_ui.cpp
+++ b/src/citra_qt/configuration/configure_ui.cpp
@@ -55,7 +55,8 @@ void ConfigureUi::InitializeLanguageComboBox() {
 void ConfigureUi::SetConfiguration() {
     ui->theme_combobox->setCurrentIndex(ui->theme_combobox->findData(UISettings::values.theme));
     ui->language_combobox->setCurrentIndex(
-        ui->language_combobox->findData(UISettings::values.language));
+        // findData returns -1 if nothing found; Use <System> in this case (index 0).
+        std::max(0, ui->language_combobox->findData(UISettings::values.language)));
     ui->icon_size_combobox->setCurrentIndex(
         static_cast<int>(UISettings::values.game_list_icon_size.GetValue()));
     ui->row_1_text_combobox->setCurrentIndex(


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

