### PR TITLE
core: Implement APT:MapProgramIdForDebug

### DIFF
--- a/src/core/hle/service/apt/applet_manager.cpp
+++ b/src/core/hle/service/apt/applet_manager.cpp
@@ -359,6 +359,15 @@ bool AppletManager::CancelParameter(bool check_sender, AppletId sender_appid, bo
     return cancellation_success;
 }
 
+void AppletManager::MapProgramIdForDebug(AppletId app_id, u64 title_id, FS::MediaType media_type) {
+    auto slot = GetAppletSlotFromId(app_id);
+    if (slot != AppletSlot::Error) {
+        auto applet_slot = GetAppletSlot(slot);
+        applet_slot->title_id = title_id;
+        applet_slot->media_type = media_type;
+    }
+}
+
 ResultVal<AppletManager::GetLockHandleResult> AppletManager::GetLockHandle(
     AppletAttributes attributes) {
     auto corrected_attributes = attributes;

--- a/src/core/hle/service/apt/applet_manager.h
+++ b/src/core/hle/service/apt/applet_manager.h
@@ -288,6 +288,8 @@ public:
     bool CancelParameter(bool check_sender, AppletId sender_appid, bool check_receiver,
                          AppletId receiver_appid);
 
+    void MapProgramIdForDebug(AppletId app_id, u64 title_id, FS::MediaType media_type);
+
     struct GetLockHandleResult {
         AppletAttributes corrected_attributes;
         u32 state;

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -574,6 +574,28 @@ void Module::APTInterface::CancelParameter(Kernel::HLERequestContext& ctx) {
                                                  receiver_appid));
 }
 
+void Module::APTInterface::MapProgramIdForDebug(Kernel::HLERequestContext& ctx) {
+    // This function got stubbed at some point and no longer
+    // does anything on real hardware. It is implemented here
+    // so that emulated applications can take advantage of it.
+
+    IPC::RequestParser rp(ctx);
+    const auto app_id = rp.PopEnum<AppletId>();
+    u64 title_id = rp.Pop<u64>();
+
+    // NOTE: Real hardware forces the media type to nand.
+    // To allow better control of this service call,
+    // treat the highest byte of the title ID as the
+    // media type instead.
+    FS::MediaType media_type = static_cast<FS::MediaType>(title_id >> 56);
+    title_id &= ~0xFF00000000000000ULL;
+
+    apt->applet_manager->MapProgramIdForDebug(app_id, title_id, media_type);
+
+    IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
+    rb.Push(ResultSuccess); // No error
+}
+
 void Module::APTInterface::PrepareToDoApplicationJump(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     auto flags = rp.PopEnum<ApplicationJumpFlags>();

--- a/src/core/hle/service/apt/apt.h
+++ b/src/core/hle/service/apt/apt.h
@@ -376,6 +376,8 @@ public:
          */
         void CancelParameter(Kernel::HLERequestContext& ctx);
 
+        void MapProgramIdForDebug(Kernel::HLERequestContext& ctx);
+
         /**
          * APT::PrepareToStartApplication service function. When the input title-info programID is
          * zero, NS will load the actual program ID via AMNet:GetTitleIDList. After doing some

--- a/src/core/hle/service/apt/apt_a.cpp
+++ b/src/core/hle/service/apt/apt_a.cpp
@@ -27,7 +27,7 @@ APT_A::APT_A(std::shared_ptr<Module> apt)
         {0x000E, &APT_A::GlanceParameter, "GlanceParameter"},
         {0x000F, &APT_A::CancelParameter, "CancelParameter"},
         {0x0010, nullptr, "DebugFunc"},
-        {0x0011, nullptr, "MapProgramIdForDebug"},
+        {0x0011, &APT_A::MapProgramIdForDebug, "MapProgramIdForDebug"},
         {0x0012, nullptr, "SetHomeMenuAppletIdForDebug"},
         {0x0013, nullptr, "GetPreparationState"},
         {0x0014, nullptr, "SetPreparationState"},

--- a/src/core/hle/service/apt/apt_s.cpp
+++ b/src/core/hle/service/apt/apt_s.cpp
@@ -27,7 +27,7 @@ APT_S::APT_S(std::shared_ptr<Module> apt)
         {0x000E, &APT_S::GlanceParameter, "GlanceParameter"},
         {0x000F, &APT_S::CancelParameter, "CancelParameter"},
         {0x0010, nullptr, "DebugFunc"},
-        {0x0011, nullptr, "MapProgramIdForDebug"},
+        {0x0011, &APT_S::MapProgramIdForDebug, "MapProgramIdForDebug"},
         {0x0012, nullptr, "SetHomeMenuAppletIdForDebug"},
         {0x0013, nullptr, "GetPreparationState"},
         {0x0014, nullptr, "SetPreparationState"},

--- a/src/core/hle/service/apt/apt_u.cpp
+++ b/src/core/hle/service/apt/apt_u.cpp
@@ -27,7 +27,7 @@ APT_U::APT_U(std::shared_ptr<Module> apt)
         {0x000E, &APT_U::GlanceParameter, "GlanceParameter"},
         {0x000F, &APT_U::CancelParameter, "CancelParameter"},
         {0x0010, nullptr, "DebugFunc"},
-        {0x0011, nullptr, "MapProgramIdForDebug"},
+        {0x0011, &APT_U::MapProgramIdForDebug, "MapProgramIdForDebug"},
         {0x0012, nullptr, "SetHomeMenuAppletIdForDebug"},
         {0x0013, nullptr, "GetPreparationState"},
         {0x0014, nullptr, "SetPreparationState"},


### PR DESCRIPTION
Implements a custom implementation of `APT:MapProgramIdForDebug`, as described in 3dbrew.

This service call was actually stubbed at some point after the documentation was written to 3dbrew, however it is useful for mods such as CTGP-7 so that the mod launcher icon is selected in the home menu instead of the base game.

The implementation is changed slightly so that the media type is also passed as the highest byte of the title ID.