### PR TITLE
apt: Properly implement app ID checks

### DIFF
--- a/src/core/hle/service/apt/applet_manager.cpp
+++ b/src/core/hle/service/apt/applet_manager.cpp
@@ -154,11 +154,13 @@ static u64 ConvertTitleID(Core::System& system, u64 base_title_id) {
 }
 
 static bool IsSystemAppletId(AppletId applet_id) {
-    return (static_cast<u32>(applet_id) & static_cast<u32>(AppletId::AnySystemApplet)) != 0;
+    return (static_cast<u32>(applet_id) & static_cast<u32>(AppletId::TypeMask)) ==
+           static_cast<u32>(AppletId::AnySystemApplet);
 }
 
 static bool IsApplicationAppletId(AppletId applet_id) {
-    return (static_cast<u32>(applet_id) & static_cast<u32>(AppletId::Application)) != 0;
+    return (static_cast<u32>(applet_id) & static_cast<u32>(AppletId::TypeMask)) ==
+           static_cast<u32>(AppletId::Application);
 }
 
 AppletManager::AppletSlot AppletManager::GetAppletSlotFromId(AppletId id) {

--- a/src/core/hle/service/apt/applet_manager.h
+++ b/src/core/hle/service/apt/applet_manager.h
@@ -101,6 +101,7 @@ enum class AppletId : u32 {
     Mint2 = 0x407,
     Extrapad2 = 0x408,
     Memolib2 = 0x409,
+    TypeMask = 0xF00,
 };
 
 /// Application Old/New 3DS target platforms


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

The IsSystemAppletId and IsApplicationAppletId checks were prone to collisions due to the way they were implemented. For example, the application app ID would pass IsSystemAppletId since 0x300 & 0x100 != 0

To account for masking collisions, add a generic `TypeMask` enum value used to mask the app ID type correctly, and then match the masked value with the app ID we're looking for.

Fixes issues with system applets that use objects from the caller applications, since the edge case for sysapplet parameters being sent to applications was also passing the other way around.