### PR TITLE
audio_core: Add '#include <cstring>' to cubeb_sink and cubeb_input.cpp

### DIFF
--- a/src/audio_core/cubeb_input.cpp
+++ b/src/audio_core/cubeb_input.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <cstring>
 #include <utility>
 #include <vector>
 #include <cubeb/cubeb.h>

--- a/src/audio_core/cubeb_sink.cpp
+++ b/src/audio_core/cubeb_sink.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/audio_core/cubeb_sink.cpp
+++ b/src/audio_core/cubeb_sink.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <cstdarg>
+#include <cstring>
 #include <mutex>
 #include <vector>
 #include <cubeb/cubeb.h>


### PR DESCRIPTION
This fixes a build failure encountered when compiling: https://pastebin.com/JQ4mbhyu

The [azahar-git[AUR]](https://aur.archlinux.org/packages/azahar-git) package uses a patch to fix this issue, honestly not sure why this wasn't reported.

Please also cherry pick to 2126! (Maybe 2125 too?)
Thanks!

- [X] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.

I used Claude to determine where to place the include line exactly (I know 0 C or C++), and it seems my intuition about using the alphabetical order was right.
