### PR TITLE
Refresh game list after uninstalling installed titles

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -2564,6 +2564,7 @@ void GMainWindow::UninstallTitles(
     } else if (!future_watcher.isCanceled()) {
         QMessageBox::information(this, tr("Azahar"),
                                  tr("Successfully uninstalled '%1'.").arg(first_name));
+        emit InstalledTitlesChanged();
     }
 }
 

--- a/src/citra_qt/citra_qt.h
+++ b/src/citra_qt/citra_qt.h
@@ -151,6 +151,7 @@ signals:
     void InfoLEDColorChanged();
     // Signal that tells widgets to update icons to use the current theme
     void UpdateThemedIcons();
+    void InstalledTitlesChanged();
 
 private:
     void InitializeWidgets();

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -379,6 +379,8 @@ GameList::GameList(PlayTime::PlayTimeManager& play_time_manager_, GMainWindow* p
     item_model->setSortRole(GameListItemPath::SortRole);
 
     connect(main_window, &GMainWindow::UpdateThemedIcons, this, &GameList::OnUpdateThemedIcons);
+    connect(main_window, &GMainWindow::InstalledTitlesChanged, this,
+            &GameList::RefreshGameDirectory);
     connect(tree_view, &QTreeView::activated, this, &GameList::ValidateEntry);
     connect(tree_view, &QTreeView::customContextMenuRequested, this, &GameList::PopupContextMenu);
     connect(tree_view, &QTreeView::expanded, this, &GameList::OnItemExpanded);


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

## Summary

Refresh the game list after successfully uninstalling an installed title.

Uninstalling updates or DLC can change the metadata used by entries in the game list, including the displayed icon. Previously, the list was not refreshed after uninstalling a title, so the UI could keep showing stale metadata until Azahar was restarted.

This adds an `InstalledTitlesChanged` signal emitted after a successful uninstall and connects it to the game list refresh path.

## Fixes

Fixes #897

## Testing

Tested manually on Windows/MSYS2:

1. Installed a CIA update for a game.
2. Confirmed the game list showed the updated icon.
3. Right-clicked the game and selected `Uninstall -> Update`.
4. Confirmed the game list refreshed and the icon reverted without restarting Azahar.