### PR TITLE
video_core: vulkan: Fix crash on color fill before framebuffer setup

### DIFF
--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -660,6 +660,11 @@ void RendererVulkan::ConfigureFramebufferTexture(TextureInfo& texture,
 }
 
 void RendererVulkan::FillScreen(Common::Vec3<u8> color, const TextureInfo& texture) {
+    // When loading some 3GX extensions, FillScreen may be called before texture image is available
+    if (!texture.image) {
+        return;
+    }
+
     const vk::ClearColorValue clear_color = {
         .float32 =
             std::array{


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------
Issue encountered myself when trying to use PokeReader 3gx on Vulkan backend with AMD GPU on windows.

Manually found last known good version (2122.1), found manually exact commit that introduced the issue through git bisect.

Used AI to dig into the supposed cause of the issue, due to lack of Vulkan API knowledge. 

Written comment + commit title based on insights from AI output

---


When running Azahar on any version more recent that 2122.1 on Windows, with 3gx loader support enabled (with potentially a default 3gx plugin, and potentially on an AMD GPU only), the emulator crashes consistently as soon as the plugin is loaded.

The issue looks like it was introduced in commit a15af9b55, when the function `RendererVulkan::FillScreen` was un-stubbed.

Attached are start logs with 3gx loader support on/off, on both a15af9b55 and its parent (4447a5c9f) which works fine.

[log-a15af9b55-off.txt](https://github.com/user-attachments/files/29419502/log-a15af9b55-off.txt)
[log-a15af9b55-on.txt](https://github.com/user-attachments/files/29419503/log-a15af9b55-on.txt)
[log-4447a5c9f-on.txt](https://github.com/user-attachments/files/29419501/log-4447a5c9f-on.txt)
[log-4447a5c9f-off.txt](https://github.com/user-attachments/files/29419505/log-4447a5c9f-off.txt)
[log-a15af9b55-on-fix.txt](https://github.com/user-attachments/files/29419504/log-a15af9b55-on-fix.txt)

There are multiple issues (#1125, #1943, #1827, #1381) where commenter are describing behavior which could be related to this

