### PR TITLE
renderer_gl: Fix OpenGL texture unit state tracking

### DIFF
--- a/src/video_core/rasterizer_cache/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache/rasterizer_cache.h
@@ -71,6 +71,7 @@ RasterizerCache<T>::RasterizerCache(Memory::MemorySystem& memory_,
     auto& null_surface = slot_surfaces[NULL_SURFACE_ID];
     runtime.ClearTexture(null_surface, {
                                            .texture_level = 0,
+                                           .texture_layer = 0,
                                            .texture_rect = null_surface.GetScaledRect(),
                                            .value =
                                                {

--- a/src/video_core/rasterizer_cache/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache/rasterizer_cache.h
@@ -78,6 +78,21 @@ RasterizerCache<T>::RasterizerCache(Memory::MemorySystem& memory_,
                                                    .color = {0.f, 0.f, 0.f, 0.f},
                                                },
                                        });
+
+    auto& null_surface_cube = slot_surfaces[NULL_SURFACE_CUBE_ID];
+    // Clear all cubemap faces
+    for (u32 cube_layer_index = 0; cube_layer_index < 6; ++cube_layer_index) {
+        runtime.ClearTexture(null_surface_cube,
+                             {
+                                 .texture_level = 0,
+                                 .texture_layer = cube_layer_index,
+                                 .texture_rect = null_surface_cube.GetScaledRect(),
+                                 .value =
+                                     {
+                                         .color = {0.f, 0.f, 0.f, 0.f},
+                                     },
+                             });
+    }
 }
 
 template <class T>

--- a/src/video_core/rasterizer_cache/utils.h
+++ b/src/video_core/rasterizer_cache/utils.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -30,6 +30,7 @@ union ClearValue {
 
 struct TextureClear {
     u32 texture_level;
+    u32 texture_layer;
     Common::Rectangle<u32> texture_rect;
     ClearValue value;
 };

--- a/src/video_core/renderer_opengl/gl_blit_helper.cpp
+++ b/src/video_core/renderer_opengl/gl_blit_helper.cpp
@@ -88,6 +88,7 @@ bool BlitHelper::ConvertDS24S8ToRGBA8(Surface& source, Surface& dest,
     SCOPE_EXIT({ prev_state.Apply(); });
 
     state.texture_units[0].texture_2d = source.Handle();
+    state.texture_units[0].target = GL_TEXTURE_2D;
     state.texture_units[0].sampler = 0;
     state.texture_units[1].sampler = 0;
 
@@ -103,6 +104,7 @@ bool BlitHelper::ConvertDS24S8ToRGBA8(Surface& source, Surface& dest,
         temp_tex.Release();
         temp_tex.Create();
         state.texture_units[1].texture_2d = temp_tex.handle;
+        state.texture_units[1].target = GL_TEXTURE_2D;
         state.Apply();
         glActiveTexture(GL_TEXTURE1);
         glTexStorage2D(GL_TEXTURE_2D, 1, GL_DEPTH24_STENCIL8, temp_extent.width,
@@ -111,6 +113,7 @@ bool BlitHelper::ConvertDS24S8ToRGBA8(Surface& source, Surface& dest,
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     }
     state.texture_units[1].texture_2d = temp_tex.handle;
+    state.texture_units[1].target = GL_TEXTURE_2D;
     state.Apply();
 
     glActiveTexture(GL_TEXTURE1);
@@ -145,6 +148,7 @@ bool BlitHelper::ConvertRGBA4ToRGB5A1(Surface& source, Surface& dest,
     SCOPE_EXIT({ prev_state.Apply(); });
 
     state.texture_units[0].texture_2d = source.Handle();
+    state.texture_units[0].target = GL_TEXTURE_2D;
 
     const Common::Rectangle src_rect{copy.src_offset.x, copy.src_offset.y + copy.extent.height,
                                      copy.src_offset.x + copy.extent.width, copy.src_offset.x};
@@ -206,6 +210,7 @@ void BlitHelper::FilterAnime4K(Surface& surface, const VideoCore::TextureBlit& b
         texture.fbo.Create();
         texture.tex.Create();
         state.texture_units[1].texture_2d = texture.tex.handle;
+        state.texture_units[1].target = GL_TEXTURE_2D;
         state.draw.draw_framebuffer = texture.fbo.handle;
         state.Apply();
         glActiveTexture(GL_TEXTURE1);
@@ -228,6 +233,10 @@ void BlitHelper::FilterAnime4K(Surface& surface, const VideoCore::TextureBlit& b
     state.texture_units[1].texture_2d = LUMAD.tex.handle;
     state.texture_units[2].texture_2d = XY.tex.handle;
 
+    state.texture_units[0].target = GL_TEXTURE_2D;
+    state.texture_units[1].target = GL_TEXTURE_2D;
+    state.texture_units[2].target = GL_TEXTURE_2D;
+
     // gradient x pass
     Draw(gradient_x_program, XY.tex.handle, XY.fbo.handle, 0, temp_rect);
 
@@ -249,6 +258,7 @@ void BlitHelper::FilterBicubic(Surface& surface, const VideoCore::TextureBlit& b
     const OpenGLState prev_state = OpenGLState::GetCurState();
     SCOPE_EXIT({ prev_state.Apply(); });
     state.texture_units[0].texture_2d = surface.Handle(0);
+    state.texture_units[0].target = GL_TEXTURE_2D;
     SetParams(bicubic_program, surface.RealExtent(false), blit.src_rect);
     Draw(bicubic_program, surface.Handle(), draw_fbo.handle, blit.dst_level, blit.dst_rect);
 }
@@ -257,6 +267,7 @@ void BlitHelper::FilterScaleForce(Surface& surface, const VideoCore::TextureBlit
     const OpenGLState prev_state = OpenGLState::GetCurState();
     SCOPE_EXIT({ prev_state.Apply(); });
     state.texture_units[0].texture_2d = surface.Handle(0);
+    state.texture_units[0].target = GL_TEXTURE_2D;
     SetParams(scale_force_program, surface.RealExtent(false), blit.src_rect);
     Draw(scale_force_program, surface.Handle(), draw_fbo.handle, blit.dst_level, blit.dst_rect);
 }
@@ -265,6 +276,7 @@ void BlitHelper::FilterXbrz(Surface& surface, const VideoCore::TextureBlit& blit
     const OpenGLState prev_state = OpenGLState::GetCurState();
     SCOPE_EXIT({ prev_state.Apply(); });
     state.texture_units[0].texture_2d = surface.Handle(0);
+    state.texture_units[0].target = GL_TEXTURE_2D;
     glProgramUniform1f(xbrz_program.handle, 2, static_cast<GLfloat>(surface.res_scale));
     SetParams(xbrz_program, surface.RealExtent(false), blit.src_rect);
     Draw(xbrz_program, surface.Handle(), draw_fbo.handle, blit.dst_level, blit.dst_rect);
@@ -274,6 +286,7 @@ void BlitHelper::FilterMMPX(Surface& surface, const VideoCore::TextureBlit& blit
     const OpenGLState prev_state = OpenGLState::GetCurState();
     SCOPE_EXIT({ prev_state.Apply(); });
     state.texture_units[0].texture_2d = surface.Handle(0);
+    state.texture_units[0].target = GL_TEXTURE_2D;
     SetParams(mmpx_program, surface.RealExtent(false), blit.src_rect);
     Draw(mmpx_program, surface.Handle(), draw_fbo.handle, blit.dst_level, blit.dst_rect);
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -717,6 +717,7 @@ void RasterizerOpenGL::SyncTextureUnits(const Framebuffer* framebuffer) {
         if (!IsFeedbackLoop(texture_index, framebuffer, surface)) {
             BindMaterial(texture_index, surface);
             state.texture_units[texture_index].texture_2d = surface.Handle();
+            state.texture_units[texture_index].target = GL_TEXTURE_2D;
         }
     }
 

--- a/src/video_core/renderer_opengl/gl_texture_runtime.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_runtime.cpp
@@ -222,8 +222,9 @@ bool TextureRuntime::ClearTextureWithoutFbo(Surface& surface,
         UNREACHABLE_MSG("Unknown surface type {}", surface.type);
     }
     glClearTexSubImage(surface.Handle(), clear.texture_level, clear.texture_rect.left,
-                       clear.texture_rect.bottom, 0, clear.texture_rect.GetWidth(),
-                       clear.texture_rect.GetHeight(), 1, format, type, &clear.value);
+                       clear.texture_rect.bottom, clear.texture_layer,
+                       clear.texture_rect.GetWidth(), clear.texture_rect.GetHeight(), 1, format,
+                       type, &clear.value);
     return true;
 }
 
@@ -245,7 +246,7 @@ void TextureRuntime::ClearTexture(Surface& surface, const VideoCore::TextureClea
     state.draw.draw_framebuffer = draw_fbos[FboIndex(surface.type)].handle;
     state.Apply();
 
-    surface.Attach(GL_DRAW_FRAMEBUFFER, clear.texture_level, 0);
+    surface.Attach(GL_DRAW_FRAMEBUFFER, clear.texture_level, clear.texture_layer);
 
     switch (surface.type) {
     case SurfaceType::Color:

--- a/src/video_core/renderer_opengl/gl_texture_runtime.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_runtime.cpp
@@ -327,6 +327,7 @@ void TextureRuntime::GenerateMipmaps(Surface& surface) {
 
     const auto generate = [&](u32 index) {
         state.texture_units[0].texture_2d = surface.Handle(index);
+        state.texture_units[0].target = GL_TEXTURE_2D;
         state.Apply();
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, surface.levels - 1);
         glGenerateMipmap(GL_TEXTURE_2D);
@@ -555,6 +556,7 @@ bool Surface::DownloadWithoutFbo(const VideoCore::BufferTextureCopy& download,
         // that only support up to 4.3
         OpenGLState state = OpenGLState::GetCurState();
         state.texture_units[0].texture_2d = Handle(0);
+        state.texture_units[0].target = GL_TEXTURE_2D;
         state.Apply();
 
         glGetTexImage(GL_TEXTURE_2D, download.texture_level, tuple.format, tuple.type,

--- a/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
@@ -350,8 +350,8 @@ bool TextureRuntime::ClearTexture(Surface& surface, const VideoCore::TextureClea
                 .aspectMask = params.aspect,
                 .baseMipLevel = clear.texture_level,
                 .levelCount = 1,
-                .baseArrayLayer = 0,
-                .layerCount = VK_REMAINING_ARRAY_LAYERS,
+                .baseArrayLayer = clear.texture_layer,
+                .layerCount = 1,
             };
 
             const vk::ImageMemoryBarrier pre_barrier = {
@@ -436,7 +436,8 @@ void TextureRuntime::ClearTextureWithRenderpass(Surface& surface,
             .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
             .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
             .image = params.src_image,
-            .subresourceRange = MakeSubresourceRange(params.aspect, clear.texture_level),
+            .subresourceRange =
+                MakeSubresourceRange(params.aspect, clear.texture_level, 1, clear.texture_layer),
         };
 
         const vk::ImageMemoryBarrier post_barrier = {


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Fixes some issues found in https://github.com/azahar-emu/azahar/pull/2159.

OpenGL state was depending on the assumption that a lot of texture-units were always going to be `GL_TEXTURE_2D`, but with null-cubemap state-tracking added, a lot of things break downstream after a cubemap has been set. This fixes this and also properly initializes `NULL_SURFACE_CUBE_ID`.

Before|After
-|-
<img width="400" height="480" alt="Pokémon Ultra Moon_27 06 26_15 38 20 263" src="https://github.com/user-attachments/assets/48a736dc-5d81-44da-b92a-873232f1897e" />|<img width="400" height="480" alt="Pokémon Ultra Moon_27 06 26_15 40 32 469" src="https://github.com/user-attachments/assets/211975f0-d447-468c-abb9-06640b63dcc7" />
<img width="400" height="480" alt="WWE All Stars_27 06 26_15 46 08 885" src="https://github.com/user-attachments/assets/c18c6f88-3cd3-4f05-8b57-6fd44d97d8a5" />|<img width="400" height="480" alt="WWE All Stars_27 06 26_15 44 59 087" src="https://github.com/user-attachments/assets/608d0ef5-da29-4aad-a222-6ac0b33bfb3e" />
