### PR TITLE
qt: Fix macOS freeze-on-boot caused by unprocessed events

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -4456,6 +4456,9 @@ int LaunchQtFrontend(int argc, char* argv[]) {
     QObject::connect(&app, &QGuiApplication::applicationStateChanged, &main_window,
                      &GMainWindow::OnAppFocusStateChanged);
 
+    // Process any pending events before executing the app (prevents freeze-on–boot on macOS)
+    app.processEvents();
+
     int result = app.exec();
     return result;
 }


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Closes #1637

As far as I can tell the line added here really shouldn't be necessary, and wasn't until a relatively recent change in either Qt or macOS. The exact reason behind the original issue is unclear, but by educated guess it could have been caused by some kind of race condition within Qt?
