### PR TITLE
qt: gdb: Do not change GDB settings when the gdbport arg is used

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -299,8 +299,7 @@ GMainWindow::GMainWindow(Core::System& system_)
             if (i >= args.size() - 1 || args[i + 1].startsWith(QChar::fromLatin1('-'))) {
                 continue;
             }
-            Settings::values.use_gdbstub = true;
-            Settings::values.gdbstub_port = strtoul(args[++i].toLatin1(), NULL, 0);
+            gdbport_from_arg = strtoul(args[++i].toLatin1(), NULL, 0);
             continue;
         }
 
@@ -1524,6 +1523,13 @@ void GMainWindow::BootGame(const QString& filename) {
     // possible. Instead register the app loader early and do not create it again on system load.
     if (loader && !loader->SupportsMultipleInstancesForSameFile()) {
         system.RegisterAppLoaderEarly(loader);
+    }
+
+    // Override GDB settings if emulator was launched with
+    // GDB port option.
+    if (gdbport_from_arg != -1) {
+        system.SetGDBPortOverride(gdbport_from_arg);
+        system.SetDebugNextProcessFlag();
     }
 
     system.ApplySettings();

--- a/src/citra_qt/citra_qt.h
+++ b/src/citra_qt/citra_qt.h
@@ -407,6 +407,8 @@ private:
     // Whether game was paused due to stopping video dumping
     bool game_paused_for_dumping = false;
 
+    int gdbport_from_arg = -1;
+
     QString gl_renderer;
     std::vector<QString> physical_devices;
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -762,8 +762,13 @@ void System::Reset() {
 
 void System::ApplySettings() {
 #ifdef ENABLE_GDBSTUB
-    GDBStub::SetServerPort(Settings::values.gdbstub_port.GetValue());
-    GDBStub::ToggleServer(Settings::values.use_gdbstub.GetValue());
+    if (override_gdb_port != -1) {
+        GDBStub::SetServerPort(override_gdb_port);
+        GDBStub::ToggleServer(true);
+    } else {
+        GDBStub::SetServerPort(Settings::values.gdbstub_port.GetValue());
+        GDBStub::ToggleServer(Settings::values.use_gdbstub.GetValue());
+    }
 #endif
 
     if (gpu) {

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -421,6 +421,10 @@ public:
 
     void DebugUnscheduleAllThreadsFromFrontend(bool unschedule);
 
+    void SetGDBPortOverride(int port) {
+        override_gdb_port = port;
+    }
+
 private:
     /**
      * Initialize the emulated system.
@@ -531,6 +535,7 @@ private:
     std::function<void()> info_led_color_changed;
 
     bool debug_next_process;
+    int override_gdb_port = -1;
 
     friend class boost::serialization::access;
     template <typename Archive>


### PR DESCRIPTION
Changes the behaviour of the `--gdbport` to match how it worked before the gdb refactor. Using the port argument will not affect the GDB settings and will enable the "debug next process on start" flag.