### PR TITLE
common: Detect and print AppData folder get failures

### DIFF
--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -864,12 +864,16 @@ const std::string& GetExeDirectory() {
 }
 
 std::string AppDataRoamingDirectory() {
-    PWSTR pw_local_path = nullptr;
-    // Only supported by Windows Vista or later
-    SHGetKnownFolderPath(FOLDERID_RoamingAppData, 0, nullptr, &pw_local_path);
-    std::string local_path = Common::UTF16ToUTF8(pw_local_path);
-    CoTaskMemFree(pw_local_path);
-    return local_path;
+    PWSTR path = nullptr;
+
+    const HRESULT hr =
+        SHGetKnownFolderPath(FOLDERID_RoamingAppData, KF_FLAG_DEFAULT, nullptr, &path);
+
+    ASSERT_MSG(SUCCEEDED(hr) && path != nullptr, "Failed to get AppData directory: {:X}", hr);
+
+    std::string result = Common::UTF16ToUTF8(path);
+    CoTaskMemFree(path);
+    return result;
 }
 #else
 /**

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -573,7 +573,9 @@ void Start() {
 }
 
 void Stop() {
-    Impl::Stop();
+    if (logging_initialized) {
+        Impl::Stop();
+    }
 }
 
 void DisableLoggingInTests() {
@@ -595,7 +597,7 @@ void SetColorConsoleBackendEnabled(bool enabled) {
 void FmtLogMessageImpl(Class log_class, Level log_level, const char* filename,
                        unsigned int line_num, const char* function, fmt::string_view format,
                        const fmt::format_args& args) {
-    if (initialization_in_progress_suppress_logging) [[unlikely]] {
+    if (initialization_in_progress_suppress_logging && log_level < Level::Critical) [[unlikely]] {
         return;
     }
 


### PR DESCRIPTION
Detects and prints an error if the `AppData` get code fails on Windows. I discovered this while playing with the `USERPROFILE` env variable.

I've also fixed a crash due to logging Stop being called while not initialized, and critical errors not being logged during initialization.