### PR TITLE
android: Implement update checker functionality mirroring the Qt frontend

### DIFF
--- a/CMakeModules/GenerateSettingKeys.cmake
+++ b/CMakeModules/GenerateSettingKeys.cmake
@@ -149,6 +149,8 @@ foreach(KEY IN ITEMS
     "web_api_url"
     "citra_username"
     "citra_token"
+    "check_for_update_on_start"
+    "update_check_channel"
 )
     set(SETTING_KEY_LIST "${SETTING_KEY_LIST}\n\"${KEY}\",")
     set(SETTING_KEY_DEFINITIONS "${SETTING_KEY_DEFINITIONS}\nDEFINE_KEY(${KEY})")
@@ -231,8 +233,6 @@ if (ENABLE_QT)
         "pauseWhenInBackground"
         "muteWhenInBackground"
         "hideInactiveMouse"
-        "check_for_update_on_start"
-        "update_check_channel"
         "inserted_cartridge"
         "enable_discord_presence"
         "iconSize"

--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -87,6 +87,8 @@ android {
             }
         }
 
+        buildConfigField("String", "GIT_VERSION", "\"${getGitVersion()}\"")
+        // ^ Has no suffix, unlike VERSION_NAME
         buildConfigField("String", "GIT_HASH", "\"${getGitHash()}\"")
         buildConfigField("String", "BRANCH", "\"${getBranch()}\"")
     }

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/SettingKeys.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/SettingKeys.kt
@@ -127,6 +127,8 @@ object SettingKeys {
     external fun udp_input_port(): String
     external fun udp_pad_index(): String
     external fun record_frame_times(): String
+    external fun check_for_update_on_start(): String
+    external fun update_check_channel(): String
 
     // Android
     external fun expand_to_cutout_area(): String

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
@@ -129,7 +129,8 @@ enum class BooleanSetting(
         SettingKeys.simulate_3ds_gpu_timings(),
         Settings.SECTION_RENDERER,
         false
-    );
+    ),
+    CHECK_FOR_UPDATES(SettingKeys.check_for_update_on_start(), Settings.SECTION_MISC, true);
 
     override var boolean: Boolean = defaultValue
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
@@ -64,7 +64,8 @@ enum class IntSetting(
         0
     ),
     RENDER_3D_WHICH_DISPLAY(SettingKeys.render_3d_which_display(), Settings.SECTION_RENDERER, 0),
-    ASPECT_RATIO(SettingKeys.aspect_ratio(), Settings.SECTION_LAYOUT, 0);
+    ASPECT_RATIO(SettingKeys.aspect_ratio(), Settings.SECTION_LAYOUT, 0),
+    UPDATE_CHECK_CHANNEL(SettingKeys.update_check_channel(), Settings.SECTION_MISC, 0);
 
     override var int: Int = defaultValue
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/Settings.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/Settings.kt
@@ -247,7 +247,8 @@ class Settings {
                     SECTION_STORAGE,
                     SECTION_UTILITY,
                     SECTION_AUDIO,
-                    SECTION_DEBUG
+                    SECTION_DEBUG,
+                    SECTION_MISC
                 )
         }
     }

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -268,6 +268,27 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
             )
             add(
                 SwitchSetting(
+                    BooleanSetting.CHECK_FOR_UPDATES,
+                    R.string.check_for_updates,
+                    R.string.check_for_updates_description,
+                    BooleanSetting.CHECK_FOR_UPDATES.key,
+                    BooleanSetting.CHECK_FOR_UPDATES.defaultValue
+                )
+            )
+            add(
+                SingleChoiceSetting(
+                    IntSetting.UPDATE_CHECK_CHANNEL,
+                    R.string.update_check_channel,
+                    R.string.update_check_channel_description,
+                    R.array.updateCheckChannels,
+                    R.array.updateCheckChannelsValues,
+                    IntSetting.UPDATE_CHECK_CHANNEL.key,
+                    IntSetting.UPDATE_CHECK_CHANNEL.defaultValue,
+                    isEnabled = BooleanSetting.CHECK_FOR_UPDATES.boolean
+                )
+            )
+            add(
+                SwitchSetting(
                     BooleanSetting.ANDROID_HIDE_IMAGES,
                     R.string.android_hide_images,
                     R.string.android_hide_images_description,

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -14,6 +14,7 @@ import android.os.Build
 import android.text.TextUtils
 import androidx.preference.PreferenceManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import org.citra.citra_emu.BuildConfig
 import org.citra.citra_emu.CitraApplication
 import org.citra.citra_emu.R
 import org.citra.citra_emu.display.ScreenLayout
@@ -272,7 +273,8 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     R.string.check_for_updates,
                     R.string.check_for_updates_description,
                     BooleanSetting.CHECK_FOR_UPDATES.key,
-                    BooleanSetting.CHECK_FOR_UPDATES.defaultValue
+                    BooleanSetting.CHECK_FOR_UPDATES.defaultValue,
+                    isEnabled = !BuildConfig.DEBUG
                 )
             )
             add(
@@ -284,7 +286,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     R.array.updateCheckChannelsValues,
                     IntSetting.UPDATE_CHECK_CHANNEL.key,
                     IntSetting.UPDATE_CHECK_CHANNEL.defaultValue,
-                    isEnabled = BooleanSetting.CHECK_FOR_UPDATES.boolean
+                    isEnabled = (!BuildConfig.DEBUG && BooleanSetting.CHECK_FOR_UPDATES.boolean)
                 )
             )
             add(

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -47,6 +47,7 @@ import org.citra.citra_emu.features.settings.model.view.SwitchSetting
 import org.citra.citra_emu.features.settings.utils.SettingsFile
 import org.citra.citra_emu.fragments.ResetSettingsDialogFragment
 import org.citra.citra_emu.utils.BirthdayMonth
+import org.citra.citra_emu.utils.BuildUtil
 import org.citra.citra_emu.utils.GraphicsUtil
 import org.citra.citra_emu.utils.Log
 import org.citra.citra_emu.utils.SystemSaveGame
@@ -277,27 +278,29 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     isEnabled = !BuildConfig.DEBUG
                 )
             )
-            add(
-                SingleChoiceSetting(
-                    IntSetting.UPDATE_CHECK_CHANNEL,
-                    R.string.update_check_channel,
-                    R.string.update_check_channel_description,
-                    R.array.updateCheckChannels,
-                    R.array.updateCheckChannelsValues,
-                    IntSetting.UPDATE_CHECK_CHANNEL.key,
-                    IntSetting.UPDATE_CHECK_CHANNEL.defaultValue,
-                    isEnabled = (!BuildConfig.DEBUG && BooleanSetting.CHECK_FOR_UPDATES.boolean)
+            if (!BuildUtil.isGooglePlayBuild) {
+                add(
+                    SingleChoiceSetting(
+                        IntSetting.UPDATE_CHECK_CHANNEL,
+                        R.string.update_check_channel,
+                        R.string.update_check_channel_description,
+                        R.array.updateCheckChannels,
+                        R.array.updateCheckChannelsValues,
+                        IntSetting.UPDATE_CHECK_CHANNEL.key,
+                        IntSetting.UPDATE_CHECK_CHANNEL.defaultValue,
+                        isEnabled = (!BuildConfig.DEBUG && BooleanSetting.CHECK_FOR_UPDATES.boolean)
+                    )
                 )
-            )
-            add(
-                SwitchSetting(
-                    BooleanSetting.ANDROID_HIDE_IMAGES,
-                    R.string.android_hide_images,
-                    R.string.android_hide_images_description,
-                    BooleanSetting.ANDROID_HIDE_IMAGES.key,
-                    BooleanSetting.ANDROID_HIDE_IMAGES.defaultValue
+                add(
+                    SwitchSetting(
+                        BooleanSetting.ANDROID_HIDE_IMAGES,
+                        R.string.android_hide_images,
+                        R.string.android_hide_images_description,
+                        BooleanSetting.ANDROID_HIDE_IMAGES.key,
+                        BooleanSetting.ANDROID_HIDE_IMAGES.defaultValue
+                    )
                 )
-            )
+            }
         }
     }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/updatechecker/UpdateChecker.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/updatechecker/UpdateChecker.kt
@@ -44,6 +44,13 @@ object UpdateChecker {
         }
     }
 
+    private fun String.stripQuotes(): String? {
+        if (this.first() != '"' || this.last() != '"') {
+            return null
+        }
+        return this.drop(1).dropLast(1)
+    }
+
     fun getLatestRelease(includePrereleases: Boolean): String? {
         val updateCheckUrl = "https://api.github.com"
         var updateCheckPath = "/repos/azahar-emu/azahar"
@@ -59,10 +66,19 @@ object UpdateChecker {
                 return null
             }
 
-            val latestTag = Json.decodeFromString<JsonArray>(
-                tagsResponse
-            )[0].jsonObject["name"].toString()
-                .drop(1).dropLast(1) // Remove quotation marks
+            var latestTag: String?
+            try {
+                latestTag = Json.decodeFromString<JsonArray>(
+                    tagsResponse
+                )[0].jsonObject["name"].toString().stripQuotes()
+            } catch (e: Exception) {
+                Log.error("[UpdateChecker] JSON decode failed: $e")
+                return null
+            }
+            if (latestTag.isNullOrEmpty()) {
+                Log.error("[UpdateChecker] Failed to strip quotes from tag or tag was blank")
+                return null
+            }
             val latestTagHasRelease = releasesResponse.contains("\"$latestTag\"")
             // If there is a newer tag, but that tag has no associated release, don't prompt the
             // user to update.
@@ -79,10 +95,19 @@ object UpdateChecker {
                 return null
             }
 
-            val latestTag = Json.decodeFromString<JsonElement>(
-                response
-            ).jsonObject["tag_name"].toString()
-                .drop(1).dropLast(1) // Remove quotation mark
+            var latestTag: String?
+            try {
+                latestTag = Json.decodeFromString<JsonElement>(
+                    response
+                ).jsonObject["tag_name"].toString().stripQuotes()
+            } catch (e: Exception) {
+                Log.error("[UpdateChecker] JSON decode failed: $e")
+                return null
+            }
+            if (latestTag.isNullOrEmpty()) {
+                Log.error("[UpdateChecker] Failed to strip quotes from tag or tag was blank")
+                return null
+            }
             return latestTag
         }
     }

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/updatechecker/UpdateChecker.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/updatechecker/UpdateChecker.kt
@@ -82,6 +82,7 @@ object UpdateChecker {
             val latestTag = Json.decodeFromString<JsonElement>(
                 response
             ).jsonObject["tag_name"].toString()
+                .drop(1).dropLast(1) // Remove quotation mark
             return latestTag
         }
     }

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/updatechecker/UpdateChecker.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/updatechecker/UpdateChecker.kt
@@ -1,0 +1,88 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+package org.citra.citra_emu.features.updatechecker
+
+import java.net.HttpURLConnection
+import java.net.URL
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.jsonObject
+import org.citra.citra_emu.utils.Log
+
+object UpdateChecker {
+
+    private fun getResponse(urlString: String): String? {
+        var connection: HttpURLConnection? = null
+        try {
+            val url = URL(urlString)
+            connection = url.openConnection() as HttpURLConnection
+            connection.requestMethod = "GET"
+            connection.connectTimeout = 15.seconds.inWholeMilliseconds.toInt()
+            connection.readTimeout = 15.seconds.inWholeMilliseconds.toInt()
+
+            if (connection.responseCode == HttpURLConnection.HTTP_OK) {
+                return connection.inputStream.bufferedReader().use { it.readText() }
+            } else {
+                Log.error(
+                    "[UpdateChecker] Failed to get HTTP response with HTTP response code ${connection.responseCode}"
+                )
+                return null
+            }
+        } catch (e: Exception) {
+            Log.error(
+                "[UpdateChecker] Failed to get HTTP response with Kotlin exception:\n" +
+                    "Type: $e\n" +
+                    "Message: ${e.message}"
+            )
+            return null
+        } finally {
+            connection?.disconnect()
+        }
+    }
+
+    fun getLatestRelease(includePrereleases: Boolean): String? {
+        val updateCheckUrl = "https://api.github.com"
+        var updateCheckPath = "/repos/azahar-emu/azahar"
+        if (includePrereleases) { // This can return either a prerelease or a stable release,
+            // whichever is more recent.
+            val updateCheckTagsPath = "$updateCheckPath/tags"
+            val updateCheckReleasesPath = "$updateCheckPath/releases"
+
+            val tagsResponse = getResponse(updateCheckUrl + updateCheckTagsPath)
+            val releasesResponse = getResponse(updateCheckUrl + updateCheckReleasesPath)
+
+            if (tagsResponse.isNullOrEmpty() || releasesResponse.isNullOrEmpty()) {
+                return null
+            }
+
+            val latestTag = Json.decodeFromString<JsonArray>(
+                tagsResponse
+            )[0].jsonObject["name"].toString()
+                .drop(1).dropLast(1) // Remove quotation marks
+            val latestTagHasRelease = releasesResponse.contains("\"$latestTag\"")
+            // If there is a newer tag, but that tag has no associated release, don't prompt the
+            // user to update.
+            if (!latestTagHasRelease) {
+                return null
+            }
+
+            return latestTag
+        } else { // Stable releases only
+            updateCheckPath += "/releases/latest"
+            val response = getResponse(updateCheckUrl + updateCheckPath)
+
+            if (response.isNullOrEmpty()) {
+                return null
+            }
+
+            val latestTag = Json.decodeFromString<JsonElement>(
+                response
+            ).jsonObject["tag_name"].toString()
+            return latestTag
+        }
+    }
+}

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/GamesFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/GamesFragment.kt
@@ -243,7 +243,8 @@ class GamesFragment : Fragment() {
         super.onResume()
 
         // Perform update check
-        if (!BuildUtil.isGooglePlayBuild &&
+        if (!BuildConfig.DEBUG &&
+            !BuildUtil.isGooglePlayBuild &&
             BooleanSetting.CHECK_FOR_UPDATES.boolean &&
             !homeViewModel.updatePromptShown
         ) {

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/GamesFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/GamesFragment.kt
@@ -235,6 +235,8 @@ class GamesFragment : Fragment() {
         setInsets()
     }
 
+    private fun getMajorVersion(version: String): Int? = version.split('.')[0].toIntOrNull()
+
     override fun onResume() {
         super.onResume()
 
@@ -243,16 +245,21 @@ class GamesFragment : Fragment() {
             Thread({
                 val checkForPrereleaseUpdates = false
                 val latestReleaseTag = UpdateChecker.getLatestRelease(checkForPrereleaseUpdates)
-                if (latestReleaseTag != BuildConfig.GIT_VERSION) {
-                    // const int latest_major_version = GetMajorVersion(latest_release_tag.value());
-                    // const int current_major_version = GetMajorVersion(Common::g_build_fullname);
-                    // if (current_major_version <= latest_major_version) {
-                    UpdateAvailableNotificationFragment.newInstance(checkForPrereleaseUpdates)
-                        .show(
-                            requireActivity().supportFragmentManager,
-                            UpdateAvailableNotificationFragment.TAG
-                        )
-                    // }
+                if (!latestReleaseTag.isNullOrEmpty() &&
+                    latestReleaseTag != BuildConfig.GIT_VERSION
+                ) {
+                    val latestMajorVersion = getMajorVersion(latestReleaseTag)
+                    val currentMajorVersion = getMajorVersion(BuildConfig.GIT_VERSION)
+                    if (latestMajorVersion != null &&
+                        currentMajorVersion != null &&
+                        currentMajorVersion <= latestMajorVersion
+                    ) {
+                        UpdateAvailableNotificationFragment.newInstance(checkForPrereleaseUpdates)
+                            .show(
+                                requireActivity().supportFragmentManager,
+                                UpdateAvailableNotificationFragment.TAG
+                            )
+                    }
                 }
             }).start()
             homeViewModel.updatePromptShown = true

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/GamesFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/GamesFragment.kt
@@ -35,6 +35,8 @@ import org.citra.citra_emu.NativeLibrary
 import org.citra.citra_emu.R
 import org.citra.citra_emu.adapters.GameAdapter
 import org.citra.citra_emu.databinding.FragmentGamesBinding
+import org.citra.citra_emu.features.settings.model.BooleanSetting
+import org.citra.citra_emu.features.settings.model.IntSetting
 import org.citra.citra_emu.features.settings.model.Settings
 import org.citra.citra_emu.features.updatechecker.UpdateChecker
 import org.citra.citra_emu.model.Game
@@ -241,9 +243,12 @@ class GamesFragment : Fragment() {
         super.onResume()
 
         // Perform update check
-        if (!BuildUtil.isGooglePlayBuild && !homeViewModel.updatePromptShown) {
+        if (!BuildUtil.isGooglePlayBuild &&
+            BooleanSetting.CHECK_FOR_UPDATES.boolean &&
+            !homeViewModel.updatePromptShown
+        ) {
             Thread({
-                val checkForPrereleaseUpdates = false
+                val checkForPrereleaseUpdates = (IntSetting.UPDATE_CHECK_CHANNEL.int == 1)
                 val latestReleaseTag = UpdateChecker.getLatestRelease(checkForPrereleaseUpdates)
                 if (!latestReleaseTag.isNullOrEmpty() &&
                     latestReleaseTag != BuildConfig.GIT_VERSION

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/GamesFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/GamesFragment.kt
@@ -29,12 +29,14 @@ import com.google.android.material.transition.MaterialFadeThrough
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import org.citra.citra_emu.BuildConfig
 import org.citra.citra_emu.CitraApplication
 import org.citra.citra_emu.NativeLibrary
 import org.citra.citra_emu.R
 import org.citra.citra_emu.adapters.GameAdapter
 import org.citra.citra_emu.databinding.FragmentGamesBinding
 import org.citra.citra_emu.features.settings.model.Settings
+import org.citra.citra_emu.features.updatechecker.UpdateChecker
 import org.citra.citra_emu.model.Game
 import org.citra.citra_emu.utils.BuildUtil
 import org.citra.citra_emu.viewmodel.CompressProgressDialogViewModel
@@ -231,6 +233,30 @@ class GamesFragment : Fragment() {
         }
 
         setInsets()
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        // Perform update check
+        if (!BuildUtil.isGooglePlayBuild && !homeViewModel.updatePromptShown) {
+            Thread({
+                val checkForPrereleaseUpdates = false
+                val latestReleaseTag = UpdateChecker.getLatestRelease(checkForPrereleaseUpdates)
+                if (latestReleaseTag != BuildConfig.GIT_VERSION) {
+                    // const int latest_major_version = GetMajorVersion(latest_release_tag.value());
+                    // const int current_major_version = GetMajorVersion(Common::g_build_fullname);
+                    // if (current_major_version <= latest_major_version) {
+                    UpdateAvailableNotificationFragment.newInstance(checkForPrereleaseUpdates)
+                        .show(
+                            requireActivity().supportFragmentManager,
+                            UpdateAvailableNotificationFragment.TAG
+                        )
+                    // }
+                }
+            }).start()
+            homeViewModel.updatePromptShown = true
+        }
     }
 
     override fun onDestroyView() {

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/GamesFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/GamesFragment.kt
@@ -254,7 +254,10 @@ class GamesFragment : Fragment() {
                         currentMajorVersion != null &&
                         currentMajorVersion <= latestMajorVersion
                     ) {
-                        UpdateAvailableNotificationFragment.newInstance(checkForPrereleaseUpdates)
+                        UpdateAvailableNotificationFragment.newInstance(
+                            latestReleaseTag,
+                            checkForPrereleaseUpdates
+                        )
                             .show(
                                 requireActivity().supportFragmentManager,
                                 UpdateAvailableNotificationFragment.TAG

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/UpdateAvailableNotificationFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/UpdateAvailableNotificationFragment.kt
@@ -48,6 +48,7 @@ class UpdateAvailableNotificationFragment(
                 )
                 startActivity(intent)
             }
+            .setNegativeButton(android.R.string.cancel, null)
             .show()
     }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/UpdateAvailableNotificationFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/UpdateAvailableNotificationFragment.kt
@@ -15,10 +15,13 @@ import org.citra.citra_emu.R
 import org.citra.citra_emu.ui.main.MainActivity
 import org.citra.citra_emu.utils.BuildUtil
 
-class UpdateAvailableNotificationFragment(checkForPrereleaseUpdatesOverride: Boolean) :
-    DialogFragment() {
+class UpdateAvailableNotificationFragment(
+    newVersionOverride: String,
+    checkForPrereleaseUpdatesOverride: Boolean
+) : DialogFragment() {
     private lateinit var mainActivity: MainActivity
 
+    private val newVersion = newVersionOverride
     private val checkForPrereleaseUpdates = checkForPrereleaseUpdatesOverride
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
@@ -27,14 +30,17 @@ class UpdateAvailableNotificationFragment(checkForPrereleaseUpdatesOverride: Boo
 
         isCancelable = false
 
+        val updateNotificationDescription =
+            getString(R.string.update_available_description, newVersion)
+
         return MaterialAlertDialogBuilder(requireContext())
             .setTitle(R.string.update_available)
-            .setMessage(R.string.update_available_description)
+            .setMessage(updateNotificationDescription)
             .setPositiveButton(android.R.string.ok) { _: DialogInterface, _: Int ->
                 val updateLink: String = if (checkForPrereleaseUpdates) {
                     getString(R.string.prerelease_channel_update_link)
                 } else {
-                    getString(R.string.stable_channel_update_link)
+                    getString(R.string.prerelease_channel_update_link)
                 }
                 val intent = Intent(
                     Intent.ACTION_VIEW,
@@ -48,9 +54,12 @@ class UpdateAvailableNotificationFragment(checkForPrereleaseUpdatesOverride: Boo
     companion object {
         const val TAG = "UpdateAvailableNotificationFragment"
 
-        fun newInstance(checkForPrereleaseUpdates: Boolean): UpdateAvailableNotificationFragment {
+        fun newInstance(
+            newVersion: String,
+            checkForPrereleaseUpdates: Boolean
+        ): UpdateAvailableNotificationFragment {
             BuildUtil.assertNotGooglePlay()
-            return UpdateAvailableNotificationFragment(checkForPrereleaseUpdates)
+            return UpdateAvailableNotificationFragment(newVersion, checkForPrereleaseUpdates)
         }
     }
 }

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/UpdateAvailableNotificationFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/UpdateAvailableNotificationFragment.kt
@@ -1,0 +1,56 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+package org.citra.citra_emu.fragments
+
+import android.app.Dialog
+import android.content.DialogInterface
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import androidx.fragment.app.DialogFragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import org.citra.citra_emu.R
+import org.citra.citra_emu.ui.main.MainActivity
+import org.citra.citra_emu.utils.BuildUtil
+
+class UpdateAvailableNotificationFragment(checkForPrereleaseUpdatesOverride: Boolean) :
+    DialogFragment() {
+    private lateinit var mainActivity: MainActivity
+
+    private val checkForPrereleaseUpdates = checkForPrereleaseUpdatesOverride
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        BuildUtil.assertNotGooglePlay()
+        mainActivity = requireActivity() as MainActivity
+
+        isCancelable = false
+
+        return MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.update_available)
+            .setMessage(R.string.update_available_description)
+            .setPositiveButton(android.R.string.ok) { _: DialogInterface, _: Int ->
+                val updateLink: String = if (checkForPrereleaseUpdates) {
+                    getString(R.string.prerelease_channel_update_link)
+                } else {
+                    getString(R.string.stable_channel_update_link)
+                }
+                val intent = Intent(
+                    Intent.ACTION_VIEW,
+                    Uri.parse(updateLink)
+                )
+                startActivity(intent)
+            }
+            .show()
+    }
+
+    companion object {
+        const val TAG = "UpdateAvailableNotificationFragment"
+
+        fun newInstance(checkForPrereleaseUpdates: Boolean): UpdateAvailableNotificationFragment {
+            BuildUtil.assertNotGooglePlay()
+            return UpdateAvailableNotificationFragment(checkForPrereleaseUpdates)
+        }
+    }
+}

--- a/src/android/app/src/main/java/org/citra/citra_emu/viewmodel/HomeViewModel.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/viewmodel/HomeViewModel.kt
@@ -82,6 +82,8 @@ class HomeViewModel : ViewModel() {
             _selectedGamesDirectory.value = value
         }
 
+    var updatePromptShown = false
+
     fun setNavigationVisibility(visible: Boolean, animated: Boolean) {
         if (_navigationVisible.value.first == visible) {
             return

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -543,6 +543,14 @@ static const char* android_config_default_file_content = (BOOST_HANA_STRING(R"(
 # 0 (default): No, 1: Yes
 )") DECLARE_KEY(android_hide_images) BOOST_HANA_STRING(R"(
 
+# Whether or not an in-app notification should be displayed when an update is available for Azahar
+# 0: No, 1 (default): Yes
+)") DECLARE_KEY(check_for_update_on_start) BOOST_HANA_STRING(R"(
+
+# Which update channel should be used by the update checker
+# 0 (default): Stable, 1: Prerelease
+)") DECLARE_KEY(update_check_channel) BOOST_HANA_STRING(R"(
+
 [Debugging]
 # Record frame time data, can be found in the log directory. Boolean value
 )") DECLARE_KEY(record_frame_times) BOOST_HANA_STRING(R"(

--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -682,4 +682,13 @@
         <item>9</item>
     </integer-array>
 
+    <string-array name="updateCheckChannels">
+        <item>@string/update_check_channel_stable</item>
+        <item>@string/update_check_channel_prerelease</item>
+    </string-array>
+    <integer-array name="updateCheckChannelsValues">
+        <item>0</item>
+        <item>1</item>
+    </integer-array>
+
 </resources>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -995,4 +995,10 @@
     <string name="decompress_failed">Decompression failed.</string>
     <string name="compress_decompress_installed_app">Already installed applications cannot be compressed or decompressed.</string>
 
+    <!-- Update Checker -->
+    <string name="stable_channel_update_link" translatable="false">https://azahar-emu.org/pages/download/</string>
+    <string name="prerelease_channel_update_link" translatable="false">https://github.com/azahar-emu/azahar/releases</string>
+    <string name="update_available">Update Available</string>
+    <string name="update_available_description">An update is available for Azahar.\nWould you like to download it?</string>
+
 </resources>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -999,6 +999,6 @@
     <string name="stable_channel_update_link" translatable="false">https://azahar-emu.org/pages/download/</string>
     <string name="prerelease_channel_update_link" translatable="false">https://github.com/azahar-emu/azahar/releases</string>
     <string name="update_available">Update Available</string>
-    <string name="update_available_description">An update is available for Azahar.\nWould you like to download it?</string>
+    <string name="update_available_description">A newer version of Azahar is available (version %1$s).\nWould you like to download it?</string>
 
 </resources>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -1000,5 +1000,11 @@
     <string name="prerelease_channel_update_link" translatable="false">https://github.com/azahar-emu/azahar/releases</string>
     <string name="update_available">Update Available</string>
     <string name="update_available_description">A newer version of Azahar is available (version %1$s).\nWould you like to download it?</string>
+    <string name="check_for_updates">Check For Updates</string>
+    <string name="check_for_updates_description">Display an in-app notification when an update is available for Azahar.</string>
+    <string name="update_check_channel">Update Channel</string>
+    <string name="update_check_channel_description">Which update channel to use when checking for updates.</string>
+    <string name="update_check_channel_stable">Stable</string>
+    <string name="update_check_channel_prerelease">Prerelease</string>
 
 </resources>

--- a/src/citra_qt/update_checker.cpp
+++ b/src/citra_qt/update_checker.cpp
@@ -10,7 +10,7 @@
 #include "common/logging/log.h"
 #include "update_checker.h"
 
-std::optional<std::string> GetResponse(std::string url, std::string path) {
+static std::optional<std::string> GetResponse(std::string url, std::string path) {
     constexpr std::size_t timeout_seconds = 15;
 
     std::unique_ptr<httplib::Client> client = std::make_unique<httplib::Client>(url);
@@ -77,7 +77,7 @@ std::optional<std::string> UpdateChecker::GetLatestRelease(bool include_prerelea
                 return {};
 
             return latest_tag;
-        } else { // This is a stable release, only check for other stable releases.
+        } else { // Stable releases only
             update_check_path += "/releases/latest";
             const auto response = GetResponse(update_check_url, update_check_path);
 


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Closes #1591

TODO:
- [x] GitHub API retrieval code implementation
- [x] Update notifications in frontend
- [x] Show available update version number in notification
- [x] Intelligent version number parsing
- [x] User-configurable update checker options (enable/disable, select update channel)
- [x] Auto-disable for Google Play builds
- [x] Auto-disable for developer builds
- [x] Testing