### PR TITLE
libretro: scope Vulkan case to fix MSVC build (C2360)

### DIFF
--- a/src/citra_libretro/citra_libretro.cpp
+++ b/src/citra_libretro/citra_libretro.cpp
@@ -552,7 +552,7 @@ bool retro_load_game(const struct retro_game_info* info) {
     emu_instance->emu_window->UpdateLayout();
 
     switch (Settings::values.graphics_api.GetValue()) {
-    case Settings::GraphicsAPI::OpenGL:
+    case Settings::GraphicsAPI::OpenGL: {
 #ifdef ENABLE_OPENGL
         LOG_INFO(Frontend, "Using OpenGL hw renderer");
         LibRetro::SetHWSharedContext();
@@ -576,7 +576,12 @@ bool retro_load_game(const struct retro_game_info* info) {
         LibRetro::SetFramebufferCallback(emu_instance->hw_render.get_current_framebuffer);
 #endif
         break;
-    case Settings::GraphicsAPI::Vulkan:
+    }
+    case Settings::GraphicsAPI::Vulkan: {
+        // These braces are required (not only for consistency): vk_negotiation
+        // below is declared with an initializer, so without an explicit scope
+        // the following case label would jump past that initialization. MSVC
+        // rejects that as error C2360 under /permissive- /WX.
 #ifdef ENABLE_VULKAN
         LOG_INFO(Frontend, "Using Vulkan hw renderer");
         emu_instance->hw_render.context_type = RETRO_HW_CONTEXT_VULKAN;
@@ -601,12 +606,14 @@ bool retro_load_game(const struct retro_game_info* info) {
         LibRetro::SetHWRenderContextNegotiationInterface((void**)&vk_negotiation);
 #endif
         break;
-    case Settings::GraphicsAPI::Software:
+    }
+    case Settings::GraphicsAPI::Software: {
         emu_instance->emu_window->CreateContext();
         emu_instance->game_loaded = do_load_game();
         if (!emu_instance->game_loaded)
             return false;
         break;
+    }
     }
 
     uint64_t quirks =


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

---

---

## Summary
Native MSVC builds of the libretro core fail to compile `src/citra_libretro/citra_libretro.cpp`:

```
error C2360: initialization of 'vk_negotiation' is skipped by 'case' label
```

In the graphics-API `switch` in `retro_load_game`, the `Vulkan` case declares a `static const ... vk_negotiation` with an initializer, and the `switch` continues to the `Software` case label. Under `/permissive-` with warnings-as-errors (`/WX`), MSVC treats the jump across that initialization as an error.

## Fix
Wrap the `Vulkan` case body in a `{ }` block so the variable's scope ends before the next `case` label. Two braces, no behavior change.

## Notes
- GCC/Clang — including the MXE cross-build used by the libretro CI — accept the original, so this surfaces only on native MSVC.
- Verified the `azahar_libretro` target builds clean under MSVC 14.5x (VS 2022+) after the change.

## AI disclosure
Per the AI Policy: this two-brace fix was drafted with AI assistance. It is a mechanical fix for a specific MSVC diagnostic (scoping a `case` body) with a single correct form and no copyrightable expression, verified via a local MSVC build.
