### PR TITLE
core: apt: Add unimplemented function and fix buffer capture handling

### DIFF
--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -444,6 +444,10 @@ std::string GetTitlePath(Service::FS::MediaType media_type, u64 tid);
  */
 std::string GetMediaTitlePath(Service::FS::MediaType media_type);
 
+Result GetTitleInfoFromList(Core::System& system, std::span<const u64> title_id_list,
+                            Service::FS::MediaType media_type,
+                            std::vector<TitleInfo>& title_info_out);
+
 /**
  * Uninstalls the specified title.
  * @param media_type the storage medium the title is installed to

--- a/src/core/hle/service/apt/applet_manager.cpp
+++ b/src/core/hle/service/apt/applet_manager.cpp
@@ -274,8 +274,9 @@ void AppletManager::CancelAndSendParameter(const MessageParameter& parameter) {
                       parameter.sender_id);
 
             if (parameter.buffer.size() >= sizeof(CaptureBufferInfo)) {
-                SetCaptureInfo(parameter.buffer);
+                SetCaptureInfoSuspendedApp(parameter.buffer);
                 CaptureFrameBuffers();
+                TransferCapturedFramebuffers();
             }
 
             next_parameter->sender_id = parameter.destination_id;
@@ -616,8 +617,6 @@ Result AppletManager::PrepareToStartLibraryApplet(AppletId applet_id) {
     last_library_launcher_slot = active_slot;
     last_prepared_library_applet = applet_id;
 
-    capture_buffer_info.reset();
-
     if (Settings::values.lle_applets) {
         bool is_setup = system.GetAppLoader().DoingInitialSetup();
         auto cfg = Service::CFG::GetModule(system);
@@ -638,6 +637,8 @@ Result AppletManager::PrepareToStartLibraryApplet(AppletId applet_id) {
         LOG_DEBUG(Service_APT, "Creating HLE applet {:03X} with parent {:03X}", applet_id, parent);
         return CreateHLEApplet(applet_id, parent, false);
     }
+
+    capture_info.reset();
 }
 
 Result AppletManager::PreloadLibraryApplet(AppletId applet_id) {
@@ -735,6 +736,14 @@ Result AppletManager::CloseLibraryApplet(std::shared_ptr<Kernel::Object> object,
         slot->Reset();
     } else {
         SendParameter(param);
+    }
+
+    // TODO: This doesn't work correctly when opening the
+    // theme shop and an error showwing, because for
+    // some reason the theme shop is an application.
+    if (last_library_launcher_slot == AppletSlot::SystemApplet &&
+        GetAppletSlotFromId(AppletId::Application) != AppletSlot::Error) {
+        TransferCapturedFramebuffers();
     }
 
     return ResultSuccess;
@@ -971,7 +980,7 @@ Result AppletManager::PrepareToJumpToHomeMenu() {
 
     last_jump_to_home_slot = active_slot;
 
-    capture_buffer_info.reset();
+    capture_info.reset();
 
     if (last_jump_to_home_slot == AppletSlot::Application) {
         EnsureHomeMenuLoaded();
@@ -1465,7 +1474,7 @@ Result AppletManager::PrepareToStartApplication(u64 title_id, FS::MediaType medi
     app_start_parameters->next_title_id = title_id;
     app_start_parameters->next_media_type = media_type;
 
-    capture_buffer_info.reset();
+    capture_info.reset();
 
     app_jump_parameters.Invalidate();
 
@@ -1632,8 +1641,8 @@ static u32 GetDisplayBufferModePixelSize(DisplayBufferMode mode) {
     }
 }
 
-static void CaptureFrameBuffer(Core::System& system, u32 capture_offset, VAddr src, u32 height,
-                               DisplayBufferMode mode) {
+static void CaptureFrameBuffer(Core::System& system, u32 capture_offset, std::span<u8> dst,
+                               VAddr src, u32 height, DisplayBufferMode mode) {
     const auto bpp = GetDisplayBufferModePixelSize(mode);
     if (bpp == 0) {
         return;
@@ -1642,15 +1651,8 @@ static void CaptureFrameBuffer(Core::System& system, u32 capture_offset, VAddr s
     system.Memory().RasterizerFlushVirtualRegion(src, GSP::FRAMEBUFFER_WIDTH * height * bpp,
                                                  Memory::FlushMode::Flush);
 
-    // Address in VRAM that APT copies framebuffer captures to.
-    constexpr VAddr screen_capture_base_vaddr = Memory::VRAM_VADDR + 0x500000;
-    const auto dst_vaddr = screen_capture_base_vaddr + capture_offset;
-    auto dst_ptr = system.Memory().GetPointer(dst_vaddr);
-    if (!dst_ptr) {
-        LOG_ERROR(Service_APT,
-                  "Could not retrieve framebuffer capture destination buffer, skipping screen.");
-        return;
-    }
+    // APT captures the framebuffer to a copy on its own bss.
+    u8* dst_ptr = dst.data() + capture_offset;
 
     const auto src_ptr = system.Memory().GetPointer(src);
     if (!src_ptr) {
@@ -1664,26 +1666,38 @@ static void CaptureFrameBuffer(Core::System& system, u32 capture_offset, VAddr s
             const auto dst_offset = VideoCore::GetMortonOffset(x, y, bpp) +
                                     (y & ~7) * GSP::FRAMEBUFFER_WIDTH_POW2 * bpp;
             const auto src_offset = bpp * (GSP::FRAMEBUFFER_WIDTH * y + x);
+            ASSERT(capture_offset + dst_offset + bpp <= dst.size());
             std::memcpy(dst_ptr + dst_offset, src_ptr + src_offset, bpp);
         }
     }
-
-    system.Memory().RasterizerFlushVirtualRegion(
-        dst_vaddr, GSP::FRAMEBUFFER_WIDTH_POW2 * height * bpp, Memory::FlushMode::Invalidate);
 }
 
 void AppletManager::CaptureFrameBuffers() {
-    CaptureFrameBuffer(system, capture_info->bottom_screen_left_offset,
-                       GSP::FRAMEBUFFER_SAVE_AREA_BOTTOM, GSP::BOTTOM_FRAMEBUFFER_HEIGHT,
-                       capture_info->bottom_screen_format);
-    CaptureFrameBuffer(system, capture_info->top_screen_left_offset,
-                       GSP::FRAMEBUFFER_SAVE_AREA_TOP_LEFT, GSP::TOP_FRAMEBUFFER_HEIGHT,
-                       capture_info->top_screen_format);
-    if (capture_info->is_3d) {
-        CaptureFrameBuffer(system, capture_info->top_screen_right_offset,
-                           GSP::FRAMEBUFFER_SAVE_AREA_TOP_RIGHT, GSP::TOP_FRAMEBUFFER_HEIGHT,
-                           capture_info->top_screen_format);
+    CaptureFrameBuffer(system, capture_info_suspended_app->bottom_screen_left_offset,
+                       framebuffer_backup, GSP::FRAMEBUFFER_SAVE_AREA_BOTTOM,
+                       GSP::BOTTOM_FRAMEBUFFER_HEIGHT,
+                       capture_info_suspended_app->bottom_screen_format);
+    CaptureFrameBuffer(system, capture_info_suspended_app->top_screen_left_offset,
+                       framebuffer_backup, GSP::FRAMEBUFFER_SAVE_AREA_TOP_LEFT,
+                       GSP::TOP_FRAMEBUFFER_HEIGHT, capture_info_suspended_app->top_screen_format);
+    if (capture_info_suspended_app->is_3d) {
+        CaptureFrameBuffer(system, capture_info_suspended_app->top_screen_right_offset,
+                           framebuffer_backup, GSP::FRAMEBUFFER_SAVE_AREA_TOP_RIGHT,
+                           GSP::TOP_FRAMEBUFFER_HEIGHT,
+                           capture_info_suspended_app->top_screen_format);
     }
+}
+
+void AppletManager::TransferCapturedFramebuffers() {
+    constexpr u32 VRAM_TRANSFER_OFFSET = 0x500000;
+
+    const VAddr dst_vaddr = Memory::VRAM_VADDR + VRAM_TRANSFER_OFFSET;
+    auto dst_ptr = system.Memory().GetPointer(dst_vaddr);
+
+    memcpy(dst_ptr, framebuffer_backup.data(), framebuffer_backup.size());
+
+    system.Memory().RasterizerFlushVirtualRegion(dst_vaddr, framebuffer_backup.size(),
+                                                 Memory::FlushMode::Invalidate);
 }
 
 void AppletManager::LoadInputDevices() {

--- a/src/core/hle/service/apt/applet_manager.cpp
+++ b/src/core/hle/service/apt/applet_manager.cpp
@@ -105,7 +105,7 @@ static constexpr std::array<AppletTitleData, NumApplets> applet_titleids = {{
     // TODO(Subv): Fill in the rest of the titleids
 }};
 
-static u64 GetTitleIdForApplet(AppletId id, u32 region_value) {
+u64 GetTitleIdForApplet(AppletId id, u32 region_value) {
     ASSERT_MSG(id != AppletId::None, "Invalid applet id");
 
     auto itr = std::find_if(applet_titleids.begin(), applet_titleids.end(),

--- a/src/core/hle/service/apt/applet_manager.h
+++ b/src/core/hle/service/apt/applet_manager.h
@@ -367,35 +367,36 @@ public:
         deliver_arg = std::move(arg);
     }
 
-    std::vector<u8> GetCaptureInfo() {
+    std::vector<u8> GetCaptureInfoSuspendedApp() {
         std::vector<u8> buffer;
-        if (capture_info) {
+        if (capture_info_suspended_app) {
             buffer.resize(sizeof(CaptureBufferInfo));
-            std::memcpy(buffer.data(), &capture_info.get(), sizeof(CaptureBufferInfo));
+            std::memcpy(buffer.data(), &capture_info_suspended_app.get(),
+                        sizeof(CaptureBufferInfo));
         }
         return buffer;
     }
-    void SetCaptureInfo(std::vector<u8> buffer) {
+    void SetCaptureInfoSuspendedApp(std::vector<u8> buffer) {
         ASSERT_MSG(buffer.size() >= sizeof(CaptureBufferInfo), "CaptureBufferInfo is too small.");
 
-        capture_info.emplace();
-        std::memcpy(&capture_info.get(), buffer.data(), sizeof(CaptureBufferInfo));
+        capture_info_suspended_app.emplace();
+        std::memcpy(&capture_info_suspended_app.get(), buffer.data(), sizeof(CaptureBufferInfo));
     }
 
     std::vector<u8> ReceiveCaptureBufferInfo() {
         std::vector<u8> buffer;
-        if (capture_buffer_info) {
+        if (capture_info) {
             buffer.resize(sizeof(CaptureBufferInfo));
-            std::memcpy(buffer.data(), &capture_buffer_info.get(), sizeof(CaptureBufferInfo));
-            capture_buffer_info.reset();
+            std::memcpy(buffer.data(), &capture_info.get(), sizeof(CaptureBufferInfo));
+            capture_info.reset();
         }
         return buffer;
     }
     void SendCaptureBufferInfo(std::vector<u8> buffer) {
         ASSERT_MSG(buffer.size() >= sizeof(CaptureBufferInfo), "CaptureBufferInfo is too small.");
 
-        capture_buffer_info.emplace();
-        std::memcpy(&capture_buffer_info.get(), buffer.data(), sizeof(CaptureBufferInfo));
+        capture_info.emplace();
+        std::memcpy(&capture_info.get(), buffer.data(), sizeof(CaptureBufferInfo));
     }
 
     Result PrepareToStartApplication(u64 title_id, FS::MediaType media_type);
@@ -451,8 +452,11 @@ private:
     boost::optional<SysMenuArg> sys_menu_arg{};
     u64 home_menu_tid_to_start{};
 
+    boost::optional<CaptureBufferInfo> capture_info_suspended_app;
     boost::optional<CaptureBufferInfo> capture_info;
-    boost::optional<CaptureBufferInfo> capture_buffer_info;
+
+    static constexpr size_t FRAMEBUFFER_BACKUP_SIZE = 0xE7000;
+    std::vector<u8> framebuffer_backup = std::vector<u8>(FRAMEBUFFER_BACKUP_SIZE);
 
     static constexpr std::size_t NumAppletSlot = 4;
 
@@ -555,6 +559,7 @@ private:
     void EnsureHomeMenuLoaded();
 
     void CaptureFrameBuffers();
+    void TransferCapturedFramebuffers();
 
     Result CreateHLEApplet(AppletId id, AppletId parent, bool preload);
     void HLEAppletUpdateEvent(std::uintptr_t user_data, s64 cycles_late);
@@ -571,8 +576,9 @@ private:
         ar & deliver_arg;
         ar & sys_menu_arg;
         ar & home_menu_tid_to_start;
+        ar & capture_info_suspended_app;
         ar & capture_info;
-        ar & capture_buffer_info;
+        ar & framebuffer_backup;
         ar & active_slot;
         ar & last_library_launcher_slot;
         ar & last_prepared_library_applet;
@@ -584,7 +590,6 @@ private:
         ar & application_close_target;
         ar & new_3ds_mode_blocked;
         ar & lock;
-        ar & capture_info;
         ar & applet_slots;
         ar & library_applet_closing_command;
         ar & next_app_mediatype;

--- a/src/core/hle/service/apt/applet_manager.h
+++ b/src/core/hle/service/apt/applet_manager.h
@@ -104,6 +104,8 @@ enum class AppletId : u32 {
     TypeMask = 0xF00,
 };
 
+u64 GetTitleIdForApplet(AppletId id, u32 region_value);
+
 /// Application Old/New 3DS target platforms
 enum class TargetPlatform : u8 {
     Old3ds = 0,

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -1123,7 +1123,7 @@ void Module::APTInterface::GetCaptureInfo(Kernel::HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_APT, "called");
 
-    auto screen_capture_buffer = apt->applet_manager->GetCaptureInfo();
+    auto screen_capture_buffer = apt->applet_manager->GetCaptureInfoSuspendedApp();
     auto real_size = std::min(static_cast<u32>(screen_capture_buffer.size()), size);
     screen_capture_buffer.resize(size);
 

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -1432,6 +1432,58 @@ void Module::APTInterface::Reboot(Kernel::HLERequestContext& ctx) {
     rb.Push(ResultSuccess);
 }
 
+void Module::APTInterface::GetAppletProgramInfo(Kernel::HLERequestContext& ctx) {
+    union {
+        u32 raw;
+        BitField<0, 1, u32> mediatype_nand;
+        BitField<1, 1, u32> mediatype_sdmc;
+        BitField<2, 1, u32> mediatype_gamecard;
+        BitField<4, 1, u32> is_appid;
+        BitField<5, 1, u32> not_appid_must_set;
+        BitField<8, 1, u32> is_system_app;
+    } flags;
+
+    IPC::RequestParser rp(ctx);
+    u32 program_id = rp.Pop<u32>();
+    flags.raw = rp.Pop<u32>();
+
+    IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
+
+    u64 title_id;
+    if (flags.is_appid) {
+        auto cfg = Service::CFG::GetModule(apt->system);
+        title_id =
+            GetTitleIdForApplet(static_cast<AppletId>(program_id), cfg->GetRegionValue(true));
+    } else {
+        if (!flags.not_appid_must_set) {
+            rb.Push(ResultUnknown); // TODO: Find proper error code
+            rb.Push(0);
+            return;
+        } else {
+            u32 tid_high = flags.is_system_app ? 0x00040010 : 0x00040000;
+            title_id = static_cast<u64>(tid_high) << 32 | program_id;
+        }
+    }
+
+    std::vector<Service::AM::TitleInfo> info;
+    Result res = ResultUnknown; // TODO: Find proper error code
+    if (res.IsError() && flags.mediatype_nand) {
+        res = Service::AM::GetTitleInfoFromList(apt->system, std::span<u64>(&title_id, 1),
+                                                FS::MediaType::NAND, info);
+    }
+    if (res.IsError() && flags.mediatype_sdmc) {
+        res = Service::AM::GetTitleInfoFromList(apt->system, std::span<u64>(&title_id, 1),
+                                                FS::MediaType::SDMC, info);
+    }
+    if (res.IsError() && flags.mediatype_gamecard) {
+        res = Service::AM::GetTitleInfoFromList(apt->system, std::span<u64>(&title_id, 1),
+                                                FS::MediaType::GameCard, info);
+    }
+
+    rb.Push(res);
+    rb.Push(res.IsSuccess() ? info[0].version : 0);
+}
+
 void Module::APTInterface::HardwareResetAsync(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 

--- a/src/core/hle/service/apt/apt.h
+++ b/src/core/hle/service/apt/apt.h
@@ -1009,6 +1009,8 @@ public:
          */
         void Reboot(Kernel::HLERequestContext& ctx);
 
+        void GetAppletProgramInfo(Kernel::HLERequestContext& ctx);
+
         /**
          * APT::HardwareResetAsync service function.
          * Outputs:

--- a/src/core/hle/service/apt/apt_a.cpp
+++ b/src/core/hle/service/apt/apt_a.cpp
@@ -87,7 +87,7 @@ APT_A::APT_A(std::shared_ptr<Module> apt)
         {0x004A, &APT_A::GetCaptureInfo, "GetCaptureInfo"},
         {0x004B, &APT_A::AppletUtility, "AppletUtility"},
         {0x004C, nullptr, "SetFatalErrDispMode"},
-        {0x004D, nullptr, "GetAppletProgramInfo"},
+        {0x004D, &APT_A::GetAppletProgramInfo, "GetAppletProgramInfo"},
         {0x004E, &APT_A::HardwareResetAsync, "HardwareResetAsync"},
         {0x004F, &APT_A::SetAppCpuTimeLimit, "SetAppCpuTimeLimit"},
         {0x0050, &APT_A::GetAppCpuTimeLimit, "GetAppCpuTimeLimit"},

--- a/src/core/hle/service/apt/apt_s.cpp
+++ b/src/core/hle/service/apt/apt_s.cpp
@@ -87,7 +87,7 @@ APT_S::APT_S(std::shared_ptr<Module> apt)
         {0x004A, &APT_S::GetCaptureInfo, "GetCaptureInfo"},
         {0x004B, &APT_S::AppletUtility, "AppletUtility"},
         {0x004C, nullptr, "SetFatalErrDispMode"},
-        {0x004D, nullptr, "GetAppletProgramInfo"},
+        {0x004D, &APT_S::GetAppletProgramInfo, "GetAppletProgramInfo"},
         {0x004E, &APT_S::HardwareResetAsync, "HardwareResetAsync"},
         {0x004F, &APT_S::SetAppCpuTimeLimit, "SetAppCpuTimeLimit"},
         {0x0050, &APT_S::GetAppCpuTimeLimit, "GetAppCpuTimeLimit"},

--- a/src/core/hle/service/apt/apt_u.cpp
+++ b/src/core/hle/service/apt/apt_u.cpp
@@ -87,7 +87,7 @@ APT_U::APT_U(std::shared_ptr<Module> apt)
         {0x004A, &APT_U::GetCaptureInfo, "GetCaptureInfo"},
         {0x004B, &APT_U::AppletUtility, "AppletUtility"},
         {0x004C, nullptr, "SetFatalErrDispMode"},
-        {0x004D, nullptr, "GetAppletProgramInfo"},
+        {0x004D, &APT_U::GetAppletProgramInfo, "GetAppletProgramInfo"},
         {0x004E, &APT_U::HardwareResetAsync, "HardwareResetAsync"},
         {0x004F, &APT_U::SetAppCpuTimeLimit, "SetAppCpuTimeLimit"},
         {0x0050, &APT_U::GetAppCpuTimeLimit, "GetAppCpuTimeLimit"},


### PR DESCRIPTION
This PR adds two commits:
- Implement `APT::GetAppletProgramInfo`, which allows applications to get the version for the specified applet. Miiverse uses it to determine if Youtube is installed and do special actions. Probably used in other places.
- Fixes capture framebuffer handling for when lib applets are opened. This fixes the suspended application framebuffer being corrupted if a library applet is opened, which prevented users from posting images to Miiverse (as they got corrupted by the "login" applet).

There is still an issue when opening the theme shop and it erroring out, which still corrupts the saved application framebuffer. This will be addressed in the future.