### PR TITLE
core: Change default value of simulate GPU timings to false

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
@@ -128,7 +128,7 @@ enum class BooleanSetting(
     SIMULATE_3DS_GPU_TIMINGS(
         SettingKeys.simulate_3ds_gpu_timings(),
         Settings.SECTION_RENDERER,
-        true
+        false
     );
 
     override var boolean: Boolean = defaultValue

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -554,7 +554,7 @@ struct Values {
                                                         Keys::texture_sampling};
     SwitchableSetting<u16, true> delay_game_render_thread_us{0, 0, 65000,
                                                              Keys::delay_game_render_thread_us};
-    SwitchableSetting<bool> simulate_3ds_gpu_timings{true, Keys::simulate_3ds_gpu_timings};
+    SwitchableSetting<bool> simulate_3ds_gpu_timings{false, Keys::simulate_3ds_gpu_timings};
 
     SwitchableSetting<LayoutOption> layout_option{LayoutOption::Default, Keys::layout_option};
     SwitchableSetting<bool> swap_screen{false, Keys::swap_screen};


### PR DESCRIPTION
Changes the setting of "Simulate 3DS GPU timings" to false, as it is still kinda experimental and will slow down some games to 3DS frame rates.

Amendment of #2095 