### PR TITLE
qt: Add open NAND and SDMC folder options

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -1140,6 +1140,9 @@ void GMainWindow::ConnectMenuEvents() {
     connect_menu(ui->action_Exit, &QMainWindow::close, QAction::QuitRole);
     connect_menu(ui->action_Load_Amiibo, &GMainWindow::OnLoadAmiibo);
     connect_menu(ui->action_Remove_Amiibo, &GMainWindow::OnRemoveAmiibo);
+    connect_menu(ui->action_Open_Citra_Folder, &GMainWindow::OnOpenCitraFolder);
+    connect_menu(ui->action_Open_NAND_Folder, &GMainWindow::OnOpenNANDFolder);
+    connect_menu(ui->action_Open_SDMC_Folder, &GMainWindow::OnOpenSDMCFolder);
 
     // Emulation
     connect_menu(ui->action_Pause, &GMainWindow::OnPauseContinueGame);
@@ -1230,7 +1233,6 @@ void GMainWindow::ConnectMenuEvents() {
     connect_menu(ui->action_Decompress_ROM_File, &GMainWindow::OnDecompressFile);
 
     // Help
-    connect_menu(ui->action_Open_Citra_Folder, &GMainWindow::OnOpenCitraFolder);
     connect_menu(ui->action_Open_Log_Folder, []() {
         QString path = QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::LogDir));
         QDesktopServices::openUrl(QUrl::fromLocalFile(path));
@@ -3094,6 +3096,16 @@ void GMainWindow::OnRemoveAmiibo() {
 void GMainWindow::OnOpenCitraFolder() {
     QDesktopServices::openUrl(QUrl::fromLocalFile(
         QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::UserDir))));
+}
+
+void GMainWindow::OnOpenNANDFolder() {
+    QDesktopServices::openUrl(QUrl::fromLocalFile(
+        QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir))));
+}
+
+void GMainWindow::OnOpenSDMCFolder() {
+    QDesktopServices::openUrl(QUrl::fromLocalFile(
+        QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir))));
 }
 
 void GMainWindow::OnToggleFilterBar() {

--- a/src/citra_qt/citra_qt.h
+++ b/src/citra_qt/citra_qt.h
@@ -265,6 +265,8 @@ private slots:
     void OnLoadAmiibo();
     void OnRemoveAmiibo();
     void OnOpenCitraFolder();
+    void OnOpenNANDFolder();
+    void OnOpenSDMCFolder();
     void OnToggleFilterBar();
     void OnDisplayTitleBars(bool);
     void InitializeHotkeys();

--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -76,6 +76,14 @@
      <addaction name="action_Load_Amiibo"/>
      <addaction name="action_Remove_Amiibo"/>
     </widget>
+    <widget class="QMenu" name="menu_Open_Folder">
+     <property name="title">
+      <string>Open Azahar Folder</string>
+     </property>
+     <addaction name="action_Open_Citra_Folder"/>
+     <addaction name="action_Open_NAND_Folder"/>
+     <addaction name="action_Open_SDMC_Folder"/>
+    </widget>
     <addaction name="action_Load_File"/>
     <addaction name="action_Install_CIA"/>
     <addaction name="action_Connect_Artic"/>
@@ -87,7 +95,7 @@
     <addaction name="separator"/>
     <addaction name="menu_Amiibo"/>
     <addaction name="separator"/>
-    <addaction name="action_Open_Citra_Folder"/>
+    <addaction name="menu_Open_Folder"/>
     <addaction name="separator"/>
     <addaction name="action_Exit"/>
    </widget>
@@ -744,7 +752,17 @@
   </action>
   <action name="action_Open_Citra_Folder">
    <property name="text">
-    <string>Open Azahar Folder</string>
+    <string>User Folder</string>
+   </property>
+  </action>
+  <action name="action_Open_NAND_Folder">
+   <property name="text">
+    <string>NAND Folder</string>
+   </property>
+  </action>
+  <action name="action_Open_SDMC_Folder">
+   <property name="text">
+    <string>SDMC Folder</string>
    </property>
   </action>
   <action name="action_Configure_Current_Game">


### PR DESCRIPTION
Changes the `Open Azahar Folder` option in QT to be able to open User, NAND or SDMC folders. This is useful for users that have changed their NAND and SDMC folders.

<img width="345" height="269" alt="image" src="https://github.com/user-attachments/assets/5ba73f55-e337-44f8-bfe4-8addb12cc704" />
