### PR TITLE
externals/cmake-modules: minor tweaks

### DIFF
--- a/externals/cmake-modules/CitraHandleSystemLibs.cmake
+++ b/externals/cmake-modules/CitraHandleSystemLibs.cmake
@@ -3,7 +3,7 @@ option(USE_SYSTEM_LIBS "Use system libraries over bundled ones" OFF)
 # System library options
 CMAKE_DEPENDENT_OPTION(USE_SYSTEM_QT "Use the system Qt lib (instead of the bundled one)" OFF "ENABLE_QT;MSVC OR APPLE" ON)
 CMAKE_DEPENDENT_OPTION(USE_SYSTEM_LIBUSB "Use the system libusb (instead of the bundled libusb)" OFF "NOT (BSD MATCHES \"FreeBSD\")" ON)
-option(USE_SYSTEM_MOLTENVK "Use the system MoltenVK lib (instead of the bundled one)" OFF "APPLE" OFF)
+option(USE_SYSTEM_MOLTENVK "Use the system MoltenVK lib (instead of the bundled one)" OFF)
 option(USE_SYSTEM_SDL2 "Use the system SDL2 lib (instead of the bundled one)" OFF)
 option(USE_SYSTEM_BOOST "Use the system Boost libs (instead of the bundled ones)" OFF)
 option(USE_SYSTEM_OPENSSL "Use the system OpenSSL libs (instead of the bundled LibreSSL)" OFF)

--- a/externals/cmake-modules/CitraHandleSystemLibs.cmake
+++ b/externals/cmake-modules/CitraHandleSystemLibs.cmake
@@ -2,11 +2,11 @@ option(USE_SYSTEM_LIBS "Use system libraries over bundled ones" OFF)
 
 # System library options
 CMAKE_DEPENDENT_OPTION(USE_SYSTEM_QT "Use the system Qt lib (instead of the bundled one)" OFF "ENABLE_QT;MSVC OR APPLE" ON)
-CMAKE_DEPENDENT_OPTION(USE_SYSTEM_MOLTENVK "Use the system MoltenVK lib (instead of the bundled one)" OFF "APPLE" OFF)
+CMAKE_DEPENDENT_OPTION(USE_SYSTEM_LIBUSB "Use the system libusb (instead of the bundled libusb)" OFF "NOT (BSD MATCHES \"FreeBSD\")" ON)
+option(USE_SYSTEM_MOLTENVK "Use the system MoltenVK lib (instead of the bundled one)" OFF "APPLE" OFF)
 option(USE_SYSTEM_SDL2 "Use the system SDL2 lib (instead of the bundled one)" OFF)
 option(USE_SYSTEM_BOOST "Use the system Boost libs (instead of the bundled ones)" OFF)
 option(USE_SYSTEM_OPENSSL "Use the system OpenSSL libs (instead of the bundled LibreSSL)" OFF)
-option(USE_SYSTEM_LIBUSB "Use the system libusb (instead of the bundled libusb)" OFF)
 option(USE_SYSTEM_CPP_JWT "Use the system cpp-jwt (instead of the bundled one)" OFF)
 option(USE_SYSTEM_SOUNDTOUCH "Use the system SoundTouch (instead of the bundled one)" OFF)
 option(USE_SYSTEM_CPP_HTTPLIB "Use the system cpp-httplib (instead of the bundled one)" OFF)


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------
In this PR, I just:
- Enable using system libusb by default on FreeBSD (it is built in)
- Simplified redundant `USE_SYSTEM_MOLTENVK` check
---
<!--
If you are contributing to Azahar for the first time please
keep the block of text between `---` and write your 
PR description below it. Do not write anything inside 
or change this block of text!

If you are a recurrent contributor, remove this entire
block of text and proceed as normal.
-->

![Ignore Until Your PR has been created!](../blob/master/.github/ignore_unless_human.png?raw=true)
---
