### PR TITLE
core: Strengthen CFG module error handling

### DIFF
--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -47,6 +47,7 @@ void Module::serialize(Archive& ar, const unsigned int) {
     ar & cfg_config_file_buffer;
     ar & cfg_system_save_data_archive;
     ar & mac_address;
+    ar & load_savegame_res.raw;
     ar & preferred_region_code;
     ar & preferred_region_chosen;
 }
@@ -802,6 +803,10 @@ ResultVal<void*> Module::GetConfigBlockPointer(u32 block_id, u32 size, AccessFla
 }
 
 Result Module::GetConfigBlock(u32 block_id, u32 size, AccessFlag accesss_flag, void* output) {
+    if (load_savegame_res.IsError()) {
+        return load_savegame_res;
+    }
+
     bool get_from_artic =
         block_id == ConsoleUniqueID2BlockID &&
         (static_cast<u16>(accesss_flag) & static_cast<u16>(AccessFlag::UserRead)) != 0;
@@ -841,6 +846,10 @@ Result Module::GetConfigBlock(u32 block_id, u32 size, AccessFlag accesss_flag, v
 }
 
 Result Module::SetConfigBlock(u32 block_id, u32 size, AccessFlag accesss_flag, const void* input) {
+    if (load_savegame_res.IsError()) {
+        return load_savegame_res;
+    }
+
     void* pointer = nullptr;
     CASCADE_RESULT(pointer, GetConfigBlockPointer(block_id, size, accesss_flag));
     std::memcpy(pointer, input, size);
@@ -849,6 +858,10 @@ Result Module::SetConfigBlock(u32 block_id, u32 size, AccessFlag accesss_flag, c
 
 Result Module::CreateConfigBlock(u32 block_id, u16 size, AccessFlag access_flags,
                                  const void* data) {
+    if (load_savegame_res.IsError()) {
+        return load_savegame_res;
+    }
+
     SaveFileConfig* config = reinterpret_cast<SaveFileConfig*>(cfg_config_file_buffer.data());
     if (config->total_entries >= CONFIG_FILE_MAX_BLOCK_ENTRIES)
         return ResultUnknown; // TODO(Subv): Find the right error code
@@ -881,11 +894,19 @@ Result Module::CreateConfigBlock(u32 block_id, u16 size, AccessFlag access_flags
 }
 
 Result Module::DeleteConfigNANDSaveFile() {
+    if (load_savegame_res.IsError()) {
+        return load_savegame_res;
+    }
+
     FileSys::Path path("/config");
     return cfg_system_save_data_archive->DeleteFile(path);
 }
 
 Result Module::UpdateConfigNANDSavegame() {
+    if (load_savegame_res.IsError()) {
+        return load_savegame_res;
+    }
+
     LOG_DEBUG(Service_CFG, "Saving config file to NAND");
 
     FileSys::Mode mode = {};
@@ -904,6 +925,10 @@ Result Module::UpdateConfigNANDSavegame() {
 }
 
 Result Module::FormatConfig() {
+    if (load_savegame_res.IsError()) {
+        return load_savegame_res;
+    }
+
     Result res = DeleteConfigNANDSaveFile();
     // The delete command fails if the file doesn't exist, so we have to check that too
     if (!res.IsSuccess() && res != FileSys::ResultFileNotFound) {
@@ -942,6 +967,8 @@ Result Module::FormatConfig() {
 Result Module::LoadConfigNANDSaveFile() {
     LOG_DEBUG(Service_CFG, "Loading config file from NAND");
 
+    cfg_system_save_data_archive.reset();
+
     const std::string& nand_directory = FileUtil::GetUserPath(FileUtil::UserPath::NANDDir);
     FileSys::ArchiveFactory_SystemSaveData systemsavedata_factory(nand_directory);
 
@@ -952,12 +979,29 @@ Result Module::LoadConfigNANDSaveFile() {
     // If the archive didn't exist, create the files inside
     if (archive_result.Code() == FileSys::ResultNotFound) {
         // Format the archive to create the directories
-        systemsavedata_factory.Format(archive_path, FileSys::ArchiveFormatInfo(), 0, 0, 0);
+        auto format_result =
+            systemsavedata_factory.Format(archive_path, FileSys::ArchiveFormatInfo(), 0, 0, 0);
+
+        if (!format_result.IsSuccess()) {
+            LOG_ERROR(Service_CFG, "Could not format the CFG SystemSaveData archive!");
+            return format_result;
+        }
 
         // Open it again to get a valid archive now that the folder exists
-        cfg_system_save_data_archive = systemsavedata_factory.Open(archive_path, 0).Unwrap();
+        auto new_archive_result = systemsavedata_factory.Open(archive_path, 0);
+
+        if (!new_archive_result.Succeeded()) {
+            LOG_ERROR(Service_CFG, "Could not open the CFG SystemSaveData archive!");
+            return archive_result.Code();
+        }
+
+        cfg_system_save_data_archive = std::move(new_archive_result).Unwrap();
+
     } else {
-        ASSERT_MSG(archive_result.Succeeded(), "Could not open the CFG SystemSaveData archive!");
+        if (!archive_result.Succeeded()) {
+            LOG_ERROR(Service_CFG, "Could not open the CFG SystemSaveData archive!");
+            return archive_result.Code();
+        }
 
         cfg_system_save_data_archive = std::move(archive_result).Unwrap();
     }
@@ -1003,7 +1047,7 @@ void Module::SaveMCUConfig() {
 }
 
 Module::Module(Core::System& system_) : system(system_) {
-    LoadConfigNANDSaveFile();
+    load_savegame_res = LoadConfigNANDSaveFile();
     LoadMCUConfig();
     (void)GetMacAddress();
     // Check the config savegame EULA Version and update it to 0x7F7F if necessary
@@ -1132,7 +1176,7 @@ void Module::SetUsername(const std::u16string& name) {
 }
 
 std::u16string Module::GetUsername() {
-    UsernameBlock block;
+    UsernameBlock block{};
     GetConfigBlock(UsernameBlockID, sizeof(block), AccessFlag::SystemRead, &block);
 
     // the username string in the block isn't null-terminated,
@@ -1150,7 +1194,7 @@ void Module::SetBirthday(u8 month, u8 day) {
 }
 
 std::tuple<u8, u8> Module::GetBirthday() {
-    BirthdayBlock block;
+    BirthdayBlock block{};
     GetConfigBlock(BirthdayBlockID, sizeof(block), AccessFlag::SystemRead, &block);
     return std::make_tuple(block.month, block.day);
 }

--- a/src/core/hle/service/cfg/cfg.h
+++ b/src/core/hle/service/cfg/cfg.h
@@ -122,36 +122,36 @@ enum SystemLanguage {
 enum SoundOutputMode { SOUND_MONO = 0, SOUND_STEREO = 1, SOUND_SURROUND = 2 };
 
 struct EULAVersion {
-    u8 minor;
-    u8 major;
+    u8 minor{};
+    u8 major{};
     INSERT_PADDING_BYTES(2);
 };
 static_assert(sizeof(EULAVersion) == 4, "EULAVersion must be exactly 0x4 bytes");
 
 struct UsernameBlock {
     /// Exactly 20 bytes long, padded with zeros at the end if necessary
-    std::array<char16_t, 10> username;
-    u32 zero;
-    u32 ng_word;
+    std::array<char16_t, 10> username{};
+    u32 zero{};
+    u32 ng_word{};
 };
 static_assert(sizeof(UsernameBlock) == 0x1C, "UsernameBlock must be exactly 0x1C bytes");
 
 struct BirthdayBlock {
-    u8 month; ///< The month of the birthday
-    u8 day;   ///< The day of the birthday
+    u8 month{}; ///< The month of the birthday
+    u8 day{};   ///< The day of the birthday
 };
 static_assert(sizeof(BirthdayBlock) == 2, "BirthdayBlock must be exactly 2 bytes");
 
 struct ConsoleModelInfo {
-    u8 model;                  ///< The console model (3DS, 2DS, etc)
-    std::array<u8, 3> unknown; ///< Unknown data
+    u8 model{};                  ///< The console model (3DS, 2DS, etc)
+    std::array<u8, 3> unknown{}; ///< Unknown data
 };
 static_assert(sizeof(ConsoleModelInfo) == 4, "ConsoleModelInfo must be exactly 4 bytes");
 
 struct ConsoleCountryInfo {
-    std::array<u8, 2> unknown; ///< Unknown data
-    u8 state_code;             ///< The state or province code.
-    u8 country_code;           ///< The country code of the console
+    std::array<u8, 2> unknown{}; ///< Unknown data
+    u8 state_code{};             ///< The state or province code.
+    u8 country_code{};           ///< The country code of the console
 
     bool operator==(const ConsoleCountryInfo& other) const {
         return unknown == other.unknown && state_code == other.state_code &&
@@ -165,15 +165,15 @@ struct ConsoleCountryInfo {
 static_assert(sizeof(ConsoleCountryInfo) == 4, "ConsoleCountryInfo must be exactly 4 bytes");
 
 struct BacklightControls {
-    u8 power_saving_enabled; ///< Whether power saving mode is enabled.
-    u8 brightness_level;     ///< The configured brightness level.
+    u8 power_saving_enabled{}; ///< Whether power saving mode is enabled.
+    u8 brightness_level{};     ///< The configured brightness level.
 };
 static_assert(sizeof(BacklightControls) == 2, "BacklightControls must be exactly 2 bytes");
 
 struct New3dsBacklightControls {
-    std::array<u8, 4> unknown_1; ///< Unknown data
-    u8 auto_brightness_enabled;  ///< Whether auto brightness is enabled.
-    std::array<u8, 3> unknown_2; ///< Unknown data
+    std::array<u8, 4> unknown_1{}; ///< Unknown data
+    u8 auto_brightness_enabled{};  ///< Whether auto brightness is enabled.
+    std::array<u8, 3> unknown_2{}; ///< Unknown data
 };
 static_assert(sizeof(New3dsBacklightControls) == 8,
               "New3dsBacklightControls must be exactly 8 bytes");
@@ -658,6 +658,8 @@ private:
     bool preferred_region_chosen = false;
     MCUData mcu_data{};
     std::string mac_address{};
+
+    Result load_savegame_res{ResultSuccess};
 
     std::shared_ptr<Network::ArticBase::Client> artic_client = nullptr;
 


### PR DESCRIPTION
Improve error handling in the CFG module when the CFG savegame is not available. This can happen on Android during the initial setup, as the user folder has not been selected yet.

Fixes crashes in 2126 RC1.