### PR TITLE
multiplayer: Allow "No Preference" preferred game

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/dialogs/NetPlayDialog.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/dialogs/NetPlayDialog.kt
@@ -39,8 +39,12 @@ import org.citra.citra_emu.utils.NetPlayManager
 
 class NetPlayDialog(context: Context) : BottomSheetDialog(context) {
     private lateinit var adapter: NetPlayAdapter
-    private val gameNameList: MutableList<Array<String>> = mutableListOf()
-    private val gameIdList: MutableList<Array<Long>> = mutableListOf()
+
+    data class PreferredGame(val name: String, val id: Long) {
+        override fun toString(): String = name
+    }
+    private val preferredGameList: MutableList<PreferredGame> = mutableListOf()
+    private var selectedPreferredGame = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -81,15 +85,15 @@ class NetPlayDialog(context: Context) : BottomSheetDialog(context) {
                 DialogMultiplayerConnectBinding.inflate(layoutInflater).apply {
                     setContentView(root)
                     // Prepare the game list in case a user tries to create a room
+
+                    preferredGameList.add(PreferredGame("%none%", -1))
+
                     for (game in GameHelper.cachedGameList) {
                         val gameName = game.title
-                        if (gameNameList.none { it[0] == gameName }) {
-                            gameNameList.add(arrayOf(gameName))
-                        }
-
                         val gameId = game.titleId
-                        if (gameIdList.none { it[0] == gameId }) {
-                            gameIdList.add((arrayOf(gameId)))
+
+                        if (preferredGameList.none { it.id == gameId }) {
+                            preferredGameList.add(PreferredGame(gameName, gameId))
                         }
                     }
 
@@ -334,8 +338,32 @@ class NetPlayDialog(context: Context) : BottomSheetDialog(context) {
         binding.username.setText(NetPlayManager.getUsername())
 
         binding.dropdownPreferedGameName.apply {
-            setAdapter(ArrayAdapter(activity, R.layout.dropdown_item, gameNameList.map { it[0] }))
+            setAdapter(
+                ArrayAdapter(
+                    activity,
+                    R.layout.dropdown_item,
+                    preferredGameList.map {
+                        if (it.name == "%none%") {
+                            it.copy(name = context.getString(R.string.no_preference))
+                        } else {
+                            it
+                        }
+                    }
+                )
+            )
         }
+        binding.dropdownPreferedGameName.setOnItemClickListener { _, _, position, _ ->
+            selectedPreferredGame = position
+        }
+        selectedPreferredGame = 0
+        binding.dropdownPreferedGameName.setText(
+            (
+                binding.dropdownPreferedGameName.adapter.getItem(
+                    selectedPreferredGame
+                ) as PreferredGame
+                ).toString(),
+            false
+        )
 
         binding.preferedGameName.visibility = if (isCreateRoom) View.VISIBLE else View.GONE
         binding.roomName.visibility = if (isCreateRoom) View.VISIBLE else View.GONE
@@ -375,9 +403,7 @@ class NetPlayDialog(context: Context) : BottomSheetDialog(context) {
             val ipAddress = binding.ipAddress.text.toString()
             val username = binding.username.text.toString()
             val portStr = binding.ipPort.text.toString()
-            val preferedGameName = binding.dropdownPreferedGameName.text.toString()
-            val preferedGameId =
-                gameIdList[gameNameList.indexOfFirst { it[0] == preferedGameName }][0]
+            val preferedGame = preferredGameList[selectedPreferredGame]
             val password = binding.password.text.toString()
             val port = portStr.toIntOrNull() ?: run {
                 Toast.makeText(activity, R.string.multiplayer_port_invalid, Toast.LENGTH_LONG)
@@ -397,17 +423,6 @@ class NetPlayDialog(context: Context) : BottomSheetDialog(context) {
                 return@setOnClickListener
             }
 
-            if (isCreateRoom && preferedGameName.isEmpty()) {
-                Toast.makeText(
-                    activity,
-                    R.string.multiplayer_prefered_game_name_invalid,
-                    Toast.LENGTH_LONG
-                ).show()
-                binding.btnConfirm.isEnabled = true
-                binding.btnConfirm.text = activity.getString(R.string.original_button_text)
-                return@setOnClickListener
-            }
-
             if (ipAddress.length < 7 || username.length < 5) {
                 Toast.makeText(activity, R.string.multiplayer_input_invalid, Toast.LENGTH_LONG)
                     .show()
@@ -420,8 +435,8 @@ class NetPlayDialog(context: Context) : BottomSheetDialog(context) {
                             ipAddress,
                             port,
                             username,
-                            preferedGameName,
-                            preferedGameId,
+                            preferedGame.name,
+                            preferedGame.id,
                             password,
                             roomName,
                             maxPlayers

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -1087,7 +1087,7 @@
     <string name="multiplayer_game_name">Preferred Games</string>
     <string name="prefered_game_name">Preferred Game</string>
     <string name="multiplayer_no_game">No Games Found</string>
-    <string name="multiplayer_prefered_game_name_invalid">You must choose a Preferred Application to host a room.</string>
+    <string name="no_preference">No Preference</string>
 
     <!-- Update Checker -->
     <string name="stable_channel_update_link" translatable="false">https://azahar-emu.org/pages/download/</string>

--- a/src/citra_qt/multiplayer/host_room.cpp
+++ b/src/citra_qt/multiplayer/host_room.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <future>
+#include <limits>
 #include <QColor>
 #include <QImage>
 #include <QList>
@@ -19,6 +20,7 @@
 #include "citra_qt/uisettings.h"
 #include "common/logging/log.h"
 #include "core/hle/service/cfg/cfg.h"
+#include "core/hle/service/fs/archive.h"
 #include "network/announce_multiplayer_session.h"
 #include "ui_host_room.h"
 #ifdef ENABLE_WEB_SERVICE
@@ -69,6 +71,8 @@ HostRoomWindow::~HostRoomWindow() = default;
 
 void HostRoomWindow::UpdateGameList(QStandardItemModel* list) {
     game_list->clear();
+    game_list->appendRow(new GameListItemPath(tr("%none%"), {}, std::numeric_limits<u64>::max(), 0,
+                                              Service::FS::MediaType::NAND, false, false));
     for (int i = 0; i < list->rowCount(); i++) {
         auto parent = list->item(i, 0);
         for (int j = 0; j < parent->rowCount(); j++) {
@@ -133,7 +137,7 @@ void HostRoomWindow::Host() {
         }
         ui->host->setDisabled(true);
 
-        auto game_name = ui->game_list->currentData(Qt::DisplayRole).toString();
+        auto game_name = ui->game_list->currentData(GameListItemPath::FullPathRole).toString();
         auto game_id = ui->game_list->currentData(GameListItemPath::ProgramIdRole).toLongLong();
         auto port = ui->port->isModified() ? ui->port->text().toInt() : Network::DefaultRoomPort;
         auto password = ui->password->text().toStdString();
@@ -215,6 +219,18 @@ void HostRoomWindow::Host() {
 }
 
 QVariant ComboBoxProxyModel::data(const QModelIndex& idx, int role) const {
+    std::string full_path;
+    // Special case for No Preference
+    if (role == GameListItemPath::FullPathRole) {
+        full_path = QSortFilterProxyModel::data(idx, GameListItemPath::FullPathRole)
+                        .toString()
+                        .toStdString();
+        if (full_path == "%none%") {
+            return QString::fromStdString("%none%");
+        }
+        // Else fallthrough using DisplayRole
+        role = Qt::DisplayRole;
+    }
     if (role != Qt::DisplayRole) {
         auto val = QSortFilterProxyModel::data(idx, role);
         // If its the icon, shrink it to 16x16
@@ -222,12 +238,16 @@ QVariant ComboBoxProxyModel::data(const QModelIndex& idx, int role) const {
             val = val.value<QImage>().scaled(16, 16, Qt::KeepAspectRatio);
         return val;
     }
-    std::string filename;
-    Common::SplitPath(
-        QSortFilterProxyModel::data(idx, GameListItemPath::FullPathRole).toString().toStdString(),
-        nullptr, &filename, nullptr);
-    QString title = QSortFilterProxyModel::data(idx, GameListItemPath::TitleRole).toString();
-    return title.isEmpty() ? QString::fromStdString(filename) : title;
+    full_path =
+        QSortFilterProxyModel::data(idx, GameListItemPath::FullPathRole).toString().toStdString();
+    if (full_path == "%none%") {
+        return tr("No Preference");
+    } else {
+        std::string filename;
+        Common::SplitPath(full_path, nullptr, &filename, nullptr);
+        QString title = QSortFilterProxyModel::data(idx, GameListItemPath::TitleRole).toString();
+        return title.isEmpty() ? QString::fromStdString(filename) : title;
+    }
 }
 
 bool ComboBoxProxyModel::lessThan(const QModelIndex& left, const QModelIndex& right) const {

--- a/src/citra_qt/multiplayer/lobby.cpp
+++ b/src/citra_qt/multiplayer/lobby.cpp
@@ -237,11 +237,15 @@ void Lobby::OnRefreshLobby() {
         }
 
         auto first_item = new LobbyItem();
+
+        QString preferred_game = room.preferred_game == "%none%"
+                                     ? tr("No Preference")
+                                     : QString::fromStdString(room.preferred_game);
+
         auto row = QList<QStandardItem*>({
             first_item,
             new LobbyItemName(room.has_password, QString::fromStdString(room.name)),
-            new LobbyItemGame(room.preferred_game_id, QString::fromStdString(room.preferred_game),
-                              smdh_icon),
+            new LobbyItemGame(room.preferred_game_id, preferred_game, smdh_icon),
             new LobbyItemHost(QString::fromStdString(room.owner), QString::fromStdString(room.ip),
                               room.port, QString::fromStdString(room.verify_UID)),
             new LobbyItemMemberList(members, room.max_player),


### PR DESCRIPTION
Adds a "No Preference" selection for preferred game in multiplayer rooms. Previously you were forced to select a preferred game when creating rooms, which only has the purpose of telling other users which game is usually being played in the room (but it actually does not limit anything, it's only a clue).

This change makes room creation more user friendly in case the user does not care to set a preferred game. It also fixes crashes due to preferred game handling on Android.

