### PR TITLE
libretro: update android ndk to r27d

### DIFF
--- a/.ci/libretro-ci.yml
+++ b/.ci/libretro-ci.yml
@@ -102,7 +102,7 @@ android-arm64-v8a:
     - .libretro-android-cmake-arm64-v8a
     - .core-defs
   variables:
-    ANDROID_NDK_VERSION: 26.2.11394342
+    ANDROID_NDK_VERSION: 27.3.13750724
     NDK_ROOT: /android-sdk-linux/ndk/$ANDROID_NDK_VERSION
     LIBNAME: ${CORENAME}_libretro.so
   artifacts:

--- a/.github/workflows/libretro.yml
+++ b/.github/workflows/libretro.yml
@@ -23,7 +23,7 @@ jobs:
       OS: android
       TARGET: arm64-v8a
       API_LEVEL: 21
-      ANDROID_NDK_VERSION: 26.2.11394342
+      ANDROID_NDK_VERSION: 27.3.13750724
       ANDROID_ABI: arm64-v8a
       BUILD_DIR: build/android-arm64-v8a
       EXTRA_PATH: bin/Release


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

I am migrating cores to the latest Android NDK LTS and deprecating some older versions.

This just updates to use it, which is already installed on the buildbot.

Tested compiling locally.