### PR TITLE
video_core: Fix crash on invalid vertex array pointer

### DIFF
--- a/src/video_core/pica/pica_core.cpp
+++ b/src/video_core/pica/pica_core.cpp
@@ -587,6 +587,11 @@ void PicaCore::LoadVertices(bool is_indexed) {
     // Locate index buffer.
     const auto& index_info = pipeline.index_array;
     const u8* index_address_8 = memory.GetPhysicalPointer(base_address + index_info.offset);
+    if (index_address_8 == nullptr) {
+        // Mario & Luigi: Superstar Saga sets an invalid base address
+        // for the vertex attributes. Return early if that is the case.
+        return;
+    }
     const u16* index_address_16 = reinterpret_cast<const u16*>(index_address_8);
     const bool index_u16 = index_info.format != 0;
 

--- a/src/video_core/rasterizer_accelerated.cpp
+++ b/src/video_core/rasterizer_accelerated.cpp
@@ -99,6 +99,11 @@ RasterizerAccelerated::VertexArrayInfo RasterizerAccelerated::AnalyzeVertexArray
         const auto& index_info = regs.pipeline.index_array;
         const PAddr address = vertex_attributes.GetPhysicalBaseAddress() + index_info.offset;
         const u8* index_address_8 = memory.GetPhysicalPointer(address);
+        if (index_address_8 == nullptr) {
+            // Mario & Luigi: Superstar Saga sets an invalid base address
+            // for the vertex attributes. Return early if that is the case.
+            return {0, 0, 0};
+        }
         const u16* index_address_16 = reinterpret_cast<const u16*>(index_address_8);
         const bool index_u16 = index_info.format != 0;
 

--- a/src/video_core/rasterizer_accelerated.h
+++ b/src/video_core/rasterizer_accelerated.h
@@ -51,6 +51,10 @@ protected:
         u32 vs_input_index_min;
         u32 vs_input_index_max;
         u32 vs_input_size;
+
+        bool Invalid() const {
+            return vs_input_index_min == 0 && vs_input_index_max == 0 && vs_input_size == 0;
+        }
     };
 
     /// Retrieve the range and the size of the input vertex

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -488,10 +488,16 @@ bool RasterizerOpenGL::AccelerateDrawBatch(bool is_indexed) {
 
 bool RasterizerOpenGL::AccelerateDrawBatchInternal(bool is_indexed) {
     const GLenum primitive_mode = MakePrimitiveMode(regs.pipeline.triangle_topology);
-    auto [vs_input_index_min, vs_input_index_max, vs_input_size] = AnalyzeVertexArray(is_indexed);
+    const auto vertex_array_info = AnalyzeVertexArray(is_indexed);
 
-    if (vs_input_size > VERTEX_BUFFER_SIZE) {
-        LOG_WARNING(Render_OpenGL, "Too large vertex input size {}", vs_input_size);
+    if (vertex_array_info.Invalid()) {
+        // Do not draw anything if the vertex array is invalid.
+        return true;
+    }
+
+    if (vertex_array_info.vs_input_size > VERTEX_BUFFER_SIZE) {
+        LOG_WARNING(Render_OpenGL, "Too large vertex input size {}",
+                    vertex_array_info.vs_input_size);
         return false;
     }
 
@@ -500,9 +506,11 @@ bool RasterizerOpenGL::AccelerateDrawBatchInternal(bool is_indexed) {
 
     u8* buffer_ptr;
     GLintptr buffer_offset;
-    std::tie(buffer_ptr, buffer_offset, std::ignore) = vertex_buffer.Map(vs_input_size, 4);
-    SetupVertexArray(buffer_ptr, buffer_offset, vs_input_index_min, vs_input_index_max);
-    vertex_buffer.Unmap(vs_input_size);
+    std::tie(buffer_ptr, buffer_offset, std::ignore) =
+        vertex_buffer.Map(vertex_array_info.vs_input_size, 4);
+    SetupVertexArray(buffer_ptr, buffer_offset, vertex_array_info.vs_input_index_min,
+                     vertex_array_info.vs_input_index_max);
+    vertex_buffer.Unmap(vertex_array_info.vs_input_size);
 
     curr_shader_manager->ApplyTo(state, accurate_mul);
     state.Apply();
@@ -523,10 +531,12 @@ bool RasterizerOpenGL::AccelerateDrawBatchInternal(bool is_indexed) {
         std::memcpy(buffer_ptr, index_data, index_buffer_size);
         index_buffer.Unmap(index_buffer_size);
 
-        glDrawRangeElementsBaseVertex(
-            primitive_mode, vs_input_index_min, vs_input_index_max, regs.pipeline.num_vertices,
-            index_u16 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_BYTE,
-            reinterpret_cast<const void*>(buffer_offset), -static_cast<GLint>(vs_input_index_min));
+        glDrawRangeElementsBaseVertex(primitive_mode, vertex_array_info.vs_input_index_min,
+                                      vertex_array_info.vs_input_index_max,
+                                      regs.pipeline.num_vertices,
+                                      index_u16 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_BYTE,
+                                      reinterpret_cast<const void*>(buffer_offset),
+                                      -static_cast<GLint>(vertex_array_info.vs_input_index_min));
     } else {
         glDrawArrays(primitive_mode, 0, regs.pipeline.num_vertices);
     }

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -446,6 +446,10 @@ bool RasterizerVulkan::AccelerateDrawBatch(bool is_indexed) {
     // Vertex data setup might involve scheduler flushes so perform it
     // early to avoid invalidating our state in the middle of the draw.
     vertex_info = AnalyzeVertexArray(is_indexed, instance.GetMinVertexStrideAlignment());
+    if (vertex_info.Invalid()) {
+        // Do not draw anything if the vertex array is invalid.
+        return true;
+    }
     SetupVertexArray();
 
     if (!SetupVertexShader()) {


### PR DESCRIPTION
Fixes a crash that could happen if an application submitted a draw call with an invalid base address for a vertex array. Mario & Luigi: Superstar Saga does this in the credits sequence, most likely due to it submitting a garbage value. On real HW invalid memory addresses are probably ignored.

With this fix the affected applications no longer crash and a log is printed instead.

Closes #1735