### PR TITLE
libretro: name the Android core azahar_libretro_android.so

### DIFF
--- a/.ci/libretro-pack.sh
+++ b/.ci/libretro-pack.sh
@@ -10,4 +10,4 @@ if [ "$GITHUB_REF_TYPE" = "tag" ]; then
 fi
 
 # Create .zip
-zip -j -9 $REV_NAME.zip $BUILD_DIR/$EXTRA_PATH/azahar_libretro.*
+zip -j -9 $REV_NAME.zip $BUILD_DIR/$EXTRA_PATH/azahar_libretro*

--- a/.github/workflows/libretro.yml
+++ b/.github/workflows/libretro.yml
@@ -50,7 +50,7 @@ jobs:
           export NDK_ROOT=${ANDROID_SDK_ROOT}/ndk/$ANDROID_NDK_VERSION
           ${ANDROID_SDK_ROOT}/cmake/3.30.3/bin/cmake $CORE_ARGS -DANDROID_PLATFORM=android-$API_LEVEL -DCMAKE_TOOLCHAIN_FILE=$NDK_ROOT/build/cmake/android.toolchain.cmake -DANDROID_STL=c++_static -DANDROID_ABI=$ANDROID_ABI . -B $BUILD_DIR
           ${ANDROID_SDK_ROOT}/cmake/3.30.3/bin/cmake --build $BUILD_DIR --target azahar_libretro --config Release -j $(nproc)
-          llvm-strip -s $BUILD_DIR/$EXTRA_PATH/azahar_libretro.*
+          llvm-strip -s $BUILD_DIR/$EXTRA_PATH/azahar_libretro*
       - name: Pack
         run: ./.ci/libretro-pack.sh
       - name: Generate SBOM
@@ -96,7 +96,7 @@ jobs:
         run: |
           cmake $CORE_ARGS $EXTRA_CORE_ARGS . -B $BUILD_DIR
           cmake --build $BUILD_DIR --target citra_libretro --config Release -j $(nproc)
-          llvm-strip -s $BUILD_DIR/$EXTRA_PATH/azahar_libretro.*
+          llvm-strip -s $BUILD_DIR/$EXTRA_PATH/azahar_libretro*
       - name: Pack
         run: ./.ci/libretro-pack.sh
       - name: Generate SBOM
@@ -146,7 +146,7 @@ jobs:
               bash -lc "\
                   ${CMAKE} $CORE_ARGS $EXTRA_CORE_ARGS . -B $BUILD_DIR && \
                   ${CMAKE} --build $BUILD_DIR --target citra_libretro --config Release -j $(nproc) && \
-                  x86_64-w64-mingw32.static-strip -s $BUILD_DIR/$EXTRA_PATH/azahar_libretro.*"
+                  x86_64-w64-mingw32.static-strip -s $BUILD_DIR/$EXTRA_PATH/azahar_libretro*"
       - name: Pack
         run: ./.ci/libretro-pack.sh
       - name: Generate SBOM
@@ -193,7 +193,7 @@ jobs:
         run: |
           cmake $CORE_ARGS -DCMAKE_OSX_ARCHITECTURES=$TARGET . -B $BUILD_DIR
           cmake --build $BUILD_DIR --target citra_libretro --config Release
-          strip -x $BUILD_DIR/$EXTRA_PATH/azahar_libretro.*
+          strip -x $BUILD_DIR/$EXTRA_PATH/azahar_libretro*
       - name: Pack
         run: ./.ci/libretro-pack.sh
       - name: Generate SBOM
@@ -235,7 +235,7 @@ jobs:
         run: |
           cmake $CORE_ARGS $EXTRA_CORE_ARGS . -B $BUILD_DIR
           cmake --build $BUILD_DIR --target citra_libretro --config Release
-          strip -x $BUILD_DIR/$EXTRA_PATH/azahar_libretro.*
+          strip -x $BUILD_DIR/$EXTRA_PATH/azahar_libretro*
       - name: Pack
         run: ./.ci/libretro-pack.sh
       - name: Generate SBOM
@@ -277,7 +277,7 @@ jobs:
         run: |
           cmake $CORE_ARGS $EXTRA_CORE_ARGS . -B $BUILD_DIR
           cmake --build $BUILD_DIR --target citra_libretro --config Release
-          strip -x $BUILD_DIR/$EXTRA_PATH/azahar_libretro.*
+          strip -x $BUILD_DIR/$EXTRA_PATH/azahar_libretro*
       - name: Pack
         run: ./.ci/libretro-pack.sh
       - name: Generate SBOM

--- a/src/citra_libretro/CMakeLists.txt
+++ b/src/citra_libretro/CMakeLists.txt
@@ -66,6 +66,7 @@ set_target_properties(citra_libretro PROPERTIES PREFIX "")
 target_compile_definitions(citra_libretro PRIVATE HAVE_LIBRETRO)
 
 if(ANDROID)
+  set_target_properties(citra_libretro PROPERTIES SUFFIX "_android.so")
   target_compile_definitions(citra_common PRIVATE HAVE_LIBRETRO_VFS)
   target_compile_definitions(citra_core PRIVATE HAVE_LIBRETRO_VFS)
   target_compile_definitions(video_core PRIVATE HAVE_LIBRETRO_VFS)


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.

Every other core on the libretro Android buildbot ships as `<name>_libretro_android.so`. The convention is enforced by libretro's CI templates (android-jni.yml and android-cmake.yml both set LIBNAME=${CORENAME}_libretro_android.so and rename the built .so), and CMake-based cores also set it in-repo, dolphin does exactly this with SUFFIX "_android.so" in DolphinLibretro/CMakeLists.txt. 

https://github.com/libretro/dolphin/blob/master/Source/Core/DolphinLibretro/CMakeLists.txt#L34

Azahar's pipeline packages the CMake output name directly, so it is currently the only Android core on the buildbot without the suffix, and frontends or tooling that pattern-match the convention miss it entirely.
https://buildbot.libretro.com/nightly/android/latest/arm64-v8a/

Set the same SUFFIX in the existing if(ANDROID) block, and loosen the strip/pack globs from azahar_libretro.* to azahar_libretro* so the suffixed Android artifact still matches (desktop names are unchanged).