### PR TITLE
qt: Fix wrong config key for camera

### DIFF
--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -309,7 +309,7 @@ void QtConfig::ReadCameraValues() {
     qt_config->beginGroup(QStringLiteral("Camera"));
 
     Settings::values.camera_name[OuterRightCamera] =
-        ReadSetting(Settings::QKeys::camera_inner_flip, QStringLiteral("blank"))
+        ReadSetting(Settings::QKeys::camera_outer_right_name, QStringLiteral("blank"))
             .toString()
             .toStdString();
     Settings::values.camera_config[OuterRightCamera] =


### PR DESCRIPTION
Fix wrong config value being read for the outer right camera name in the QT build.