### PR TITLE
Change internal references to azahar_libretro to citra_libretro

### DIFF
--- a/.github/workflows/libretro.yml
+++ b/.github/workflows/libretro.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           export NDK_ROOT=${ANDROID_SDK_ROOT}/ndk/$ANDROID_NDK_VERSION
           ${ANDROID_SDK_ROOT}/cmake/3.30.3/bin/cmake $CORE_ARGS -DANDROID_PLATFORM=android-$API_LEVEL -DCMAKE_TOOLCHAIN_FILE=$NDK_ROOT/build/cmake/android.toolchain.cmake -DANDROID_STL=c++_static -DANDROID_ABI=$ANDROID_ABI . -B $BUILD_DIR
-          ${ANDROID_SDK_ROOT}/cmake/3.30.3/bin/cmake --build $BUILD_DIR --target azahar_libretro --config Release -j $(nproc)
+          ${ANDROID_SDK_ROOT}/cmake/3.30.3/bin/cmake --build $BUILD_DIR --target citra_libretro --config Release -j $(nproc)
           llvm-strip -s $BUILD_DIR/$EXTRA_PATH/azahar_libretro.*
       - name: Pack
         run: ./.ci/libretro-pack.sh
@@ -95,7 +95,7 @@ jobs:
       - name: Build
         run: |
           cmake $CORE_ARGS $EXTRA_CORE_ARGS . -B $BUILD_DIR
-          cmake --build $BUILD_DIR --target azahar_libretro --config Release -j $(nproc)
+          cmake --build $BUILD_DIR --target citra_libretro --config Release -j $(nproc)
           llvm-strip -s $BUILD_DIR/$EXTRA_PATH/azahar_libretro.*
       - name: Pack
         run: ./.ci/libretro-pack.sh
@@ -145,7 +145,7 @@ jobs:
               $IMAGE \
               bash -lc "\
                   ${CMAKE} $CORE_ARGS $EXTRA_CORE_ARGS . -B $BUILD_DIR && \
-                  ${CMAKE} --build $BUILD_DIR --target azahar_libretro --config Release -j $(nproc) && \
+                  ${CMAKE} --build $BUILD_DIR --target citra_libretro --config Release -j $(nproc) && \
                   x86_64-w64-mingw32.static-strip -s $BUILD_DIR/$EXTRA_PATH/azahar_libretro.*"
       - name: Pack
         run: ./.ci/libretro-pack.sh
@@ -192,7 +192,7 @@ jobs:
       - name: Build
         run: |
           cmake $CORE_ARGS -DCMAKE_OSX_ARCHITECTURES=$TARGET . -B $BUILD_DIR
-          cmake --build $BUILD_DIR --target azahar_libretro --config Release
+          cmake --build $BUILD_DIR --target citra_libretro --config Release
           strip -x $BUILD_DIR/$EXTRA_PATH/azahar_libretro.*
       - name: Pack
         run: ./.ci/libretro-pack.sh
@@ -234,7 +234,7 @@ jobs:
       - name: Build
         run: |
           cmake $CORE_ARGS $EXTRA_CORE_ARGS . -B $BUILD_DIR
-          cmake --build $BUILD_DIR --target azahar_libretro --config Release
+          cmake --build $BUILD_DIR --target citra_libretro --config Release
           strip -x $BUILD_DIR/$EXTRA_PATH/azahar_libretro.*
       - name: Pack
         run: ./.ci/libretro-pack.sh
@@ -276,7 +276,7 @@ jobs:
       - name: Build
         run: |
           cmake $CORE_ARGS $EXTRA_CORE_ARGS . -B $BUILD_DIR
-          cmake --build $BUILD_DIR --target azahar_libretro --config Release
+          cmake --build $BUILD_DIR --target citra_libretro --config Release
           strip -x $BUILD_DIR/$EXTRA_PATH/azahar_libretro.*
       - name: Pack
         run: ./.ci/libretro-pack.sh

--- a/src/citra_libretro/CMakeLists.txt
+++ b/src/citra_libretro/CMakeLists.txt
@@ -2,7 +2,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/$<CONFIG>)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/CMakeModules)
 
 # Object library for libretro code (can be linked into both shared lib and tests)
-add_library(azahar_libretro_common OBJECT
+add_library(citra_libretro_common OBJECT
         emu_window/libretro_window.cpp
         emu_window/libretro_window.h
         input/input_factory.cpp
@@ -15,25 +15,27 @@ add_library(azahar_libretro_common OBJECT
         core_settings.cpp
         core_settings.h)
 
-target_compile_definitions(azahar_libretro_common PRIVATE HAVE_LIBRETRO)
-target_link_libraries(azahar_libretro_common PRIVATE citra_common citra_core video_core libretro tsl::robin_map)
+target_compile_definitions(citra_libretro_common PRIVATE HAVE_LIBRETRO)
+target_link_libraries(citra_libretro_common PRIVATE citra_common citra_core video_core libretro tsl::robin_map)
 if(ENABLE_OPENGL)
-    target_link_libraries(azahar_libretro_common PRIVATE glad)
+    target_link_libraries(citra_libretro_common PRIVATE glad)
 endif()
 if(ENABLE_VULKAN)
-    target_link_libraries(azahar_libretro_common PRIVATE sirit vulkan-headers vma)
+    target_link_libraries(citra_libretro_common PRIVATE sirit vulkan-headers vma)
 endif()
 
-add_library(azahar_libretro SHARED
+add_library(citra_libretro SHARED
         citra_libretro.cpp
         citra_libretro.h
-        $<TARGET_OBJECTS:azahar_libretro_common>)
+        $<TARGET_OBJECTS:citra_libretro_common>)
 
-create_target_directory_groups(azahar_libretro)
+set_target_properties(citra_libretro PROPERTIES OUTPUT_NAME "azahar_libretro")
+
+create_target_directory_groups(citra_libretro)
 
 if (BSD STREQUAL "NetBSD")
     include(DisablePaxMprotect)
-    disable_pax_mprotect(azahar_libretro)
+    disable_pax_mprotect(citra_libretro)
 endif()
 
 target_link_libraries(citra_common PRIVATE libretro)
@@ -47,55 +49,55 @@ target_compile_definitions(video_core PRIVATE HAVE_LIBRETRO)
 target_compile_definitions(audio_core PRIVATE HAVE_LIBRETRO)
 target_compile_definitions(input_common PRIVATE HAVE_LIBRETRO)
 
-target_link_libraries(azahar_libretro PRIVATE citra_common citra_core)
-target_link_libraries(azahar_libretro PRIVATE Boost::boost dds-ktx libretro tsl::robin_map)
+target_link_libraries(citra_libretro PRIVATE citra_common citra_core)
+target_link_libraries(citra_libretro PRIVATE Boost::boost dds-ktx libretro tsl::robin_map)
 if(ENABLE_VULKAN)
-  target_link_libraries(azahar_libretro PRIVATE sirit vulkan-headers vma)
+  target_link_libraries(citra_libretro PRIVATE sirit vulkan-headers vma)
 endif()
 if(ENABLE_OPENGL)
-  target_link_libraries(azahar_libretro PRIVATE glad)
+  target_link_libraries(citra_libretro PRIVATE glad)
 endif()
-target_link_libraries(azahar_libretro PRIVATE ${PLATFORM_LIBRARIES} Threads::Threads)
+target_link_libraries(citra_libretro PRIVATE ${PLATFORM_LIBRARIES} Threads::Threads)
 if(DEFINED LIBRETRO_STATIC)
-  target_link_libraries(azahar_libretro PRIVATE -static-libstdc++)
+  target_link_libraries(citra_libretro PRIVATE -static-libstdc++)
 endif()
 
-set_target_properties(azahar_libretro PROPERTIES PREFIX "")
-target_compile_definitions(azahar_libretro PRIVATE HAVE_LIBRETRO)
+set_target_properties(citra_libretro PROPERTIES PREFIX "")
+target_compile_definitions(citra_libretro PRIVATE HAVE_LIBRETRO)
 
 if(ANDROID)
   target_compile_definitions(citra_common PRIVATE HAVE_LIBRETRO_VFS)
   target_compile_definitions(citra_core PRIVATE HAVE_LIBRETRO_VFS)
   target_compile_definitions(video_core PRIVATE HAVE_LIBRETRO_VFS)
-  target_compile_definitions(azahar_libretro_common PRIVATE USING_GLES HAVE_LIBRETRO_VFS)
-  target_compile_definitions(azahar_libretro PRIVATE USING_GLES HAVE_LIBRETRO_VFS)
+  target_compile_definitions(citra_libretro_common PRIVATE USING_GLES HAVE_LIBRETRO_VFS)
+  target_compile_definitions(citra_libretro PRIVATE USING_GLES HAVE_LIBRETRO_VFS)
   target_link_libraries(citra_common PRIVATE libretro_common)
   target_link_libraries(citra_core PRIVATE libretro_common)
   target_link_libraries(video_core PRIVATE libretro_common)
-  target_link_libraries(azahar_libretro_common PRIVATE libretro_common)
-  target_link_libraries(azahar_libretro PRIVATE libretro_common)
+  target_link_libraries(citra_libretro_common PRIVATE libretro_common)
+  target_link_libraries(citra_libretro PRIVATE libretro_common)
   # Link Android log library for __android_log_print
-  target_link_libraries(azahar_libretro PRIVATE log)
+  target_link_libraries(citra_libretro PRIVATE log)
 endif()
 
 if(MINGW)
-  target_link_libraries(azahar_libretro PRIVATE crypt32)
+  target_link_libraries(citra_libretro PRIVATE crypt32)
 endif()
 
 if(IOS)
-  target_compile_definitions(azahar_libretro_common PRIVATE IOS)
-  target_compile_definitions(azahar_libretro PRIVATE IOS)
-  target_link_libraries(azahar_libretro PRIVATE "-framework CoreFoundation" "-framework Foundation")
+  target_compile_definitions(citra_libretro_common PRIVATE IOS)
+  target_compile_definitions(citra_libretro PRIVATE IOS)
+  target_link_libraries(citra_libretro PRIVATE "-framework CoreFoundation" "-framework Foundation")
 endif()
 
 if (SSE42_COMPILE_OPTION)
-  target_compile_definitions(azahar_libretro PRIVATE CITRA_HAS_SSE42)
+  target_compile_definitions(citra_libretro PRIVATE CITRA_HAS_SSE42)
 endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR
     CMAKE_SYSTEM_NAME STREQUAL "iOS" OR
     CMAKE_SYSTEM_NAME STREQUAL "tvOS")
-  target_link_libraries(azahar_libretro PRIVATE "-Wl,-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libretro.osx.def")
+  target_link_libraries(citra_libretro PRIVATE "-Wl,-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libretro.osx.def")
 else()
-  target_link_libraries(azahar_libretro PRIVATE "-Wl,-Bsymbolic")
+  target_link_libraries(citra_libretro PRIVATE "-Wl,-Bsymbolic")
 endif()

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -32,7 +32,7 @@ target_link_libraries(tests PRIVATE citra_common citra_core video_core audio_cor
 target_link_libraries(tests PRIVATE ${PLATFORM_LIBRARIES} catch2 nihstro-headers Threads::Threads)
 
 if (ENABLE_LIBRETRO)
-    target_link_libraries(tests PRIVATE $<TARGET_OBJECTS:azahar_libretro_common>)
+    target_link_libraries(tests PRIVATE $<TARGET_OBJECTS:citra_libretro_common>)
 endif()
 
 add_test(NAME tests COMMAND tests)


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Fits existing project precident around using the name "Citra" internally to refer to the project

Compiled library file is still called azahar_libretro