### PR TITLE
refactor: optimize multiple resource and instruction caches using tsl

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -547,6 +547,7 @@ if ("x86_64" IN_LIST ARCHITECTURE OR "arm64" IN_LIST ARCHITECTURE)
         arm/dynarmic/arm_tick_counts.h
     )
     target_link_libraries(citra_core PRIVATE dynarmic)
+    target_link_libraries(citra_core PUBLIC tsl::robin_map)
 endif()
 
 if (CITRA_USE_PRECOMPILED_HEADERS)

--- a/src/core/arm/skyeye_common/armstate.h
+++ b/src/core/arm/skyeye_common/armstate.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <array>
-#include <unordered_map>
+#include <tsl/robin_map.h>
 #include "common/common_types.h"
 #include "core/arm/skyeye_common/arm_regformat.h"
 #ifdef ENABLE_GDBSTUB
@@ -262,7 +262,7 @@ public:
 
     // TODO(bunnei): Move this cache to a better place - it should be per codeset (likely per
     // process for our purposes), not per ARMul_State (which tracks CPU core state).
-    std::unordered_map<u32, std::size_t> instruction_cache;
+    tsl::robin_map<u32, std::size_t> instruction_cache;
 
 private:
     void ResetMPCoreCP15Registers();

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -215,7 +215,8 @@ target_include_directories(video_core PRIVATE ${HOST_SHADERS_INCLUDE})
 create_target_directory_groups(video_core)
 
 target_link_libraries(video_core PUBLIC citra_common citra_core)
-target_link_libraries(video_core PRIVATE Boost::serialization dds-ktx json-headers nihstro-headers tsl::robin_map)
+target_link_libraries(video_core PRIVATE Boost::serialization dds-ktx json-headers nihstro-headers)
+target_link_libraries(video_core PUBLIC tsl::robin_map)
 
 if ("x86_64" IN_LIST ARCHITECTURE)
     target_link_libraries(video_core PUBLIC xbyak)

--- a/src/video_core/custom_textures/custom_tex_manager.h
+++ b/src/video_core/custom_textures/custom_tex_manager.h
@@ -7,7 +7,8 @@
 #include <list>
 #include <span>
 #include <unordered_map>
-#include <unordered_set>
+#include <tsl/robin_map.h>
+#include <tsl/robin_set.h>
 #include "common/thread_worker.h"
 #include "video_core/custom_textures/material.h"
 #include "video_core/rasterizer_interface.h"
@@ -82,8 +83,8 @@ private:
 private:
     Core::System& system;
     Frontend::ImageInterface& image_interface;
-    std::unordered_set<u64> dumped_textures;
-    std::unordered_map<u64, std::unique_ptr<Material>> material_map;
+    tsl::robin_set<u64> dumped_textures;
+    tsl::robin_map<u64, std::unique_ptr<Material>> material_map;
     std::unordered_map<std::string, std::vector<u64>> path_to_hash_map;
     std::vector<std::unique_ptr<CustomTexture>> custom_textures;
     std::list<AsyncUpload> async_uploads;

--- a/src/video_core/rasterizer_cache/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache/rasterizer_cache.h
@@ -161,7 +161,7 @@ void RasterizerCache<T>::RemoveTextureCubeFace(SurfaceId surface_id) {
     }
 
     for (auto it = texture_cube_cache.begin(); it != texture_cube_cache.end();) {
-        TextureCube& cube = it->second;
+        TextureCube& cube = it.value();
         for (SurfaceId& face_id : cube.face_ids) {
             if (face_id == surface_id) {
                 face_id = SurfaceId{};
@@ -422,7 +422,7 @@ typename T::Sampler& RasterizerCache<T>::GetSampler(
 
     auto [it, is_new] = samplers.try_emplace(params);
     if (is_new) {
-        it->second = slot_samplers.insert(runtime, params);
+        it.value() = slot_samplers.insert(runtime, params);
     }
 
     return slot_samplers[it->second];
@@ -627,7 +627,7 @@ typename T::Surface& RasterizerCache<T>::GetTextureCube(const TextureCubeConfig&
     }
 
     auto [it, new_surface] = texture_cube_cache.try_emplace(config);
-    TextureCube& cube = it->second;
+    TextureCube& cube = it.value();
 
     const std::array addresses = {config.px, config.nx, config.py, config.ny, config.pz, config.nz};
 
@@ -791,7 +791,7 @@ FramebufferHelper<T> RasterizerCache<T>::GetFramebufferSurfaces(bool using_color
 
     auto [it, new_framebuffer] = framebuffers.try_emplace(fb_params);
     if (new_framebuffer) {
-        it->second = slot_framebuffers.insert(runtime, fb_params, color_surface, depth_surface);
+        it.value() = slot_framebuffers.insert(runtime, fb_params, color_surface, depth_surface);
     }
 
     return FramebufferHelper<T>{this, &slot_framebuffers[it->second],

--- a/src/video_core/rasterizer_cache/rasterizer_cache_base.h
+++ b/src/video_core/rasterizer_cache/rasterizer_cache_base.h
@@ -8,7 +8,6 @@
 #include <list>
 #include <optional>
 #include <span>
-#include <unordered_map>
 #include <vector>
 #include <boost/icl/interval_map.hpp>
 #include <tsl/robin_map.h>
@@ -216,10 +215,10 @@ private:
     Runtime& runtime;
     Pica::RegsInternal& regs;
     RendererBase& renderer;
-    std::unordered_map<TextureCubeConfig, TextureCube> texture_cube_cache;
+    tsl::robin_map<TextureCubeConfig, TextureCube> texture_cube_cache;
     tsl::robin_pg_map<u64, std::vector<SurfaceId>, Common::IdentityHash<u64>> page_table;
-    std::unordered_map<FramebufferParams, FramebufferId> framebuffers;
-    std::unordered_map<SamplerParams, SamplerId> samplers;
+    tsl::robin_map<FramebufferParams, FramebufferId> framebuffers;
+    tsl::robin_map<SamplerParams, SamplerId> samplers;
     std::list<std::pair<SurfaceId, u64>> sentenced;
     Common::SlotVector<Surface> slot_surfaces;
     Common::SlotVector<Sampler> slot_samplers;

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -8,6 +8,7 @@
 #include <span>
 #include <thread>
 #include <unordered_map>
+#include <tsl/robin_map.h>
 #include <variant>
 #include "common/hash.h"
 #include "common/settings.h"
@@ -325,7 +326,7 @@ public:
     FixedGeometryShaders fixed_geometry_shaders;
 
     FragmentShaders fragment_shaders;
-    std::unordered_map<u64, OGLProgram> program_cache;
+    tsl::robin_map<u64, OGLProgram> program_cache;
     OGLPipeline pipeline;
     ShaderDiskCache disk_cache;
 

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -8,8 +8,8 @@
 #include <span>
 #include <thread>
 #include <unordered_map>
-#include <tsl/robin_map.h>
 #include <variant>
+#include <tsl/robin_map.h>
 #include "common/hash.h"
 #include "common/settings.h"
 #include "core/frontend/emu_window.h"

--- a/src/video_core/renderer_vulkan/vk_blit_helper.h
+++ b/src/video_core/renderer_vulkan/vk_blit_helper.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <unordered_map>
+#include <tsl/robin_map.h>
 
 #include "video_core/rasterizer_cache/pixel_format.h"
 #include "video_core/renderer_vulkan/vk_resource_pool.h"
@@ -98,7 +98,7 @@ private:
     vk::Sampler nearest_sampler;
 
     /// Cache of texture filter pipelines (keyed by shader+layout+format hash)
-    std::unordered_map<std::uint64_t, vk::Pipeline> filter_pipeline_cache;
+    tsl::robin_map<std::uint64_t, vk::Pipeline> filter_pipeline_cache;
 };
 
 } // namespace Vulkan

--- a/src/video_core/shader/shader_jit.cpp
+++ b/src/video_core/shader/shader_jit.cpp
@@ -38,7 +38,7 @@ void JitEngine::SetupBatch(ShaderSetup& setup, u32 entry_point) {
         auto shader = std::make_unique<JitShader>();
         shader->Compile(&setup.GetProgramCode(), &setup.GetSwizzleData());
         setup.cached_shader = shader.get();
-        cache.emplace_hint(iter, cache_key, std::move(shader));
+        cache.emplace(cache_key, std::move(shader));
     }
 }
 

--- a/src/video_core/shader/shader_jit.h
+++ b/src/video_core/shader/shader_jit.h
@@ -8,7 +8,7 @@
 #if CITRA_ARCH(x86_64) || CITRA_ARCH(arm64)
 
 #include <memory>
-#include <unordered_map>
+#include <tsl/robin_map.h>
 #include "common/common_types.h"
 #include "video_core/shader/shader.h"
 
@@ -25,7 +25,7 @@ public:
     void Run(const ShaderSetup& setup, ShaderUnit& state) const override;
 
 private:
-    std::unordered_map<u64, std::unique_ptr<JitShader>> cache;
+    tsl::robin_map<u64, std::unique_ptr<JitShader>> cache;
 };
 
 } // namespace Pica::Shader


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

This PR replaces several legacy instances of `std::unordered_map` with `tsl::robin_map` / `tsl::robin_pg_map` to improve CPU cache locality, reduce memory overhead, and modernize map implementations across key rendering and CPU paths

---------

I used AI to find relevant target areas for this optimization