### PR TITLE
Add azahar_libretro CMake target for compatibility with libretro buildbot

### DIFF
--- a/.github/workflows/libretro.yml
+++ b/.github/workflows/libretro.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           export NDK_ROOT=${ANDROID_SDK_ROOT}/ndk/$ANDROID_NDK_VERSION
           ${ANDROID_SDK_ROOT}/cmake/3.30.3/bin/cmake $CORE_ARGS -DANDROID_PLATFORM=android-$API_LEVEL -DCMAKE_TOOLCHAIN_FILE=$NDK_ROOT/build/cmake/android.toolchain.cmake -DANDROID_STL=c++_static -DANDROID_ABI=$ANDROID_ABI . -B $BUILD_DIR
-          ${ANDROID_SDK_ROOT}/cmake/3.30.3/bin/cmake --build $BUILD_DIR --target citra_libretro --config Release -j $(nproc)
+          ${ANDROID_SDK_ROOT}/cmake/3.30.3/bin/cmake --build $BUILD_DIR --target azahar_libretro --config Release -j $(nproc)
           llvm-strip -s $BUILD_DIR/$EXTRA_PATH/azahar_libretro.*
       - name: Pack
         run: ./.ci/libretro-pack.sh

--- a/src/citra_libretro/CMakeLists.txt
+++ b/src/citra_libretro/CMakeLists.txt
@@ -101,3 +101,5 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR
 else()
   target_link_libraries(citra_libretro PRIVATE "-Wl,-Bsymbolic")
 endif()
+
+add_custom_target(azahar_libretro DEPENDS citra_libretro)


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Follow-up to #2304 which restores compatibility with the libretro build infrastructure, which derives the CMake target name from the name of the core.