### PR TITLE
qt: Make string non translatable

### DIFF
--- a/src/citra_qt/multiplayer/host_room.cpp
+++ b/src/citra_qt/multiplayer/host_room.cpp
@@ -71,7 +71,8 @@ HostRoomWindow::~HostRoomWindow() = default;
 
 void HostRoomWindow::UpdateGameList(QStandardItemModel* list) {
     game_list->clear();
-    game_list->appendRow(new GameListItemPath(tr("%none%"), {}, std::numeric_limits<u64>::max(), 0,
+    game_list->appendRow(new GameListItemPath(QStringLiteral("%none%"), {},
+                                              std::numeric_limits<u64>::max(), 0,
                                               Service::FS::MediaType::NAND, false, false));
     for (int i = 0; i < list->rowCount(); i++) {
         auto parent = list->item(i, 0);


### PR DESCRIPTION
Fixes a mistake from #2296 that incorrectly marks a string as translatable. This PR does not need to get into the changelog.