### PR TITLE
BUGFIX #2313 - crash when touchpad is enabled

### DIFF
--- a/src/input_common/sdl/sdl_joystick.cpp
+++ b/src/input_common/sdl/sdl_joystick.cpp
@@ -125,7 +125,10 @@ int SDLJoystick::GetPort() const {
 }
 
 std::tuple<float, float, float> SDLJoystick::GetTouch(int pad) const {
-    return state.touchpad.at(pad);
+    if (state.touchpad.contains(pad))
+        return state.touchpad.at(pad);
+    else
+        return std::tuple<float, float, float>(0.0f, 0.0f, 0.0f);
 }
 
 SDL_Joystick* SDLJoystick::GetSDLJoystick() const {


### PR DESCRIPTION
Hotfix for #2313 

This does not solve the cause, but provides a backup value for the touch parameter that should prevent the crash. I will not close the issue at this moment as I hope to do more digging into why exactly the root cause is happening now and fix that eventually, but for now this should prevent crashing (and won't hurt to keep even after the cause is fixed).