### PR TITLE
video_core: Improve cmd list processing (lut + batch + vectorize)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,8 @@ if(ENABLE_SSE42 AND (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64"))
     else()
         SET(SSE42_COMPILE_OPTION -msse4.1 -msse4.2)
     endif()
+    add_compile_options(${SSE42_COMPILE_OPTION})
+    add_compile_definitions(CITRA_HAS_SSE42)
 endif()
 
 include(CitraHandleSystemLibs)

--- a/src/citra_libretro/CMakeLists.txt
+++ b/src/citra_libretro/CMakeLists.txt
@@ -90,10 +90,6 @@ if(IOS)
   target_link_libraries(citra_libretro PRIVATE "-framework CoreFoundation" "-framework Foundation")
 endif()
 
-if (SSE42_COMPILE_OPTION)
-  target_compile_definitions(citra_libretro PRIVATE CITRA_HAS_SSE42)
-endif()
-
 if (CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR
     CMAKE_SYSTEM_NAME STREQUAL "iOS" OR
     CMAKE_SYSTEM_NAME STREQUAL "tvOS")

--- a/src/citra_meta/CMakeLists.txt
+++ b/src/citra_meta/CMakeLists.txt
@@ -108,10 +108,6 @@ if (CITRA_USE_PRECOMPILED_HEADERS)
     target_precompile_headers(citra_meta PRIVATE precompiled_headers.h)
 endif()
 
-if (SSE42_COMPILE_OPTION)
-    target_compile_definitions(citra_meta PRIVATE CITRA_HAS_SSE42)
-endif()
-
 # Bundle in-place on MSVC so dependencies can be resolved by builds.
 if (ENABLE_QT AND MSVC)
     include(BundleTarget)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -175,9 +175,4 @@ if (BACKTRACE_LIBRARY AND ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND CMAKE_CXX_CO
     target_compile_definitions(citra_common PRIVATE CITRA_LINUX_GCC_BACKTRACE)
 endif()
 
-if (SSE42_COMPILE_OPTION)
-    target_compile_definitions(citra_common PRIVATE CITRA_HAS_SSE42)
-    target_compile_options(citra_common PRIVATE ${SSE42_COMPILE_OPTION})
-endif()
-
 target_link_libraries(citra_common PUBLIC xxHash::xxhash)

--- a/src/video_core/pica/dirty_regs.h
+++ b/src/video_core/pica/dirty_regs.h
@@ -16,6 +16,37 @@ union DirtyRegs {
         qwords[reg_id >> 6] |= 1ULL << (reg_id & 0x3f);
     }
 
+    void SetRange(u32 start_reg_id, u32 count) {
+        if (count == 0) [[unlikely]] {
+            return;
+        }
+
+        const u32 end = start_reg_id + count;
+        const u32 first_word = start_reg_id >> 6;
+        const u32 last_word = (end - 1) >> 6;
+        const u32 start_bit = start_reg_id & 0x3f;
+
+        if (first_word == last_word) {
+            // Entire range fits in one qword.
+            const u64 mask = (count >= 64) ? ~0ULL : (((1ULL << count) - 1ULL) << start_bit);
+            qwords[first_word] |= mask;
+            return;
+        }
+
+        // Partial first qword, set from start_bit until bit 63.
+        qwords[first_word] |= (~0ULL << start_bit);
+
+        // Set all middle qwords.
+        for (u32 w = first_word + 1; w < last_word; ++w) {
+            qwords[w] = ~0ULL;
+        }
+
+        // Partial last qword, set bits from 0 to end_bit.
+        const u32 end_bit = end & 0x3f;
+        const u64 last_mask = (end_bit == 0) ? ~0ULL : ((1ULL << end_bit) - 1ULL);
+        qwords[last_word] |= last_mask;
+    }
+
     void SetAllDirty() {
         qwords.fill(UINT64_MAX);
     }

--- a/src/video_core/pica/pica_core.cpp
+++ b/src/video_core/pica/pica_core.cpp
@@ -21,6 +21,43 @@ MICROPROFILE_DEFINE(GPU_Drawing, "GPU", "Drawing", MP_RGB(50, 50, 240));
 
 using namespace DebugUtils;
 
+// Class representing implementation details of each internal register
+// The set/get pattern is used instead of a bitfield union to allow
+// constexpr evaluation.
+class RegImplInfo {
+private:
+    using NeedsSpecialHandlingBF = BitField<0, 1, u16>;
+    using SupportsBatchBF = BitField<1, 1, u16>;
+    using RegsUntilSpecialBF = BitField<2, 14, u16>;
+
+    u16 raw{};
+
+public:
+    constexpr bool NeedsSpecialHandling() const {
+        return NeedsSpecialHandlingBF::ExtractValue(raw) != 0;
+    }
+
+    constexpr void SetNeedsSpecialHandling() {
+        raw = (raw & ~NeedsSpecialHandlingBF::mask) | NeedsSpecialHandlingBF::FormatValue(1);
+    }
+
+    constexpr bool SupportsBatch() const {
+        return SupportsBatchBF::ExtractValue(raw) != 0;
+    }
+
+    constexpr void SetSupportsBatch() {
+        raw = (raw & ~SupportsBatchBF::mask) | SupportsBatchBF::FormatValue(1);
+    }
+
+    constexpr u16 RegsUntilSpecial() const {
+        return RegsUntilSpecialBF::ExtractValue(raw);
+    }
+
+    constexpr void SetRegsUntilSpecial(u16 value) {
+        raw = (raw & ~RegsUntilSpecialBF::mask) | RegsUntilSpecialBF::FormatValue(value);
+    }
+};
+
 union CommandHeader {
     u32 hex;
     BitField<0, 16, u32> cmd_id;
@@ -99,24 +136,196 @@ void PicaCore::SetInterruptHandler(Service::GSP::InterruptHandler& signal_interr
     this->signal_interrupt = signal_interrupt;
 }
 
-void PicaCore::ProcessCmdList(PAddr list, u32 size, bool ignore_list) {
+static consteval std::array<RegImplInfo, RegsInternal::NUM_REGS> BuildRegImplFlagsLUT() {
+    std::array<RegImplInfo, RegsInternal::NUM_REGS> table{};
+
+    // Marks the register as needing special handling.
+    const auto mark_special = [&table](u32 index) { table[index].SetNeedsSpecialHandling(); };
+
+    // Marks the register as supporting batch writes.
+    const auto mark_batch = [&table](u32 index) { table[index].SetSupportsBatch(); };
+
+    // Single registers
+    mark_special(PICA_REG_INDEX(irq_request));
+    mark_special(PICA_REG_INDEX(pipeline.triangle_topology));
+    mark_special(PICA_REG_INDEX(pipeline.restart_primitive));
+    mark_special(PICA_REG_INDEX(pipeline.vs_default_attributes_setup.index));
+    mark_special(PICA_REG_INDEX(pipeline.trigger_draw));
+    mark_special(PICA_REG_INDEX(pipeline.trigger_draw_indexed));
+    mark_special(PICA_REG_INDEX(gs.bool_uniforms));
+    mark_special(PICA_REG_INDEX(vs.output_mask));
+    mark_special(PICA_REG_INDEX(vs.bool_uniforms));
+
+    // Array based registers
+    for (u32 i = 0; i < 2; ++i) {
+        mark_special(PICA_REG_INDEX(pipeline.command_buffer.trigger[0]) + i);
+    }
+    for (u32 i = 0; i < 3; ++i) {
+        mark_special(PICA_REG_INDEX(pipeline.vs_default_attributes_setup.set_value[0]) + i);
+        mark_batch(PICA_REG_INDEX(pipeline.vs_default_attributes_setup.set_value[0]) + i);
+    }
+    for (u32 i = 0; i < 4; ++i) {
+        mark_special(PICA_REG_INDEX(vs.int_uniforms[0]) + i);
+        mark_special(PICA_REG_INDEX(gs.int_uniforms[0]) + i);
+    }
+    for (u32 i = 0; i < 8; ++i) {
+        mark_special(PICA_REG_INDEX(gs.uniform_setup.set_value[0]) + i);
+        mark_batch(PICA_REG_INDEX(gs.uniform_setup.set_value[0]) + i);
+        mark_special(PICA_REG_INDEX(vs.uniform_setup.set_value[0]) + i);
+        mark_batch(PICA_REG_INDEX(vs.uniform_setup.set_value[0]) + i);
+        mark_special(PICA_REG_INDEX(gs.program.set_word[0]) + i);
+        mark_batch(PICA_REG_INDEX(gs.program.set_word[0]) + i);
+        mark_special(PICA_REG_INDEX(vs.program.set_word[0]) + i);
+        mark_batch(PICA_REG_INDEX(vs.program.set_word[0]) + i);
+        mark_special(PICA_REG_INDEX(gs.swizzle_patterns.set_word[0]) + i);
+        mark_batch(PICA_REG_INDEX(gs.swizzle_patterns.set_word[0]) + i);
+        mark_special(PICA_REG_INDEX(vs.swizzle_patterns.set_word[0]) + i);
+        mark_batch(PICA_REG_INDEX(vs.swizzle_patterns.set_word[0]) + i);
+        mark_special(PICA_REG_INDEX(lighting.lut_data[0]) + i);
+        mark_batch(PICA_REG_INDEX(lighting.lut_data[0]) + i);
+        mark_special(PICA_REG_INDEX(texturing.fog_lut_data[0]) + i);
+        mark_batch(PICA_REG_INDEX(texturing.fog_lut_data[0]) + i);
+        mark_special(PICA_REG_INDEX(texturing.proctex_lut_data[0]) + i);
+        mark_batch(PICA_REG_INDEX(texturing.proctex_lut_data[0]) + i);
+    }
+
+    // Build distances to next special register.
+    u16 regs_since_special = std::numeric_limits<u16>::max();
+    for (size_t i = RegsInternal::NUM_REGS; i-- > 0;) {
+        if (table[i].NeedsSpecialHandling()) {
+            regs_since_special = 0;
+        }
+        table[i].SetRegsUntilSpecial(regs_since_special);
+        if (regs_since_special != std::numeric_limits<u16>::max()) {
+            regs_since_special++;
+        }
+    }
+
+    return table;
+}
+
+static constexpr std::array<RegImplInfo, RegsInternal::NUM_REGS> reg_impl_flags_lut =
+    BuildRegImplFlagsLUT();
+
+// Expand a 4-bit mask to 4-byte mask, e.g. 0b0101 -> 0x00FF00FF
+static constexpr std::array<u32, 16> ExpandBitsToBytes = {
+    0x00000000, 0x000000ff, 0x0000ff00, 0x0000ffff, 0x00ff0000, 0x00ff00ff, 0x00ffff00, 0x00ffffff,
+    0xff000000, 0xff0000ff, 0xff00ff00, 0xff00ffff, 0xffff0000, 0xffff00ff, 0xffffff00, 0xffffffff,
+};
+
+/**
+ * This is the main loop for processing GPU command lists. On Azahar, it's the most
+ * CPU expensive function (excluding the inner Draw calls) due to applications submitting
+ * 10-50 command lists per frame, each with hundreds of commands in them. For this reason,
+ * it is important that this function is well optimized to reduce the load on the CPU.
+ *
+ * Each command in the list has the following properties:
+ *  - Commands come in [value (32 bit), header (32 bit)] pairs, most of the time.
+ *  - The register ID that the 32 bit value should be written to is stored in the header.
+ *  - The mask of bits that should be written comes in the header
+ *    (to be able to write individual bytes of the 4-byte register)
+ *  - Commands can have an extra length N, which means that N extra words follow
+ *    after the header word.
+ *    - If group_command is set in the header, N sequential registers are
+ *      written to starting from the ID + 1 specified in the header.
+ *    - If group_command is not set, the same register is written
+ *      to with the N extra words. This is used for things like shader uploads
+ *      which has a single register ID.
+ *
+ * Regarding implementation details, we store all register values in an array,
+ * as well as a dirty array to indicate which registers have changed since
+ * the last draw. Some registers need special handling, as they are "trigger"
+ * registers that start the draw, or store the data in the shader units.
+ *
+ * To be able to determine if a register is special, we use a lookup table
+ * generated by BuildRegImplFlagsLUT(). This allows determining if a register
+ * is special or not in O(1). This LUT also determines if a register has
+ * support for batch handling (extra_data_length != 0 && group_command == 0)
+ * and the amount of commands away from the next special register, useful for
+ * sequential writes (extra_data_length != 0 && group_command == 1).
+ *
+ * As much as possible, we want to target the following optimizations:
+ *  - We should prevent branches and jumps to functions if they are not needed.
+ *  - We should clearly separate special command handling from normal commands
+ *    that are much cheaper to handle.
+ *  - Commands with extra length should be processed in batch if possible.
+ *  - Vectorization should be used as much as possible.
+ *
+ * On the other hand, if PICA debugging is enabled we should avoid optimizations
+ * that would make debugging more complicated.
+ */
+void PicaCore::ProcessCmdList(PAddr list, u32 size, bool ignore_list) [[hot]] {
     if (ignore_list) {
         signal_interrupt(Service::GSP::InterruptId::P3D, delay_generator.CalculateAndResetDelay());
         return;
     }
-    // Initialize command list tracking.
+
     const u8* head = memory.GetPhysicalPointer(list);
     cmd_list.Reset(list, head, size);
 
     bool stop_requested = false;
+    bool skip_fast_path = false;
     while (cmd_list.current_index < cmd_list.length) {
         if (stop_requested) [[unlikely]] {
             break;
         }
-        // Align read pointer to 8 bytes
         if (cmd_list.current_index % 2 != 0) {
             cmd_list.current_index++;
         }
+
+        // Early path that processes commands in batches of 4. If any of the commands
+        // needs special handling or has extra length it stops and falls back to the
+        // slower path. This pattern allows the compiler to auto-vectorize the function
+        // if the current ISA allows it (that's why we process in batches of 4
+        // as most SIMD operations work with 128 bit registers). MSVC is not able to
+        // auto-vectorize this part with SSE4.2, due to the LUT read, instead it just
+        // unrolls the loop. Other ISAs and/or compilers may be able to do it,
+        // that's why it was decided to keep the structure like this.
+        if (!debug_context) [[likely]] {
+            if (!skip_fast_path) {
+                constexpr u32 batch_size = 4;
+                u32 index = cmd_list.current_index;
+                u32 ids[batch_size], values[batch_size], masks[batch_size];
+                u32 run = 0;
+
+                while (run < batch_size && index + 1 < cmd_list.length) {
+                    const u32 value = cmd_list.head[index];
+                    const CommandHeader header{cmd_list.head[index + 1]};
+
+                    // If extra handling is needed stop and fallback to slower path.
+                    if (header.extra_data_length != 0 || header.cmd_id >= RegsInternal::NUM_REGS ||
+                        reg_impl_flags_lut[header.cmd_id].NeedsSpecialHandling()) {
+                        skip_fast_path = true;
+                        break;
+                    }
+
+                    ids[run] = header.cmd_id;
+                    values[run] = value;
+                    masks[run] = header.parameter_mask;
+                    ++run;
+                    index += 2;
+                }
+
+                // Process the commands that we have read so far (up to 4).
+                if (run > 0) {
+                    delay_generator.AddCommands(run);
+                    for (u32 i = 0; i < run; ++i) {
+                        const u32 id = ids[i];
+                        const u32 write_mask = ExpandBitsToBytes[masks[i]];
+                        regs.internal.reg_array[id] =
+                            (regs.internal.reg_array[id] & ~write_mask) | (values[i] & write_mask);
+                        dirty_regs.Set(id);
+                    }
+                    cmd_list.current_index = index;
+
+                    // Continue from the while loop in case we reached the end of the list.
+                    continue;
+                }
+            }
+        }
+        // Slow path, command needs special handling.
+
+        skip_fast_path = false;
 
         // Read the header and the value to write.
         const u32 value = cmd_list.head[cmd_list.current_index++];
@@ -126,13 +335,35 @@ void PicaCore::ProcessCmdList(PAddr list, u32 size, bool ignore_list) {
         WriteInternalReg(header.cmd_id, value, header.parameter_mask, stop_requested);
 
         // Write any extra paramters as well.
-        for (u32 i = 0; i < header.extra_data_length; ++i) {
-            if (stop_requested) [[unlikely]] {
-                break;
+        const u32 count = header.extra_data_length;
+        if (count == 0)
+            continue;
+
+        if (debug_context) [[unlikely]] {
+            // Fallback to per word register writes if debugging is
+            // enabled.
+            for (u32 i = 0; i < count; ++i) {
+                if (stop_requested) [[unlikely]] {
+                    break;
+                }
+                const u32 cmd = header.cmd_id + (header.group_commands ? i + 1 : 0);
+                const u32 extra_value = cmd_list.head[cmd_list.current_index++];
+                WriteInternalReg(cmd, extra_value, header.parameter_mask, stop_requested);
             }
-            const u32 cmd = header.cmd_id + (header.group_commands ? i + 1 : 0);
-            const u32 extra_value = cmd_list.head[cmd_list.current_index++];
-            WriteInternalReg(cmd, extra_value, header.parameter_mask, stop_requested);
+        } else {
+            // Handle commands with extra length.
+            const u32* extra = &cmd_list.head[cmd_list.current_index];
+            cmd_list.current_index += count;
+
+            if (!header.group_commands) {
+                // Same register written count times in a row (program/swizzle upload, LUT, etc.).
+                WriteInternalRegBatch(header.cmd_id, extra, count, header.parameter_mask,
+                                      stop_requested);
+            } else {
+                // Sequential registers written from header.cmd_id+1 to header.cmd_id+count.
+                WriteInternalRegSequential(header.cmd_id + 1, extra, count, header.parameter_mask,
+                                           stop_requested);
+            }
         }
     }
 }
@@ -142,37 +373,206 @@ static bool any_byte_match(u32 a, u32 b) {
            (((a >> 16) & 0xFF) == ((b >> 16) & 0xFF)) || (((a >> 24) & 0xFF) == ((b >> 24) & 0xFF));
 }
 
-void PicaCore::WriteInternalReg(u32 id, u32 value, u32 mask, bool& stop_requested) {
-    if (id >= RegsInternal::NUM_REGS) {
-        LOG_ERROR(
-            HW_GPU,
-            "Commandlist tried to write to invalid register 0x{:03X} (value: {:08X}, mask: {:X})",
-            id, value, mask);
-        return;
+// Handle registers which our backend support batch writes.
+void PicaCore::HandleSpecialRegBatch(u32 id, const u32* values, u32 count) {
+    switch (id) {
+    case PICA_REG_INDEX(pipeline.vs_default_attributes_setup.set_value[0]):
+    case PICA_REG_INDEX(pipeline.vs_default_attributes_setup.set_value[1]):
+    case PICA_REG_INDEX(pipeline.vs_default_attributes_setup.set_value[2]): {
+        for (u32 i = 0; i < count; i++) {
+            SubmitImmediate(values[i]);
+        }
+        break;
     }
-
-    delay_generator.AddCommands(1);
-
-    // Expand a 4-bit mask to 4-byte mask, e.g. 0b0101 -> 0x00FF00FF
-    constexpr std::array<u32, 16> ExpandBitsToBytes = {
-        0x00000000, 0x000000ff, 0x0000ff00, 0x0000ffff, 0x00ff0000, 0x00ff00ff,
-        0x00ffff00, 0x00ffffff, 0xff000000, 0xff0000ff, 0xff00ff00, 0xff00ffff,
-        0xffff0000, 0xffff00ff, 0xffffff00, 0xffffffff,
-    };
-
-    // TODO: Figure out how register masking acts on e.g. vs.uniform_setup.set_value
-    const u32 old_value = regs.internal.reg_array[id];
-    const u32 write_mask = ExpandBitsToBytes[mask];
-    regs.internal.reg_array[id] = (old_value & ~write_mask) | (value & write_mask);
-
-    // Track register write.
-    DebugUtils::OnPicaRegWrite(id, mask, regs.internal.reg_array[id]);
-
-    // Track events.
-    if (debug_context) {
-        debug_context->OnEvent(DebugContext::Event::PicaCommandLoaded, &id);
+    case PICA_REG_INDEX(gs.uniform_setup.set_value[0]):
+    case PICA_REG_INDEX(gs.uniform_setup.set_value[1]):
+    case PICA_REG_INDEX(gs.uniform_setup.set_value[2]):
+    case PICA_REG_INDEX(gs.uniform_setup.set_value[3]):
+    case PICA_REG_INDEX(gs.uniform_setup.set_value[4]):
+    case PICA_REG_INDEX(gs.uniform_setup.set_value[5]):
+    case PICA_REG_INDEX(gs.uniform_setup.set_value[6]):
+    case PICA_REG_INDEX(gs.uniform_setup.set_value[7]): {
+        gs_setup.WriteUniformFloatRegRange(regs.internal.gs, values, count);
+        break;
     }
+    case PICA_REG_INDEX(gs.program.set_word[0]):
+    case PICA_REG_INDEX(gs.program.set_word[1]):
+    case PICA_REG_INDEX(gs.program.set_word[2]):
+    case PICA_REG_INDEX(gs.program.set_word[3]):
+    case PICA_REG_INDEX(gs.program.set_word[4]):
+    case PICA_REG_INDEX(gs.program.set_word[5]):
+    case PICA_REG_INDEX(gs.program.set_word[6]):
+    case PICA_REG_INDEX(gs.program.set_word[7]): {
+        u32& offset = regs.internal.gs.program.offset;
+        if (offset + count > 4096) {
+            LOG_ERROR(HW_GPU, "Invalid GS program offset {} count {}", offset, count);
+        } else {
+            gs_setup.UpdateProgramCodeRange(offset, values, count);
+            offset += count;
+        }
+        break;
+    }
+    case PICA_REG_INDEX(gs.swizzle_patterns.set_word[0]):
+    case PICA_REG_INDEX(gs.swizzle_patterns.set_word[1]):
+    case PICA_REG_INDEX(gs.swizzle_patterns.set_word[2]):
+    case PICA_REG_INDEX(gs.swizzle_patterns.set_word[3]):
+    case PICA_REG_INDEX(gs.swizzle_patterns.set_word[4]):
+    case PICA_REG_INDEX(gs.swizzle_patterns.set_word[5]):
+    case PICA_REG_INDEX(gs.swizzle_patterns.set_word[6]):
+    case PICA_REG_INDEX(gs.swizzle_patterns.set_word[7]): {
+        u32& offset = regs.internal.gs.swizzle_patterns.offset;
+        if (offset + count > gs_setup.GetSwizzleData().size()) {
+            LOG_ERROR(HW_GPU, "Invalid GS swizzle pattern offset {} count {}", offset, count);
+        } else {
+            gs_setup.UpdateSwizzleDataRange(offset, values, count);
+            offset += count;
+        }
+        break;
+    }
+    case PICA_REG_INDEX(vs.uniform_setup.set_value[0]):
+    case PICA_REG_INDEX(vs.uniform_setup.set_value[1]):
+    case PICA_REG_INDEX(vs.uniform_setup.set_value[2]):
+    case PICA_REG_INDEX(vs.uniform_setup.set_value[3]):
+    case PICA_REG_INDEX(vs.uniform_setup.set_value[4]):
+    case PICA_REG_INDEX(vs.uniform_setup.set_value[5]):
+    case PICA_REG_INDEX(vs.uniform_setup.set_value[6]):
+    case PICA_REG_INDEX(vs.uniform_setup.set_value[7]): {
+        const auto range = vs_setup.WriteUniformFloatRegRange(regs.internal.vs, values, count);
+        if (range && !regs.internal.pipeline.gs_unit_exclusive_configuration &&
+            regs.internal.pipeline.use_gs == PipelineRegs::UseGS::No) {
+            for (u32 i = 0; i < range->count; ++i) {
+                const u32 idx = range->first_index + i;
+                gs_setup.uniforms.f[idx] = vs_setup.uniforms.f[idx];
+            }
+        }
+        break;
+    }
+    case PICA_REG_INDEX(vs.program.set_word[0]):
+    case PICA_REG_INDEX(vs.program.set_word[1]):
+    case PICA_REG_INDEX(vs.program.set_word[2]):
+    case PICA_REG_INDEX(vs.program.set_word[3]):
+    case PICA_REG_INDEX(vs.program.set_word[4]):
+    case PICA_REG_INDEX(vs.program.set_word[5]):
+    case PICA_REG_INDEX(vs.program.set_word[6]):
+    case PICA_REG_INDEX(vs.program.set_word[7]): {
+        u32& offset = regs.internal.vs.program.offset;
+        if (offset + count > 512) {
+            LOG_ERROR(HW_GPU, "Invalid VS program offset {} count {}", offset, count);
+        } else {
+            vs_setup.UpdateProgramCodeRange(offset, values, count);
+            if (!regs.internal.pipeline.gs_unit_exclusive_configuration &&
+                regs.internal.pipeline.use_gs == PipelineRegs::UseGS::No) {
+                gs_setup.UpdateProgramCodeRange(offset, values, count);
+            }
+            offset += count;
+        }
+        break;
+    }
+    case PICA_REG_INDEX(vs.swizzle_patterns.set_word[0]):
+    case PICA_REG_INDEX(vs.swizzle_patterns.set_word[1]):
+    case PICA_REG_INDEX(vs.swizzle_patterns.set_word[2]):
+    case PICA_REG_INDEX(vs.swizzle_patterns.set_word[3]):
+    case PICA_REG_INDEX(vs.swizzle_patterns.set_word[4]):
+    case PICA_REG_INDEX(vs.swizzle_patterns.set_word[5]):
+    case PICA_REG_INDEX(vs.swizzle_patterns.set_word[6]):
+    case PICA_REG_INDEX(vs.swizzle_patterns.set_word[7]): {
+        u32& offset = regs.internal.vs.swizzle_patterns.offset;
+        if (offset + count > vs_setup.GetSwizzleData().size()) {
+            LOG_ERROR(HW_GPU, "Invalid VS swizzle pattern offset {} count {}", offset, count);
+        } else {
+            vs_setup.UpdateSwizzleDataRange(offset, values, count);
+            if (!regs.internal.pipeline.gs_unit_exclusive_configuration &&
+                regs.internal.pipeline.use_gs == PipelineRegs::UseGS::No) {
+                gs_setup.UpdateSwizzleDataRange(offset, values, count);
+            }
+            offset += count;
+        }
+        break;
+    }
+    case PICA_REG_INDEX(lighting.lut_data[0]):
+    case PICA_REG_INDEX(lighting.lut_data[1]):
+    case PICA_REG_INDEX(lighting.lut_data[2]):
+    case PICA_REG_INDEX(lighting.lut_data[3]):
+    case PICA_REG_INDEX(lighting.lut_data[4]):
+    case PICA_REG_INDEX(lighting.lut_data[5]):
+    case PICA_REG_INDEX(lighting.lut_data[6]):
+    case PICA_REG_INDEX(lighting.lut_data[7]): {
+        auto& lut_config = regs.internal.lighting.lut_config;
+        ASSERT_MSG(lut_config.index + count <= 256,
+                   "lut_config.index exceeded maximum value of 255!");
 
+        for (u32 i = 0; i < count; i++) {
+            const u32 prev =
+                std::exchange(lighting.luts[lut_config.type][lut_config.index + i].raw, values[i]);
+            lighting.lut_dirty |= (prev != values[i]) << lut_config.type;
+        }
+        lut_config.index.Assign(lut_config.index + count);
+        break;
+    }
+    case PICA_REG_INDEX(texturing.fog_lut_data[0]):
+    case PICA_REG_INDEX(texturing.fog_lut_data[1]):
+    case PICA_REG_INDEX(texturing.fog_lut_data[2]):
+    case PICA_REG_INDEX(texturing.fog_lut_data[3]):
+    case PICA_REG_INDEX(texturing.fog_lut_data[4]):
+    case PICA_REG_INDEX(texturing.fog_lut_data[5]):
+    case PICA_REG_INDEX(texturing.fog_lut_data[6]):
+    case PICA_REG_INDEX(texturing.fog_lut_data[7]): {
+        for (u32 i = 0; i < count; i++) {
+            const u32 prev = std::exchange(
+                fog.lut[(regs.internal.texturing.fog_lut_offset + i) % 128].raw, values[i]);
+            fog.lut_dirty |= prev != values[i];
+        }
+        regs.internal.texturing.fog_lut_offset.Assign(regs.internal.texturing.fog_lut_offset +
+                                                      count);
+        break;
+    }
+    case PICA_REG_INDEX(texturing.proctex_lut_data[0]):
+    case PICA_REG_INDEX(texturing.proctex_lut_data[1]):
+    case PICA_REG_INDEX(texturing.proctex_lut_data[2]):
+    case PICA_REG_INDEX(texturing.proctex_lut_data[3]):
+    case PICA_REG_INDEX(texturing.proctex_lut_data[4]):
+    case PICA_REG_INDEX(texturing.proctex_lut_data[5]):
+    case PICA_REG_INDEX(texturing.proctex_lut_data[6]):
+    case PICA_REG_INDEX(texturing.proctex_lut_data[7]): {
+        auto& index = regs.internal.texturing.proctex_lut_config.index;
+        const auto lut_table = regs.internal.texturing.proctex_lut_config.ref_table.Value();
+
+        for (u32 i = 0; i < count; i++) {
+
+            const auto sync_lut = [&](auto& proctex_table) {
+                const u32 prev =
+                    std::exchange(proctex_table[(index + i) % proctex_table.size()].raw, values[i]);
+                proctex.table_dirty |= (prev != values[i]) << u32(lut_table);
+            };
+
+            switch (lut_table) {
+            case TexturingRegs::ProcTexLutTable::Noise:
+                sync_lut(proctex.noise_table);
+                break;
+            case TexturingRegs::ProcTexLutTable::ColorMap:
+                sync_lut(proctex.color_map_table);
+                break;
+            case TexturingRegs::ProcTexLutTable::AlphaMap:
+                sync_lut(proctex.alpha_map_table);
+                break;
+            case TexturingRegs::ProcTexLutTable::Color:
+                sync_lut(proctex.color_table);
+                break;
+            case TexturingRegs::ProcTexLutTable::ColorDiff:
+                sync_lut(proctex.color_diff_table);
+                break;
+            }
+        }
+        index.Assign(index + count);
+        break;
+    }
+    }
+}
+
+// Handle special registers. This function should also include the
+// registers that support batch processing can be submitted
+// individually.
+void PicaCore::HandleSpecialReg(u32 id, u32 value, bool& stop_requested) {
     switch (id) {
     // Trigger IRQ
     case PICA_REG_INDEX(irq_request):
@@ -448,10 +848,119 @@ void PicaCore::WriteInternalReg(u32 id, u32 value, u32 mask, bool& stop_requeste
     default:
         break;
     }
+}
+
+// Handle batch register writes
+void PicaCore::WriteInternalRegBatch(u32 id, const u32* values, u32 count, u32 mask,
+                                     bool& stop_requested) {
+    if (id >= RegsInternal::NUM_REGS) [[unlikely]] {
+        LOG_ERROR(HW_GPU,
+                  "Commandlist tried to write to invalid register 0x{:03X} repeated 0x{:04X} times"
+                  "(mask: {:X})",
+                  id, count, mask);
+        return;
+    }
+
+    delay_generator.AddCommands(count);
+    const u32 write_mask = ExpandBitsToBytes[mask];
+    // Only write the last value to the register array.
+    // Batch handlers should take this in mind.
+    regs.internal.reg_array[id] =
+        (regs.internal.reg_array[id] & ~write_mask) | (values[count - 1] & write_mask);
+    dirty_regs.Set(id);
+
+    if (reg_impl_flags_lut[id].SupportsBatch()) {
+        // If the register supports batch then call the handler.
+        HandleSpecialRegBatch(id, values, count);
+    } else if (reg_impl_flags_lut[id].NeedsSpecialHandling()) [[unlikely]] {
+        // Unlikely as all special regs that make sense to use batch mode already
+        // support batch handling.
+        for (u32 i = 0; i < count && !stop_requested; ++i) {
+            HandleSpecialReg(id, values[i], stop_requested);
+        }
+    }
+}
+
+// Handle sequential register writes.
+void PicaCore::WriteInternalRegSequential(u32 id, const u32* __restrict values, u32 count, u32 mask,
+                                          bool& stop_requested) {
+    if (id + count > RegsInternal::NUM_REGS) [[unlikely]] {
+        LOG_ERROR(
+            HW_GPU,
+            "Commandlist tried to write to invalid register range 0x{:03X}-0x{:03X} (mask: {:X})",
+            id, id + count, mask);
+        return;
+    }
+    const u32 write_mask = ExpandBitsToBytes[mask];
+    u32* __restrict dst = &regs.internal.reg_array[id];
+    u32 offset = 0;
+
+    // This code is structured so that it uses the LUT to get the distance from the
+    // register ID to the next special register. Then copies the range of normal registers
+    // until it reaches the special register which is handled individually, and so on.
+    while (offset < count) {
+        if (stop_requested) [[unlikely]] {
+            break;
+        }
+        const u32 reg = id + offset;
+        // Distance to the next special register, capped by how many writes
+        // are actually left in this write. If this register is special this is 0.
+        const u32 batch_count =
+            std::min<u32>(reg_impl_flags_lut[reg].RegsUntilSpecial(), count - offset);
+        if (batch_count > 0) {
+            delay_generator.AddCommands(batch_count);
+
+            // Allows the compiler to auto-vectorize thanks to the __restrict keywords.
+            // Verified in MSVC that vectorization is happening.
+            u32* __restrict batch_dst = dst + offset;
+            const u32* __restrict batch_src = values + offset;
+            for (u32 i = 0; i < batch_count; ++i) {
+                batch_dst[i] = (batch_dst[i] & ~write_mask) | (batch_src[i] & write_mask);
+            }
+
+            dirty_regs.SetRange(reg, batch_count);
+            offset += batch_count;
+        }
+        // Whatever register stopped the batch (if we didn't reach the end)
+        // needs individual handling, then resume batching after it.
+        if (offset < count) {
+            WriteInternalReg(id + offset, values[offset], mask, stop_requested);
+            ++offset;
+        }
+    }
+}
+
+// Handle individual command write.
+void PicaCore::WriteInternalReg(u32 id, u32 value, u32 mask, bool& stop_requested) {
+    if (id >= RegsInternal::NUM_REGS) [[unlikely]] {
+        LOG_ERROR(
+            HW_GPU,
+            "Commandlist tried to write to invalid register 0x{:03X} (value: {:08X}, mask: {:X})",
+            id, value, mask);
+        return;
+    }
+
+    delay_generator.AddCommands(1);
+
+    // TODO: Figure out how register masking acts on e.g. vs.uniform_setup.set_value
+    const u32 old_value = regs.internal.reg_array[id];
+    const u32 write_mask = ExpandBitsToBytes[mask];
+    regs.internal.reg_array[id] = (old_value & ~write_mask) | (value & write_mask);
+
+    if (debug_context) [[unlikely]] {
+        // Track register write.
+        DebugUtils::OnPicaRegWrite(id, mask, regs.internal.reg_array[id]);
+        // Track events.
+        debug_context->OnEvent(DebugContext::Event::PicaCommandLoaded, &id);
+    }
+
+    if (reg_impl_flags_lut[id].NeedsSpecialHandling()) {
+        HandleSpecialReg(id, value, stop_requested);
+    }
 
     dirty_regs.Set(id);
 
-    if (debug_context) {
+    if (debug_context) [[unlikely]] {
         debug_context->OnEvent(DebugContext::Event::PicaCommandProcessed, &id);
     }
 }

--- a/src/video_core/pica/pica_core.h
+++ b/src/video_core/pica/pica_core.h
@@ -123,6 +123,16 @@ public:
 private:
     void InitializeRegs();
 
+    void HandleSpecialRegBatch(u32 id, const u32* values, u32 count);
+
+    void HandleSpecialReg(u32 id, u32 value, bool& stop_requested);
+
+    void WriteInternalRegBatch(u32 id, const u32* values, u32 count, u32 mask,
+                               bool& stop_requested);
+
+    void WriteInternalRegSequential(u32 id, const u32* __restrict values, u32 count, u32 mask,
+                                    bool& stop_requested);
+
     void WriteInternalReg(u32 id, u32 value, u32 mask, bool& stop_requested);
 
     void SubmitImmediate(u32 data);

--- a/src/video_core/pica/shader_setup.cpp
+++ b/src/video_core/pica/shader_setup.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <limits>
 #include <utility>
 #include "common/assert.h"
 #include "common/bit_set.h"
@@ -9,6 +10,25 @@
 #include "common/logging/log.h"
 #include "video_core/pica/regs_shader.h"
 #include "video_core/pica/shader_setup.h"
+
+#if defined(CITRA_HAS_SSE42)
+#include <nmmintrin.h>
+#endif
+
+#if defined(__aarch64__) || defined(__ARM_NEON)
+#define CITRA_HAS_NEON
+#include <arm_neon.h>
+#endif
+
+#if defined(_MSC_VER)
+#define DISABLE_VECTORIZE __pragma(loop(no_vector))
+#elif defined(__clang__)
+#define DISABLE_VECTORIZE _Pragma("clang loop vectorize(disable)")
+#elif defined(__GNUC__) && (__GNUC__ >= 14)
+#define DISABLE_VECTORIZE _Pragma("GCC novector")
+#else
+#define DISABLE_VECTORIZE
+#endif
 
 namespace Pica {
 
@@ -50,6 +70,47 @@ std::optional<u32> ShaderSetup::WriteUniformFloatReg(ShaderRegs& config, u32 val
     return index;
 }
 
+std::optional<ShaderSetup::UniformWriteRange> ShaderSetup::WriteUniformFloatRegRange(
+    ShaderRegs& config, const u32* values, u32 count) {
+
+    if (count == 0) [[unlikely]] {
+        return std::nullopt;
+    }
+
+    auto& uniform_setup = config.uniform_setup;
+    const bool is_float32 = uniform_setup.IsFloat32();
+
+    std::optional<u32> first_index;
+    u32 written = 0;
+
+    for (u32 i = 0; i < count; ++i) {
+        if (!uniform_queue.Push(values[i], is_float32)) {
+            continue;
+        }
+
+        const auto uniform = uniform_queue.Get(is_float32);
+        if (uniform_setup.index >= uniforms.f.size()) [[unlikely]] {
+            LOG_ERROR(HW_GPU, "Invalid float uniform index {}", uniform_setup.index.Value());
+            break;
+        }
+
+        const u32 index = uniform_setup.index.Value();
+        const auto prev = std::exchange(uniforms.f[index], uniform);
+        uniforms_dirty |= prev != uniform;
+        uniform_setup.index.Assign(index + 1);
+
+        if (!first_index) {
+            first_index = index;
+        }
+        ++written;
+    }
+
+    if (written == 0) {
+        return std::nullopt;
+    }
+    return UniformWriteRange{*first_index, written};
+}
+
 u64 ShaderSetup::GetProgramCodeHash() {
     if (program_code_hash_dirty) {
         const auto& prog_code = GetProgramCode();
@@ -67,6 +128,182 @@ u64 ShaderSetup::GetSwizzleDataHash() {
         swizzle_data_hash_dirty = false;
     }
     return swizzle_data_hash;
+}
+
+// Returns the index of the highest most significant bit set.
+// 0001 -> 0, 0010 -> 1, 1000 -> 3...
+inline u32 HighestSetBitIndex(u32 mask) {
+#if defined(_MSC_VER)
+    unsigned long index;
+    _BitScanReverse(&index, mask);
+    return static_cast<u32>(index);
+#else
+    return 31u - static_cast<u32>(__builtin_clz(mask));
+#endif
+}
+
+// Process 32 bit words in groups of 4. If any of the words changed,
+// store the new value and return true, plus the index of the word
+// that changed.
+#if defined(CITRA_HAS_SSE42)
+static inline u32 ProcessBlockSSE42(u32* dst, const u32* values) {
+    // Load 4 old values into old_vals.
+    const __m128i old_vals = _mm_loadu_si128(reinterpret_cast<const __m128i*>(dst));
+    // Load 4 new values into new_vals.
+    const __m128i new_vals = _mm_loadu_si128(reinterpret_cast<const __m128i*>(values));
+    // Compare both, eq now holds 4 words where each word X is either
+    // 0xFFFFFFFF if words at X are equal or 0x0 if words at X differ.
+    const __m128i eq = _mm_cmpeq_epi32(old_vals, new_vals);
+
+    // If eq is all F, old_vals and new_vals are equal, return.
+    if (_mm_testc_si128(eq, _mm_set1_epi32(-1))) {
+        return std::numeric_limits<u32>::max();
+    }
+
+    // Store the new values to the destination.
+    _mm_storeu_si128(reinterpret_cast<__m128i*>(dst), new_vals);
+
+    // Reduce the four 0x0/0xFFFFFFFF words to 4 bits
+    // stored to the 4 LSB of eq_mask.
+    const u32 eq_mask = static_cast<u32>(_mm_movemask_ps(_mm_castsi128_ps(eq)));
+    // Negate the result to make 0 signify equality instead of 1.
+    const u32 neq_mask = (~eq_mask) & 0xFu;
+    // Return the index of the highest 1, which corresponds to the index of the
+    // last new word that differs (taking into account endianness).
+    return HighestSetBitIndex(neq_mask);
+}
+#endif
+
+#if defined(CITRA_HAS_NEON)
+static inline u32 ProcessBlockNEON(u32* dst, const u32* values) {
+    // Load 4 old values into old_vals.
+    const uint32x4_t old_vals = vld1q_u32(dst);
+    // Load 4 new values into new_vals.
+    const uint32x4_t new_vals = vld1q_u32(values);
+    // Compare both, neq now holds 4 words where each word X is either
+    // 0x0 if words at X are equal or 0xFFFFFFFF if words at X differ.
+    const uint32x4_t neq = vmvnq_u32(vceqq_u32(old_vals, new_vals));
+
+    // If neq is all 0, old_vals and new_vals are equal, return.
+    if (vmaxvq_u32(neq) == 0) {
+        return std::numeric_limits<u32>::max();
+    }
+
+    // Store the new values to the destination.
+    vst1q_u32(dst, new_vals);
+
+    // Extract the value to an array and check which
+    // entry is the first that differs. Corresponds to
+    // the index of the last new word that differs
+    // (taking into account endianness).
+    // This needs to be done manually due to missing
+    // _mm_movemask_ps equivalent on NEON.
+    u32 neq_arr[4];
+    vst1q_u32(neq_arr, neq);
+    for (int i = 3; i >= 0; --i) {
+        if (neq_arr[i] != 0) {
+            return static_cast<u32>(i);
+        }
+    }
+
+    // Should never happen as otherwise we would have
+    // returned earlier.
+    UNREACHABLE();
+}
+#endif
+
+void ShaderSetup::UpdateProgramCodeRange(size_t offset, const u32* __restrict values, u32 count) {
+    if (count == 0) [[unlikely]] {
+        return;
+    }
+
+    u32* __restrict dst = &program_code[offset];
+    bool any_changed = false;
+    size_t last_changed_offset = offset;
+    u32 i = 0;
+
+    // SIMD block.
+#if defined(CITRA_HAS_SSE42) || defined(CITRA_HAS_NEON)
+    for (; i + 4 <= count; i += 4) {
+#if defined(CITRA_HAS_SSE42)
+        u32 index = ProcessBlockSSE42(dst + i, values + i);
+#else
+        u32 index = ProcessBlockNEON(dst + i, values + i);
+#endif
+        if (index != std::numeric_limits<u32>::max()) {
+            any_changed = true;
+            last_changed_offset = offset + i + index;
+        }
+    }
+#endif
+
+    // Scalar remainder (and whole loop when SIMD is not available).
+    DISABLE_VECTORIZE
+    for (; i < count; ++i) {
+        u32& inst = dst[i];
+        const u32 value = values[i];
+        if (inst != value) {
+            inst = value;
+            any_changed = true;
+            last_changed_offset = offset + i;
+        }
+    }
+
+    if (any_changed) {
+        if (!program_code_hash_dirty) {
+            MakeProgramCodeDirty();
+        }
+        if ((last_changed_offset + 1) > biggest_program_size) {
+            biggest_program_size = last_changed_offset + 1;
+        }
+    }
+}
+
+void ShaderSetup::UpdateSwizzleDataRange(size_t offset, const u32* __restrict values, u32 count) {
+    if (count == 0) [[unlikely]] {
+        return;
+    }
+
+    u32* __restrict dst = &swizzle_data[offset];
+    bool any_changed = false;
+    size_t last_changed_offset = offset;
+    u32 i = 0;
+
+    // SIMD block.
+#if defined(CITRA_HAS_SSE42) || defined(CITRA_HAS_NEON)
+    for (; i + 4 <= count; i += 4) {
+#if defined(CITRA_HAS_SSE42)
+        u32 index = ProcessBlockSSE42(dst + i, values + i);
+#else
+        u32 index = ProcessBlockNEON(dst + i, values + i);
+#endif
+        if (index != std::numeric_limits<u32>::max()) {
+            any_changed = true;
+            last_changed_offset = offset + i + index;
+        }
+    }
+#endif
+
+    // Scalar remainder (and whole loop when SIMD is not available).
+    DISABLE_VECTORIZE
+    for (; i < count; ++i) {
+        u32& inst = dst[i];
+        const u32 value = values[i];
+        if (inst != value) {
+            inst = value;
+            any_changed = true;
+            last_changed_offset = offset + i;
+        }
+    }
+
+    if (any_changed) {
+        if (!swizzle_data_hash_dirty) {
+            MakeSwizzleDataDirty();
+        }
+        if ((last_changed_offset + 1) > biggest_swizzle_size) {
+            biggest_swizzle_size = last_changed_offset + 1;
+        }
+    }
 }
 
 void ShaderSetup::DoProgramCodeFixup() {

--- a/src/video_core/pica/shader_setup.cpp
+++ b/src/video_core/pica/shader_setup.cpp
@@ -155,22 +155,25 @@ static inline u32 ProcessBlockSSE42(u32* dst, const u32* values) {
     // 0xFFFFFFFF if words at X are equal or 0x0 if words at X differ.
     const __m128i eq = _mm_cmpeq_epi32(old_vals, new_vals);
 
-    // If eq is all F, old_vals and new_vals are equal, return.
-    if (_mm_testc_si128(eq, _mm_set1_epi32(-1))) {
+    // Load all 0xF values
+    const __m128i ones = _mm_set1_epi32(-1);
+
+    // If eq is all 0xF, old_vals and new_vals are equal, return.
+    if (_mm_testc_si128(eq, ones)) {
         return std::numeric_limits<u32>::max();
     }
 
     // Store the new values to the destination.
     _mm_storeu_si128(reinterpret_cast<__m128i*>(dst), new_vals);
 
-    // Reduce the four 0x0/0xFFFFFFFF words to 4 bits
-    // stored to the 4 LSB of eq_mask.
-    const u32 eq_mask = static_cast<u32>(_mm_movemask_ps(_mm_castsi128_ps(eq)));
-    // Negate the result to make 0 signify equality instead of 1.
-    const u32 neq_mask = (~eq_mask) & 0xFu;
+    // First negate the result to make 0 signify equality instead of 1
+    // (using a XOR of all F).
+    // Then reduce the four 0x0/0xFFFFFFFF words to 4 bits
+    // stored to the 4 LSB of res.
+    const u32 res = static_cast<u32>(_mm_movemask_ps(_mm_castsi128_ps(_mm_xor_si128(eq, ones))));
     // Return the index of the highest 1, which corresponds to the index of the
     // last new word that differs (taking into account endianness).
-    return HighestSetBitIndex(neq_mask);
+    return HighestSetBitIndex(res);
 }
 #endif
 
@@ -192,23 +195,14 @@ static inline u32 ProcessBlockNEON(u32* dst, const u32* values) {
     // Store the new values to the destination.
     vst1q_u32(dst, new_vals);
 
-    // Extract the value to an array and check which
-    // entry is the first that differs. Corresponds to
-    // the index of the last new word that differs
-    // (taking into account endianness).
-    // This needs to be done manually due to missing
-    // _mm_movemask_ps equivalent on NEON.
-    u32 neq_arr[4];
-    vst1q_u32(neq_arr, neq);
-    for (int i = 3; i >= 0; --i) {
-        if (neq_arr[i] != 0) {
-            return static_cast<u32>(i);
-        }
-    }
-
-    // Should never happen as otherwise we would have
-    // returned earlier.
-    UNREACHABLE();
+    // Extract the index of the highest value that was different.
+    // This is achieved by ANDing the neq array with (0,1,2,3).
+    // If word is equal, 0 is produced, otherwise the index
+    // is produced. Then the max index is selected from the
+    // result.
+    static constexpr u32 index_arr[4] = {0, 1, 2, 3};
+    const uint32x4_t indices = vld1q_u32(index_arr);
+    return vmaxvq_u32(vandq_u32(neq, indices));
 }
 #endif
 

--- a/src/video_core/pica/shader_setup.h
+++ b/src/video_core/pica/shader_setup.h
@@ -72,6 +72,13 @@ public:
 
     std::optional<u32> WriteUniformFloatReg(ShaderRegs& config, u32 value);
 
+    struct UniformWriteRange {
+        u32 first_index;
+        u32 count;
+    };
+    std::optional<UniformWriteRange> WriteUniformFloatRegRange(ShaderRegs& config,
+                                                               const u32* values, u32 count);
+
     u64 GetProgramCodeHash();
 
     u64 GetSwizzleDataHash();
@@ -94,6 +101,8 @@ public:
         }
     }
 
+    void UpdateProgramCodeRange(size_t offset, const u32* __restrict values, u32 count);
+
     void UpdateProgramCode(const ProgramCode& other, u32 other_size = MAX_PROGRAM_CODE_LENGTH) {
         program_code = other;
         biggest_program_size = std::max(biggest_program_size, other_size);
@@ -115,6 +124,8 @@ public:
             biggest_swizzle_size = offset + 1;
         }
     }
+
+    void UpdateSwizzleDataRange(size_t offset, const u32* __restrict values, u32 count);
 
     void UpdateSwizzleData(const SwizzleData& other, u32 other_size = MAX_SWIZZLE_DATA_LENGTH) {
         swizzle_data = other;

--- a/src/video_core/rasterizer_accelerated.cpp
+++ b/src/video_core/rasterizer_accelerated.cpp
@@ -90,7 +90,7 @@ void RasterizerAccelerated::AddTriangle(const Pica::OutputVertex& v0, const Pica
 }
 
 RasterizerAccelerated::VertexArrayInfo RasterizerAccelerated::AnalyzeVertexArray(
-    bool is_indexed, u32 stride_alignment) {
+    bool is_indexed, u32 stride_alignment) [[hot]] {
     const auto& vertex_attributes = regs.pipeline.vertex_attributes;
 
     u32 vertex_min;


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.

All optimization ideas are mine, including the LUT and the batch processing, determined by manually profiling the application. AI assisted code is limited to the `ProcessBlockSSE42` and `ProcessBlockNEON` functions, where AI suggested the algorithm to use and provided the SIMD intrinsics. I have researched them using the relevant documentation and commented them so they are easier to follow and maintain.

AI was used to find a bug in `WriteInternalRegSequential` which was being troublesome, a bit of the code in that function may be inspired by the response, but is fully written by me.

---------

Improves the GPU command list processing to use a LUT, batch processing and vectorization techniques. This saves 0.5-1.0ms per frame for command list processing (which may benefit systems that are bottlenecked by the CPU). 
