### PR TITLE
Implement early depth test registers for PICA200 GPU

### DIFF
--- a/src/video_core/pica/regs_internal.h
+++ b/src/video_core/pica/regs_internal.h
@@ -65,8 +65,12 @@ ASSERT_REG_POSITION(rasterizer.viewport_depth_range, 0x4d);
 ASSERT_REG_POSITION(rasterizer.viewport_depth_near_plane, 0x4e);
 ASSERT_REG_POSITION(rasterizer.vs_output_attributes[0], 0x50);
 ASSERT_REG_POSITION(rasterizer.vs_output_attributes[1], 0x51);
+ASSERT_REG_POSITION(rasterizer.early_depth_func, 0x61);
+ASSERT_REG_POSITION(rasterizer.early_depth_test_enable, 0x62);
+ASSERT_REG_POSITION(rasterizer.early_depth_clear, 0x63);
 ASSERT_REG_POSITION(rasterizer.scissor_test, 0x65);
 ASSERT_REG_POSITION(rasterizer.viewport_corner, 0x68);
+ASSERT_REG_POSITION(rasterizer.early_depth_data, 0x6A);
 ASSERT_REG_POSITION(rasterizer.depthmap_enable, 0x6D);
 
 ASSERT_REG_POSITION(texturing, 0x80);

--- a/src/video_core/pica/regs_rasterizer.h
+++ b/src/video_core/pica/regs_rasterizer.h
@@ -10,6 +10,7 @@
 #include "common/common_funcs.h"
 #include "common/math_util.h"
 #include "common/vector_math.h"
+#include "video_core/pica/regs_framebuffer.h"
 #include "video_core/pica_types.h"
 
 namespace Pica {
@@ -118,7 +119,13 @@ struct RasterizerRegs {
         }
     }
 
-    INSERT_PADDING_WORDS(0xe);
+    INSERT_PADDING_WORDS(0xa);
+
+    BitField<0, 3, FramebufferRegs::CompareFunc> early_depth_func;
+    BitField<0, 1, u32> early_depth_test_enable;
+    BitField<0, 1, u32> early_depth_clear;
+
+    INSERT_PADDING_WORDS(0x1);
 
     enum class ScissorMode : u32 {
         Disabled = 0,
@@ -148,8 +155,7 @@ struct RasterizerRegs {
 
     INSERT_PADDING_WORDS(0x1);
 
-    // TODO: early depth
-    INSERT_PADDING_WORDS(0x1);
+    BitField<0, 1, u32> early_depth_data;
 
     INSERT_PADDING_WORDS(0x2);
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -345,12 +345,19 @@ void RasterizerOpenGL::SyncDrawState() {
     state.stencil.action_depth_pass =
         PicaToGL::StencilOp(regs.framebuffer.output_merger.stencil_test.action_depth_pass);
     // SyncDepthTest();
-    state.depth.test_enabled = regs.framebuffer.output_merger.depth_test_enable == 1 ||
-                               regs.framebuffer.output_merger.depth_write_enable == 1;
-    state.depth.test_func =
-        regs.framebuffer.output_merger.depth_test_enable == 1
-            ? PicaToGL::CompareFunc(regs.framebuffer.output_merger.depth_test_func)
-            : GL_ALWAYS;
+    const bool early_test = regs.rasterizer.early_depth_test_enable == 1;
+    const bool late_test = regs.framebuffer.output_merger.depth_test_enable == 1;
+    const bool depth_write = regs.framebuffer.output_merger.depth_write_enable == 1;
+    state.depth.test_enabled = early_test || late_test || depth_write;
+    if (late_test) {
+        state.depth.test_func =
+            PicaToGL::CompareFunc(regs.framebuffer.output_merger.depth_test_func);
+    } else if (early_test) {
+        state.depth.test_func =
+            PicaToGL::CompareFunc(regs.rasterizer.early_depth_func);
+    } else {
+        state.depth.test_func = GL_ALWAYS;
+    }
     // SyncStencilWriteMask();
     state.stencil.write_mask =
         (regs.framebuffer.framebuffer.allow_depth_stencil_write != 0)
@@ -572,6 +579,7 @@ bool RasterizerOpenGL::Draw(bool accelerate, bool is_indexed) {
     const bool using_depth_fb =
         !shadow_rendering && regs.framebuffer.framebuffer.GetDepthBufferPhysicalAddress() != 0 &&
         (write_depth_fb || regs.framebuffer.output_merger.depth_test_enable != 0 ||
+         regs.rasterizer.early_depth_test_enable != 0 ||
          (has_stencil && state.stencil.test_enabled));
 
     const auto fb_helper = res_cache.GetFramebufferSurfaces(using_color_fb, using_depth_fb);

--- a/src/video_core/renderer_software/sw_rasterizer.cpp
+++ b/src/video_core/renderer_software/sw_rasterizer.cpp
@@ -354,6 +354,45 @@ void RasterizerSoftware::ProcessTriangle(const Vertex& v0, const Vertex& v1, con
                 // Clamp the result
                 depth = std::clamp(depth, 0.0f, 1.0f);
 
+                // Early depth test - discard fragment before shader execution
+                if (regs.rasterizer.early_depth_test_enable) {
+                    const u32 num_bits_early =
+                        FramebufferRegs::DepthBitsPerPixel(framebuffer.depth_format);
+                    const u32 z_early =
+                        static_cast<u32>(depth * ((1 << num_bits_early) - 1));
+                    const u32 ref_z_early = fb.GetDepth(x >> 4, y >> 4);
+                    bool pass_early = false;
+                    switch (regs.rasterizer.early_depth_func) {
+                    case FramebufferRegs::CompareFunc::Never:
+                        pass_early = false;
+                        break;
+                    case FramebufferRegs::CompareFunc::Always:
+                        pass_early = true;
+                        break;
+                    case FramebufferRegs::CompareFunc::Equal:
+                        pass_early = z_early == ref_z_early;
+                        break;
+                    case FramebufferRegs::CompareFunc::NotEqual:
+                        pass_early = z_early != ref_z_early;
+                        break;
+                    case FramebufferRegs::CompareFunc::LessThan:
+                        pass_early = z_early < ref_z_early;
+                        break;
+                    case FramebufferRegs::CompareFunc::LessThanOrEqual:
+                        pass_early = z_early <= ref_z_early;
+                        break;
+                    case FramebufferRegs::CompareFunc::GreaterThan:
+                        pass_early = z_early > ref_z_early;
+                        break;
+                    case FramebufferRegs::CompareFunc::GreaterThanOrEqual:
+                        pass_early = z_early >= ref_z_early;
+                        break;
+                    }
+                    if (!pass_early) {
+                        continue;
+                    }
+                }
+
                 /**
                  * Perspective correct attribute interpolation:
                  * Attribute values cannot be calculated by simple linear interpolation since

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -218,11 +218,14 @@ void RasterizerVulkan::SyncDrawState() {
             ? static_cast<u32>(regs.framebuffer.output_merger.stencil_test.write_mask)
             : 0;
     // SyncDepthTest();
-    const bool test_enabled = regs.framebuffer.output_merger.depth_test_enable == 1 ||
-                              regs.framebuffer.output_merger.depth_write_enable == 1;
-    const auto compare_op = regs.framebuffer.output_merger.depth_test_enable == 1
+    const bool early_test = regs.rasterizer.early_depth_test_enable == 1;
+    const bool late_test = regs.framebuffer.output_merger.depth_test_enable == 1;
+    const bool depth_write = regs.framebuffer.output_merger.depth_write_enable == 1;
+    const bool test_enabled = early_test || late_test || depth_write;
+    const auto compare_op = late_test
                                 ? regs.framebuffer.output_merger.depth_test_func.Value()
-                                : Pica::FramebufferRegs::CompareFunc::Always;
+                                : early_test ? regs.rasterizer.early_depth_func.Value()
+                                             : Pica::FramebufferRegs::CompareFunc::Always;
 
     pipeline_info.state.depth_stencil.depth_test_enable.Assign(test_enabled);
     pipeline_info.state.depth_stencil.depth_compare_op.Assign(compare_op);
@@ -552,6 +555,7 @@ bool RasterizerVulkan::Draw(bool accelerate, bool is_indexed) {
     const bool using_depth_fb =
         !shadow_rendering && regs.framebuffer.framebuffer.GetDepthBufferPhysicalAddress() != 0 &&
         (write_depth_fb || regs.framebuffer.output_merger.depth_test_enable != 0 ||
+         regs.rasterizer.early_depth_test_enable != 0 ||
          (has_stencil && pipeline_info.state.depth_stencil.stencil_test_enable));
 
     const auto fb_helper = res_cache.GetFramebufferSurfaces(using_color_fb, using_depth_fb);

--- a/src/video_core/shader/generator/pica_fs_config.cpp
+++ b/src/video_core/shader/generator/pica_fs_config.cpp
@@ -11,6 +11,7 @@ FramebufferConfig::FramebufferConfig(const Pica::RegsInternal& regs) {
     scissor_test_mode.Assign(regs.rasterizer.scissor_test.mode);
     depthmap_enable.Assign(regs.rasterizer.depthmap_enable);
     shadow_rendering.Assign(regs.framebuffer.IsShadowRendering());
+    early_depth_test_enable.Assign(regs.rasterizer.early_depth_test_enable);
     alpha_test_func.Assign(output_merger.alpha_test.enable
                                ? output_merger.alpha_test.func.Value()
                                : Pica::FramebufferRegs::CompareFunc::Always);

--- a/src/video_core/shader/generator/pica_fs_config.h
+++ b/src/video_core/shader/generator/pica_fs_config.h
@@ -68,6 +68,7 @@ struct FramebufferConfig {
         BitField<6, 4, Pica::FramebufferRegs::LogicOp> logic_op;
         BitField<10, 1, u32> shadow_rendering;
         BitField<11, 1, u32> alphablend_enable;
+        BitField<12, 1, u32> early_depth_test_enable;
     };
     BlendConfig requested_rgb_blend{};
     BlendConfig requested_alpha_blend{};
@@ -77,7 +78,7 @@ struct FramebufferConfig {
     void ApplyProfile(const Profile& profile);
 
     static consteval u64 StructHash() {
-        constexpr u64 STRUCT_VERSION = 0;
+        constexpr u64 STRUCT_VERSION = 1;
 
         using T = FramebufferConfig;
         return Common::HashCombine(
@@ -89,6 +90,7 @@ struct FramebufferConfig {
             // fields
             FIELD_HASH(alpha_test_func), FIELD_HASH(scissor_test_mode), FIELD_HASH(depthmap_enable),
             FIELD_HASH(logic_op), FIELD_HASH(shadow_rendering), FIELD_HASH(alphablend_enable),
+            FIELD_HASH(early_depth_test_enable),
             FIELD_HASH(requested_rgb_blend), FIELD_HASH(requested_alpha_blend),
             FIELD_HASH(requested_logic_op),
 


### PR DESCRIPTION
Add support for the previously unimplemented early depth testing
registers on the PICA200 GPU:

- GPUREG_EARLYDEPTH_FUNC (0x061): comparison function
- GPUREG_EARLYDEPTH_TEST1 (0x062): test enable
- GPUREG_EARLYDEPTH_CLEAR (0x063): clear control
- GPUREG_EARLYDEPTH_DATA (0x06A): data register

The registers were previously mapped to padding and silently
ignored. Now they are properly defined and wired into all three
renderers (OpenGL, Vulkan, Software) to control depth testing
before fragment shader execution.

Related to #2316 