### PR TITLE
Add "Pixel by Pixel"-scaling-mode

### DIFF
--- a/CMakeModules/GenerateSettingKeys.cmake
+++ b/CMakeModules/GenerateSettingKeys.cmake
@@ -121,7 +121,7 @@ foreach(KEY IN ITEMS
     "log_regex_filter"
     "toggle_unique_data_console_type"
     "break_on_unmapped_memory_access"
-    "use_integer_scaling"
+    "scaling_mode"
     "layouts_to_cycle"
     "camera_inner_flip"
     "camera_outer_left_flip"

--- a/CMakeModules/GenerateSettingKeys.cmake
+++ b/CMakeModules/GenerateSettingKeys.cmake
@@ -121,7 +121,7 @@ foreach(KEY IN ITEMS
     "log_regex_filter"
     "toggle_unique_data_console_type"
     "enable_exception_handler"
-    "use_integer_scaling"
+    "scaling_mode"
     "layouts_to_cycle"
     "camera_inner_flip"
     "camera_outer_left_flip"

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/SettingKeys.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/SettingKeys.kt
@@ -109,7 +109,7 @@ object SettingKeys {
     external fun toggle_unique_data_console_type(): String
     external fun log_filter(): String
     external fun log_regex_filter(): String
-    external fun use_integer_scaling(): String
+    external fun scaling_mode(): String
     external fun layouts_to_cycle(): String
     external fun camera_inner_flip(): String
     external fun camera_outer_left_flip(): String

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
@@ -123,7 +123,6 @@ enum class BooleanSetting(
     ASYNC_FS_OPERATIONS(SettingKeys.async_fs_operations(), Settings.SECTION_STORAGE, true),
     ANDROID_HIDE_IMAGES(SettingKeys.android_hide_images(), Settings.SECTION_MISC, false),
     APPLY_REGION_FREE_PATCH(SettingKeys.apply_region_free_patch(), Settings.SECTION_SYSTEM, true),
-    USE_INTEGER_SCALING(SettingKeys.use_integer_scaling(), Settings.SECTION_RENDERER, false),
     ENABLE_SECONDARY_DISPLAY(SettingKeys.enable_secondary_display(), Settings.SECTION_LAYOUT, true),
     SIMULATE_3DS_GPU_TIMINGS(
         SettingKeys.simulate_3ds_gpu_timings(),

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
@@ -65,7 +65,8 @@ enum class IntSetting(
     ),
     RENDER_3D_WHICH_DISPLAY(SettingKeys.render_3d_which_display(), Settings.SECTION_RENDERER, 0),
     ASPECT_RATIO(SettingKeys.aspect_ratio(), Settings.SECTION_LAYOUT, 0),
-    UPDATE_CHECK_CHANNEL(SettingKeys.update_check_channel(), Settings.SECTION_MISC, 0);
+    UPDATE_CHECK_CHANNEL(SettingKeys.update_check_channel(), Settings.SECTION_MISC, 0),
+    SCALING_MODE(SettingKeys.scaling_mode(), Settings.SECTION_RENDERER, 0);
 
     override var int: Int = defaultValue
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -997,12 +997,14 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                 )
             )
             add(
-                SwitchSetting(
-                    BooleanSetting.USE_INTEGER_SCALING,
-                    R.string.use_integer_scaling,
-                    R.string.use_integer_scaling_description,
-                    BooleanSetting.USE_INTEGER_SCALING.key,
-                    BooleanSetting.USE_INTEGER_SCALING.defaultValue
+                SingleChoiceSetting(
+                    IntSetting.SCALING_MODE,
+                    R.string.scaling_mode_name,
+                    R.string.scaling_mode_description,
+                    R.array.scalingModeNames,
+                    R.array.scalingModeValues,
+                    IntSetting.SCALING_MODE.key,
+                    IntSetting.SCALING_MODE.defaultValue
                 )
             )
             add(

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -172,7 +172,7 @@ void Config::ReadValues() {
     Settings::values.pp_shader_name =
         android_config->GetString("Renderer", "pp_shader_name", default_shader);
     ReadSetting("Renderer", Settings::values.filter_mode);
-    ReadSetting("Renderer", Settings::values.use_integer_scaling);
+    ReadSetting("Renderer", Settings::values.scaling_mode);
 
     ReadSetting("Renderer", Settings::values.bg_red);
     ReadSetting("Renderer", Settings::values.bg_green);

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -147,6 +147,7 @@ static const char* android_config_default_file_content = (BOOST_HANA_STRING(R"(
 # Which scaling mode should be used
 # 0 (default): Fit to Screen
 # 1: Fit to Screen with Integer Scaling
+# 2: Pixel by Pixel
 )") DECLARE_KEY(scaling_mode) BOOST_HANA_STRING(R"(
 
 # Turns on the frame limiter, which will limit frames output to the target game speed

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -144,9 +144,10 @@ static const char* android_config_default_file_content = (BOOST_HANA_STRING(R"(
 # factor for the 3DS resolution
 )") DECLARE_KEY(resolution_factor) BOOST_HANA_STRING(R"(
 
-# Use Integer Scaling when the layout allows
-# 0: Off (default), 1: On
-)") DECLARE_KEY(use_integer_scaling) BOOST_HANA_STRING(R"(
+# Which scaling mode should be used
+# 0 (default): Fit to Screen
+# 1: Fit to Screen with Integer Scaling
+)") DECLARE_KEY(scaling_mode) BOOST_HANA_STRING(R"(
 
 # Turns on the frame limiter, which will limit frames output to the target game speed
 # 0: Off, 1: On (default)

--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -451,6 +451,15 @@
         <item>18</item>
     </integer-array>
 
+    <string-array name="scalingModeNames">
+        <item>@string/fit_to_screen</item>
+        <item>@string/fit_to_screen_integer</item>
+    </string-array>
+    <integer-array name="scalingModeValues">
+        <item>0</item>
+        <item>1</item>
+    </integer-array>
+
     <string-array name="countries">
         <item></item>
         <item>@string/japan</item>

--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -454,10 +454,12 @@
     <string-array name="scalingModeNames">
         <item>@string/fit_to_screen</item>
         <item>@string/fit_to_screen_integer</item>
+        <item>@string/pixel_by_pixel</item>
     </string-array>
     <integer-array name="scalingModeValues">
         <item>0</item>
         <item>1</item>
+        <item>2</item>
     </integer-array>
 
     <string-array name="countries">

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -272,8 +272,8 @@
     <string name="async_shaders_description">Compiles shaders in the background to reduce stuttering during gameplay. When enabled expect temporary graphical glitches</string>
     <string name="linear_filtering">Linear Filtering</string>
     <string name="linear_filtering_description">Enables linear filtering, which causes game visuals to appear smoother.</string>
-    <string name="use_integer_scaling">Integer Scaling</string>
-    <string name="use_integer_scaling_description">Scales the screens with an integer multiplier of the original 3DS screen. For layouts with two different screen sizes, the largest screen is integer-scaled.</string>
+    <string name="scaling_mode_name">Scaling Mode</string>
+    <string name="scaling_mode_description">How to scale the screens of the emulated 3DS to the screen those are displayed on.</string>
     <string name="texture_filter_name">Texture Filter</string>
     <string name="texture_filter_description">Enhances the visuals of applications by applying a filter to textures. The supported filters are Anime4K Ultrafast, Bicubic, ScaleForce, xBRZ freescale, and MMPX.</string>
     <string name="delay_render_thread">Delay Game Render Thread</string>
@@ -320,6 +320,8 @@
     <string name="internal_resolution_setting_16x">16x Native (6400x3840)</string>
     <string name="internal_resolution_setting_17x">17x Native (6800x4080)</string>
     <string name="internal_resolution_setting_18x">18x Native (7200x4320)</string>
+    <string name="fit_to_screen">Fit to Screen</string>
+    <string name="fit_to_screen_integer">Fit to Screen with Integer Scaling</string>
     <string name="performance_warning">Turning off this setting will significantly reduce emulation performance! For the best experience, it is recommended that you leave this setting enabled.</string>
     <string name="debug_warning">Warning: Modifying these settings will slow emulation</string>
     <string name="stereoscopy">Stereoscopy</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -322,6 +322,7 @@
     <string name="internal_resolution_setting_18x">18x Native (7200x4320)</string>
     <string name="fit_to_screen">Fit to Screen</string>
     <string name="fit_to_screen_integer">Fit to Screen with Integer Scaling</string>
+    <string name="pixel_by_pixel">Pixel by Pixel</string>
     <string name="performance_warning">Turning off this setting will significantly reduce emulation performance! For the best experience, it is recommended that you leave this setting enabled.</string>
     <string name="debug_warning">Warning: Modifying these settings will slow emulation</string>
     <string name="stereoscopy">Stereoscopy</string>

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -721,7 +721,7 @@ void QtConfig::ReadRendererValues() {
     ReadGlobalSetting(Settings::values.use_skip_duplicate_frames);
     ReadGlobalSetting(Settings::values.use_display_refresh_rate_detection);
     ReadGlobalSetting(Settings::values.resolution_factor);
-    ReadGlobalSetting(Settings::values.use_integer_scaling);
+    ReadGlobalSetting(Settings::values.scaling_mode);
     ReadGlobalSetting(Settings::values.frame_limit);
     ReadGlobalSetting(Settings::values.turbo_limit);
 
@@ -1273,7 +1273,7 @@ void QtConfig::SaveRendererValues() {
     WriteGlobalSetting(Settings::values.use_skip_duplicate_frames);
     WriteGlobalSetting(Settings::values.use_display_refresh_rate_detection);
     WriteGlobalSetting(Settings::values.resolution_factor);
-    WriteGlobalSetting(Settings::values.use_integer_scaling);
+    WriteGlobalSetting(Settings::values.scaling_mode);
     WriteGlobalSetting(Settings::values.frame_limit);
     WriteGlobalSetting(Settings::values.turbo_limit);
 

--- a/src/citra_qt/configuration/configure_enhancements.cpp
+++ b/src/citra_qt/configuration/configure_enhancements.cpp
@@ -44,6 +44,8 @@ void ConfigureEnhancements::SetConfiguration() {
     if (!Settings::IsConfiguringGlobal()) {
         ConfigurationShared::SetPerGameSetting(ui->resolution_factor_combobox,
                                                &Settings::values.resolution_factor);
+        ConfigurationShared::SetPerGameSetting(ui->scaling_mode_combobox,
+                                               &Settings::values.scaling_mode);
         ConfigurationShared::SetPerGameSetting(ui->texture_filter_combobox,
                                                &Settings::values.texture_filter);
         ConfigurationShared::SetHighlight(ui->widget_texture_filter,
@@ -51,6 +53,8 @@ void ConfigureEnhancements::SetConfiguration() {
     } else {
         ui->resolution_factor_combobox->setCurrentIndex(
             Settings::values.resolution_factor.GetValue());
+        ui->scaling_mode_combobox->setCurrentIndex(
+            static_cast<int>(Settings::values.scaling_mode.GetValue()));
         ui->texture_filter_combobox->setCurrentIndex(
             static_cast<int>(Settings::values.texture_filter.GetValue()));
     }
@@ -63,7 +67,6 @@ void ConfigureEnhancements::SetConfiguration() {
         static_cast<int>(Settings::values.mono_render_option.GetValue()));
     updateShaders(Settings::values.render_3d.GetValue());
     ui->toggle_linear_filter->setChecked(Settings::values.filter_mode.GetValue());
-    ui->use_integer_scaling->setChecked(Settings::values.use_integer_scaling.GetValue());
     ui->toggle_dump_textures->setChecked(Settings::values.dump_textures.GetValue());
     ui->toggle_custom_textures->setChecked(Settings::values.custom_textures.GetValue());
     ui->toggle_preload_textures->setChecked(Settings::values.preload_textures.GetValue());
@@ -128,8 +131,8 @@ void ConfigureEnhancements::ApplyConfiguration() {
 
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.filter_mode,
                                              ui->toggle_linear_filter, linear_filter);
-    ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_integer_scaling,
-                                             ui->use_integer_scaling, use_integer_scaling);
+    ConfigurationShared::ApplyPerGameSetting(&Settings::values.scaling_mode,
+                                             ui->scaling_mode_combobox);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.texture_filter,
                                              ui->texture_filter_combobox);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.dump_textures,
@@ -149,9 +152,9 @@ void ConfigureEnhancements::SetupPerGameUI() {
     // Block the global settings if a game is currently running that overrides them
     if (Settings::IsConfiguringGlobal()) {
         ui->widget_resolution->setEnabled(Settings::values.resolution_factor.UsingGlobal());
+        ui->widget_scaling_mode->setEnabled(Settings::values.scaling_mode.UsingGlobal());
         ui->widget_texture_filter->setEnabled(Settings::values.texture_filter.UsingGlobal());
         ui->toggle_linear_filter->setEnabled(Settings::values.filter_mode.UsingGlobal());
-        ui->use_integer_scaling->setEnabled(Settings::values.use_integer_scaling.UsingGlobal());
         ui->toggle_dump_textures->setEnabled(Settings::values.dump_textures.UsingGlobal());
         ui->toggle_custom_textures->setEnabled(Settings::values.custom_textures.UsingGlobal());
         ui->toggle_preload_textures->setEnabled(Settings::values.preload_textures.UsingGlobal());
@@ -170,8 +173,6 @@ void ConfigureEnhancements::SetupPerGameUI() {
 
     ConfigurationShared::SetColoredTristate(ui->toggle_linear_filter, Settings::values.filter_mode,
                                             linear_filter);
-    ConfigurationShared::SetColoredTristate(
-        ui->use_integer_scaling, Settings::values.use_integer_scaling, use_integer_scaling);
     ConfigurationShared::SetColoredTristate(ui->toggle_dump_textures,
                                             Settings::values.dump_textures, dump_textures);
     ConfigurationShared::SetColoredTristate(ui->toggle_custom_textures,
@@ -188,6 +189,9 @@ void ConfigureEnhancements::SetupPerGameUI() {
     ConfigurationShared::SetColoredComboBox(
         ui->resolution_factor_combobox, ui->widget_resolution,
         static_cast<int>(Settings::values.resolution_factor.GetValue(true)));
+    ConfigurationShared::SetColoredComboBox(
+        ui->scaling_mode_combobox, ui->widget_scaling_mode,
+        static_cast<int>(Settings::values.scaling_mode.GetValue(true)));
 
     ConfigurationShared::SetColoredComboBox(
         ui->texture_filter_combobox, ui->widget_texture_filter,

--- a/src/citra_qt/configuration/configure_enhancements.h
+++ b/src/citra_qt/configuration/configure_enhancements.h
@@ -39,7 +39,7 @@ private:
 
     std::unique_ptr<Ui::ConfigureEnhancements> ui;
     ConfigurationShared::CheckState linear_filter;
-    ConfigurationShared::CheckState use_integer_scaling;
+    ConfigurationShared::CheckState scaling_mode;
     ConfigurationShared::CheckState dump_textures;
     ConfigurationShared::CheckState custom_textures;
     ConfigurationShared::CheckState preload_textures;

--- a/src/citra_qt/configuration/configure_enhancements.ui
+++ b/src/citra_qt/configuration/configure_enhancements.ui
@@ -176,7 +176,8 @@
               &lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Scaling mode&lt;/p&gt;&lt;p&gt;
               How to scale the screens of the emulated 3DS to the screen those are displayed on.&lt;/p&gt;&lt;p&gt;
               Fit to Screen: Scales the screens until those reach the borders of the window/screen.&lt;/p&gt;&lt;p&gt;
-              Fit to Screen with Integer Scaling: Scales the screens with an integer multiplier of the original 3DS screen to the largest fitting size. For layouts with two different screen sizes, the largest screen is integer-scaled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+              Fit to Screen with Integer Scaling: Scales the screens with an integer multiplier of the original 3DS screen to the largest fitting size. For layouts with two different screen sizes, the largest screen is integer-scaled.&lt;/p&gt;&lt;p&gt;
+              Pixel by Pixel: Displays each pixel from the game/app on one pixel of the screen. If the game-views do not fit within the window/screen, the width and height of those will be halved until those do fit; which, when combined with linear filtering, applies 4x supersampling.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
             </string>
            </property>
            <item>
@@ -187,6 +188,11 @@
            <item>
             <property name="text">
              <string>Fit to Screen with Integer Scaling</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Pixel by Pixel</string>
             </property>
            </item>
           </widget>

--- a/src/citra_qt/configuration/configure_enhancements.ui
+++ b/src/citra_qt/configuration/configure_enhancements.ui
@@ -148,13 +148,50 @@
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="use_integer_scaling">
-        <property name="text">
-         <string>Use Integer Scaling</string>
-        </property>
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use Integer Scaling&lt;/p&gt;&lt;p&gt;Enforces that the larger screen in all layouts is an integer scale of the 240px height of the original 3DS screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
+       <widget class="QWidget" name="widget_scaling_mode" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="scaling_mode_label">
+           <property name="text">
+            <string>Scaling Mode</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="scaling_mode_combobox">
+           <property name="toolTip">
+            <string>
+              &lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Scaling mode&lt;/p&gt;&lt;p&gt;
+              How to scale the screens of the emulated 3DS to the screen those are displayed on.&lt;/p&gt;&lt;p&gt;
+              Fit to Screen: Scales the screens until those reach the borders of the window/screen.&lt;/p&gt;&lt;p&gt;
+              Fit to Screen with Integer Scaling: Scales the screens with an integer multiplier of the original 3DS screen to the largest fitting size. For layouts with two different screen sizes, the largest screen is integer-scaled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+            </string>
+           </property>
+           <item>
+            <property name="text">
+             <string>Fit to Screen</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Fit to Screen with Integer Scaling</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
       <item>

--- a/src/citra_qt/configuration/configure_enhancements.ui
+++ b/src/citra_qt/configuration/configure_enhancements.ui
@@ -179,7 +179,8 @@
               &lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Scaling mode&lt;/p&gt;&lt;p&gt;
               How to scale the screens of the emulated 3DS to the screen those are displayed on.&lt;/p&gt;&lt;p&gt;
               Fit to Screen: Scales the screens until those reach the borders of the window/screen.&lt;/p&gt;&lt;p&gt;
-              Fit to Screen with Integer Scaling: Scales the screens with an integer multiplier of the original 3DS screen to the largest fitting size. For layouts with two different screen sizes, the largest screen is integer-scaled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+              Fit to Screen with Integer Scaling: Scales the screens with an integer multiplier of the original 3DS screen to the largest fitting size. For layouts with two different screen sizes, the largest screen is integer-scaled.&lt;/p&gt;&lt;p&gt;
+              Pixel by Pixel: Displays each pixel from the game/app on one pixel of the screen. If the game-views do not fit within the window/screen, the width and height of those will be halved until those do fit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
             </string>
            </property>
            <item>
@@ -190,6 +191,11 @@
            <item>
             <property name="text">
              <string>Fit to Screen with Integer Scaling</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Pixel by Pixel</string>
             </property>
            </item>
           </widget>

--- a/src/citra_qt/configuration/configure_enhancements.ui
+++ b/src/citra_qt/configuration/configure_enhancements.ui
@@ -151,13 +151,50 @@
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="use_integer_scaling">
-        <property name="text">
-         <string>Use Integer Scaling</string>
-        </property>
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use Integer Scaling&lt;/p&gt;&lt;p&gt;Enforces that the larger screen in all layouts is an integer scale of the 240px height of the original 3DS screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
+       <widget class="QWidget" name="widget_scaling_mode" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="scaling_mode_label">
+           <property name="text">
+            <string>Scaling Mode</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="scaling_mode_combobox">
+           <property name="toolTip">
+            <string>
+              &lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Scaling mode&lt;/p&gt;&lt;p&gt;
+              How to scale the screens of the emulated 3DS to the screen those are displayed on.&lt;/p&gt;&lt;p&gt;
+              Fit to Screen: Scales the screens until those reach the borders of the window/screen.&lt;/p&gt;&lt;p&gt;
+              Fit to Screen with Integer Scaling: Scales the screens with an integer multiplier of the original 3DS screen to the largest fitting size. For layouts with two different screen sizes, the largest screen is integer-scaled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+            </string>
+           </property>
+           <item>
+            <property name="text">
+             <string>Fit to Screen</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Fit to Screen with Integer Scaling</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
       <item>

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -41,6 +41,17 @@ std::string_view GetGraphicsAPIName(GraphicsAPI api) {
     }
 }
 
+std::string_view GetScalingModeName(ScalingMode mode) {
+    switch (mode) {
+    case ScalingMode::FitToScreen:
+        return "Fit to Screen";
+    case ScalingMode::FitToScreenInteger:
+        return "Fit to Screen with Integer Scaling";
+    default:
+        return "Invalid";
+    }
+}
+
 std::string_view GetTextureFilterName(TextureFilter filter) {
     switch (filter) {
     case TextureFilter::NoFilter:
@@ -101,7 +112,7 @@ void LogSettings() {
     log_setting("Renderer_ShadersAccurateMul", values.shaders_accurate_mul.GetValue());
     log_setting("Renderer_UseShaderJit", values.use_shader_jit.GetValue());
     log_setting("Renderer_UseResolutionFactor", values.resolution_factor.GetValue());
-    log_setting("Renderer_UseIntegerScaling", values.use_integer_scaling.GetValue());
+    log_setting("Renderer_ScalingMode", GetScalingModeName(values.scaling_mode.GetValue()));
     log_setting("Renderer_FrameLimit", values.frame_limit.GetValue());
     log_setting("Renderer_VSyncNew", values.use_vsync.GetValue());
     log_setting("Renderer_SkipDuplicateFrames", values.use_skip_duplicate_frames.GetValue());
@@ -219,7 +230,7 @@ void RestoreGlobalState(bool is_powered_on) {
     values.use_vsync.SetGlobal(true);
     values.use_skip_duplicate_frames.SetGlobal(true);
     values.resolution_factor.SetGlobal(true);
-    values.use_integer_scaling.SetGlobal(true);
+    values.scaling_mode.SetGlobal(true);
     values.frame_limit.SetGlobal(true);
     values.texture_filter.SetGlobal(true);
     values.texture_sampling.SetGlobal(true);

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -47,6 +47,8 @@ std::string_view GetScalingModeName(ScalingMode mode) {
         return "Fit to Screen";
     case ScalingMode::FitToScreenInteger:
         return "Fit to Screen with Integer Scaling";
+    case ScalingMode::PixelByPixel:
+        return "Pixel by Pixel";
     default:
         return "Invalid";
     }

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -41,6 +41,17 @@ std::string_view GetGraphicsAPIName(GraphicsAPI api) {
     }
 }
 
+std::string_view GetScalingModeName(ScalingMode mode) {
+    switch (mode) {
+    case ScalingMode::FitToScreen:
+        return "Fit to Screen";
+    case ScalingMode::FitToScreenInteger:
+        return "Fit to Screen with Integer Scaling";
+    default:
+        return "Invalid";
+    }
+}
+
 std::string_view GetTextureFilterName(TextureFilter filter) {
     switch (filter) {
     case TextureFilter::NoFilter:
@@ -101,7 +112,7 @@ void LogSettings() {
     log_setting("Renderer_ShadersAccurateMul", values.shaders_accurate_mul.GetValue());
     log_setting("Renderer_UseShaderJit", values.use_shader_jit.GetValue());
     log_setting("Renderer_UseResolutionFactor", values.resolution_factor.GetValue());
-    log_setting("Renderer_UseIntegerScaling", values.use_integer_scaling.GetValue());
+    log_setting("Renderer_ScalingMode", GetScalingModeName(values.scaling_mode.GetValue()));
     log_setting("Renderer_FrameLimit", values.frame_limit.GetValue());
     log_setting("Renderer_VSyncNew", values.use_vsync.GetValue());
     log_setting("Renderer_SkipDuplicateFrames", values.use_skip_duplicate_frames.GetValue());
@@ -218,7 +229,7 @@ void RestoreGlobalState(bool is_powered_on) {
     values.use_vsync.SetGlobal(true);
     values.use_skip_duplicate_frames.SetGlobal(true);
     values.resolution_factor.SetGlobal(true);
-    values.use_integer_scaling.SetGlobal(true);
+    values.scaling_mode.SetGlobal(true);
     values.frame_limit.SetGlobal(true);
     values.texture_filter.SetGlobal(true);
     values.texture_sampling.SetGlobal(true);

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -117,6 +117,7 @@ enum class AudioEmulation : u32 {
 enum class ScalingMode : u32 {
     FitToScreen = 0,
     FitToScreenInteger = 1,
+    PixelByPixel = 2,
 };
 
 enum class TextureFilter : u32 {

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -114,6 +114,11 @@ enum class AudioEmulation : u32 {
     LLEMultithreaded = 2,
 };
 
+enum class ScalingMode : u32 {
+    FitToScreen = 0,
+    FitToScreenInteger = 1,
+};
+
 enum class TextureFilter : u32 {
     NoFilter = 0,
     Anime4K = 1,
@@ -549,7 +554,7 @@ struct Values {
         true, Keys::use_display_refresh_rate_detection};
     Setting<bool> use_shader_jit{true, Keys::use_shader_jit};
     SwitchableSetting<u32, true> resolution_factor{1, 0, 18, Keys::resolution_factor};
-    SwitchableSetting<bool> use_integer_scaling{false, Keys::use_integer_scaling};
+    SwitchableSetting<ScalingMode> scaling_mode{ScalingMode::FitToScreen, Keys::scaling_mode};
     SwitchableSetting<double, true> frame_limit{100, 0, 1000, Keys::frame_limit};
     SwitchableSetting<double, true> turbo_limit{200, 0, 1000, Keys::turbo_limit};
     SwitchableSetting<TextureFilter> texture_filter{TextureFilter::NoFilter, Keys::texture_filter};

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -37,7 +37,7 @@ static Common::Rectangle<T> MaxRectangle(Common::Rectangle<T> window_area,
 }
 
 // overload of the above that takes an inner rectangle instead of an aspect ratio, and can be
-// limited to integer scaling if desired
+// limited to integer scaling or pixel by pixel mapping if desired
 template <class T>
 static Common::Rectangle<T> MaxRectangle(Common::Rectangle<T> bounding_window,
                                          Common::Rectangle<T> inner_window,
@@ -45,9 +45,27 @@ static Common::Rectangle<T> MaxRectangle(Common::Rectangle<T> bounding_window,
     float scale =
         std::min(static_cast<float>(bounding_window.GetWidth()) / inner_window.GetWidth(),
                  static_cast<float>(bounding_window.GetHeight()) / inner_window.GetHeight());
+
+    if (scaling_mode == Settings::ScalingMode::PixelByPixel) {
+        if (Settings::values.resolution_factor.GetValue() != 0) {
+            const float resolution_factor = Settings::values.resolution_factor.GetValue();
+            u32 divisor = 1;
+            while (resolution_factor * inner_window.GetWidth() / divisor >
+                       bounding_window.GetWidth() ||
+                   resolution_factor * inner_window.GetHeight() / divisor >
+                       bounding_window.GetHeight()) {
+                divisor *= 2;
+            };
+            scale = resolution_factor / divisor;
+        } else if (scale >= 1.0) {
+            scale = std::floor(scale);
+        }
+    }
+
     if (scaling_mode == Settings::ScalingMode::FitToScreenInteger && scale >= 1.0) {
         scale = std::floor(scale);
     }
+
     return Common::Rectangle(bounding_window.left, bounding_window.top,
                              bounding_window.left + static_cast<T>(inner_window.GetWidth() * scale),
                              bounding_window.top +

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -41,11 +41,11 @@ static Common::Rectangle<T> MaxRectangle(Common::Rectangle<T> window_area,
 template <class T>
 static Common::Rectangle<T> MaxRectangle(Common::Rectangle<T> bounding_window,
                                          Common::Rectangle<T> inner_window,
-                                         bool use_integer = false) {
+                                         Settings::ScalingMode scaling_mode) {
     float scale =
         std::min(static_cast<float>(bounding_window.GetWidth()) / inner_window.GetWidth(),
                  static_cast<float>(bounding_window.GetHeight()) / inner_window.GetHeight());
-    if (use_integer && scale >= 1.0) {
+    if (scaling_mode == Settings::ScalingMode::FitToScreenInteger && scale >= 1.0) {
         scale = std::floor(scale);
     }
     return Common::Rectangle(bounding_window.left, bounding_window.top,
@@ -104,10 +104,10 @@ FramebufferLayout SingleFrameLayout(u32 width, u32 height, bool swapped, bool up
     case Settings::AspectRatio::Default:
         // this is the only one where we allow integer scaling to apply
         // also the only option on desktop
-        top_screen = MaxRectangle(screen_window_area, top_screen,
-                                  Settings::values.use_integer_scaling.GetValue());
-        bot_screen = MaxRectangle(screen_window_area, bot_screen,
-                                  Settings::values.use_integer_scaling.GetValue());
+        top_screen =
+            MaxRectangle(screen_window_area, top_screen, Settings::values.scaling_mode.GetValue());
+        bot_screen =
+            MaxRectangle(screen_window_area, bot_screen, Settings::values.scaling_mode.GetValue());
         break;
     case Settings::AspectRatio::Stretch:
         top_screen = MaxRectangle(screen_window_area, window_aspect_ratio);
@@ -181,8 +181,8 @@ FramebufferLayout LargeFrameLayout(u32 width, u32 height, bool swapped, bool upr
 
     Common::Rectangle<u32> screen_window_area{0, 0, width, height};
     Common::Rectangle<u32> total_rect{0, 0, emulation_width, emulation_height};
-    total_rect = MaxRectangle(screen_window_area, total_rect,
-                              Settings::values.use_integer_scaling.GetValue());
+    total_rect =
+        MaxRectangle(screen_window_area, total_rect, Settings::values.scaling_mode.GetValue());
     total_rect = total_rect.TranslateX((width - total_rect.GetWidth()) / 2)
                      .TranslateY((height - total_rect.GetHeight()) / 2);
 


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Closes https://github.com/azahar-emu/azahar/issues/2308 .

Although this is sufficient for practical use, this is not properly implemented for use with automatic internal resolution, and the software-renderer, because i could not find a way to access the result of [`RendererBase::GetResolutionScaleFactor()`](https://github.com/azahar-emu/azahar/blob/79c2f965fe5c1bd6d042e17d396a455546536f2f/src/video_core/renderer_base.cpp#L20-L30) in [`Common::Rectangle<T> MaxRectangle`](https://github.com/azahar-emu/azahar/blob/79c2f965fe5c1bd6d042e17d396a455546536f2f/src/core/frontend/framebuffer_layout.cpp#L41-L55), so this directly uses the value of the "Internal Resolution"-setting instead.

The scaling-behaviour, while using automatic internal resolution, is still correct, unless the game-views are displayed at a size smaller than 1x[^1], because rounding `scale` down, to the nearest integer, results in the same size when the resolution is the largest fitting integer-multiple of the original resolution.
Though, if the option for automatically chosen internal resolution will be changed to also choose resolutions that are not an integer-multiple, this workaround would not work properly anymore.

Other than that, i am not sure about the name of this option; some ideas are:
- Pixel By Pixel
- Pixel To Pixel
- ~~Pixel-Accurate~~

[^1]: The minimum size of the window of the Qt-frontend seems to be limited to a size that can contain the game-views at 1x, but the game-views can be smaller when a screen-gap is shown.