### PR TITLE
android: Fix typo in multiplayer_join_room_success string

### DIFF
--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -1017,7 +1017,7 @@
     <string name="multiplayer_ip_address">IP Address</string>
     <string name="multiplayer_ip_port">Port</string>
     <string name="multiplayer_create_room_success">Room created successfully!</string>
-    <string name="multiplayer_join_room_success">Join the room successfully!</string>
+    <string name="multiplayer_join_room_success">Joined the room successfully!</string>
     <string name="multiplayer_create_room_failed">Failed to create room!</string>
     <string name="multiplayer_join_room_failed">Failed to join room!</string>
     <string name="multiplayer_input_invalid">Invalid address or name is too short!</string>


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------
