### PR TITLE
BUGFIX: Legacy joystick triggers on linux

### DIFF
--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -992,6 +992,7 @@ public:
                 value = event.caxis.value;
                 timestamp = event.caxis.timestamp;
                 value = event.caxis.value;
+                axis_center_value[id][axis] = 0;
                 controller = true;
                 [[fallthrough]];
             }
@@ -1012,19 +1013,15 @@ public:
                     // starting a new movement.
                     axisStartTimestamps[id][axis] = event.jaxis.timestamp;
                     axis_event_count[id][axis] = 1;
-                    if (IsAxisAtExtreme(value)) {
-                        // a single event with a value right at the extreme.
-                        // Assume this is a digital "axis" and send the down
-                        // signal with center set to 0.
-                        if (controller) {
-                            event.caxis.value = std::copysign(32767, value);
-                        } else {
-                            event.jaxis.value = std::copysign(32767, value);
-                        }
-                        axis_center_value[id][axis] = 0;
+                    if (axis_center_value.contains(id) && axis_center_value[id].contains(axis) &&
+                        IsAxisAtExtreme(value)) {
+                        // a single event with a value at the extreme after we
+                        // have established the center value. Must be a digital axis press.
+                        event.caxis.value = std::copysign(32767, value);
                         return SDLEventToButtonParamPackage(state, event, true);
                     }
-                    // otherwise, this is our first event, identify the center
+                    // otherwise, this is our first event ever on this axis,
+                    // so assume we are near the center
                     if (value < -28000)
                         axis_center_value[id][axis] = -32768;
                     else if (value > 28000)
@@ -1036,12 +1033,21 @@ public:
                     break;
                 } else {
                     axis_event_count[id][axis]++;
-                    // only two events, second one at center, means this is a digital release
-                    if (axis_event_count[id][axis] == 2 && IsAxisAtCenter(value, id, axis) &&
-                        IsAxisAtExtreme(axis_memory[id][axis])) {
-                        // send the up signal for this digital axis, and clear.
+                    if (axis_event_count[id][axis] == 2 && IsAxisAtPole(value) &&
+                        IsAxisAtPole(axis_memory[id][axis])) {
+                        // if there are two events and both are at poles, the only reasonable
+                        // way that happens is if this is the second half of a digital axis release.
+                        // So treat this as a release and make sure this is recorded as the center
                         axis_event_count[id][axis] = 0;
-                        axis_memory[id][axis] = 0;
+                        if (!IsAxisAtCenter(value, id, axis)) {
+                            // fix the center value
+                            if (value > 28000)
+                                axis_center_value[id][axis] = 32767;
+                            else if (value < -28000)
+                                axis_center_value[id][axis] = -32768;
+                            else
+                                axis_center_value[id][axis] = 0;
+                        }
                         return SDLEventToButtonParamPackage(state, event, false);
                     }
                     if (IsAxisAtCenter(value, id, axis) &&
@@ -1054,7 +1060,7 @@ public:
                             event.jaxis.value = static_cast<Sint16>(std::copysign(
                                 32767, axis_memory[id][axis] - axis_center_value[id][axis]));
                         }
-                        axis_memory[id][axis] = 0;
+                        axis_memory[id][axis] = axis_center_value[id][axis];
                         axis_event_count[id][axis] = 0;
                         return SDLEventToButtonParamPackage(state, event, false);
                     } else if (IsAxisAtCenter(axis_memory[id][axis], id, axis) &&
@@ -1102,7 +1108,8 @@ public:
 
 private:
     bool IsAxisAtCenter(int16_t value, SDL_JoystickID id, uint8_t axis) {
-        return std::abs(value - axis_center_value[id][axis]) < 367;
+        return axis_center_value[id].contains(axis) &&
+               std::abs(value - axis_center_value[id][axis]) < 367;
     }
 
     bool IsAxisPastThreshold(int16_t value, SDL_JoystickID id, uint8_t axis) {
@@ -1110,7 +1117,11 @@ private:
     }
 
     bool IsAxisAtExtreme(int16_t value) {
-        return std::abs(value) > 32766;
+        return std::abs(value) > 32300;
+    }
+
+    bool IsAxisAtPole(int16_t value) {
+        return IsAxisAtExtreme(value) || std::abs(value) < 367;
     }
 
     /** Holds the first received value for the axis. Used to

--- a/src/input_common/sdl/sdl_joystick.cpp
+++ b/src/input_common/sdl/sdl_joystick.cpp
@@ -13,6 +13,19 @@ SDLJoystick::SDLJoystick(std::string guid_, int port_, SDL_Joystick* joystick,
       sdl_controller{game_controller, &SDL_GameControllerClose} {
     EnableMotion();
     CreateControllerButtonMap();
+    CalibrateJoystickAxes();
+}
+
+void SDLJoystick::CalibrateJoystickAxes() {
+    if (!sdl_joystick)
+        return;
+    const int num_axes = SDL_JoystickNumAxes(sdl_joystick.get());
+    for (int axis = 0; axis < num_axes; ++axis) {
+        // assume the joystick is approximately centered at start.
+        // maybe not a great assumption but the best we've got.
+        const auto raw = SDL_JoystickGetAxis(sdl_joystick.get(), axis);
+        joystick_axis_centers[axis] = raw > 28000 ? 32767 : (raw < -28000 ? -32768 : 0);
+    }
 }
 
 bool SDLJoystick::IsButtonMappedToController(int button) const {
@@ -61,7 +74,10 @@ float SDLJoystick::GetAxis(int axis, bool isController) const {
         return SDL_GameControllerGetAxis(sdl_controller.get(),
                                          static_cast<SDL_GameControllerAxis>(axis)) /
                32767.0f;
-    return SDL_JoystickGetAxis(sdl_joystick.get(), axis) / 32767.0f;
+    const int16_t center = joystick_axis_centers.count(axis) ? joystick_axis_centers.at(axis) : 0;
+    const auto delta = SDL_JoystickGetAxis(sdl_joystick.get(), axis) - center;
+    const float range = delta >= 0 ? (32767.0f - center) : (center - (-32768.0f));
+    return range > 0.0f ? delta / range : 0.0f;
 }
 
 std::tuple<float, float> SDLJoystick::GetAnalog(int axis_x, int axis_y, bool isController) const {

--- a/src/input_common/sdl/sdl_joystick.h
+++ b/src/input_common/sdl/sdl_joystick.h
@@ -69,8 +69,10 @@ private:
     bool has_accel{false};
     std::unique_ptr<SDL_Joystick, void (*)(SDL_Joystick*)> sdl_joystick;
     std::unique_ptr<SDL_GameController, void (*)(SDL_GameController*)> sdl_controller;
+    std::unordered_map<int, int16_t> joystick_axis_centers;
     mutable std::mutex mutex;
     std::unordered_set<int> mapped_joystick_buttons;
     void CreateControllerButtonMap();
+    void CalibrateJoystickAxes();
 };
 } // namespace InputCommon::SDL


### PR DESCRIPTION
Steam deck users using emudeck reported that L and R were always depressed. This ended up being because emudeck uses triggers for L and R, and there was an issue with how legacy Joystick API triggers were being detected as buttons.

Legacy triggers using the joystick API are sometimes "centered" at -32767 instead of 0 - this seems to the case on steam deck for example - and the changes introduced in 2126 resulted in that becoming an issue, as we no longer record historical state and instead simply look up axis values directly from SDL, which means the previous default assumption of a center at zero is now causing an issue.

The axes now are calibrated as centered when the joystick is first initialized and all changes are compared to the calibrated center. 

Anybody mapping their controller *now* will be unaffected by any of these changes, as the more modern Controller API used by default now does not have these problems, but these changes preserve backwards compatibility.

- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.

**AI Disclosure**
AI helped me identify the places in the large sdl_impl.cpp file that related to the issue and had change since 2125. It proposed some potential solutions (which were mostly wrong). The code in the end is my own.


