### PR TITLE
video_core: Implement shader output register banking

### DIFF
--- a/src/common/hacks/hack_list.cpp
+++ b/src/common/hacks/hack_list.cpp
@@ -167,25 +167,7 @@ HackManager hack_manager = {
         {HackType::REQUIRES_SHADER_FIXUP,
          HackEntry{
              .mode = HackAllowMode::FORCE,
-             .affected_title_ids =
-                 {
-                     // 3D Thunder Blade
-                     0x0004000000128A00, // JPN
-                     0x0004000000158200, // EUR
-                     0x0004000000158C00, // USA
-
-                     // 3D After Burner II
-                     0x0004000000114200, // JPN
-                     0x0004000000157A00, // EUR
-                     0x0004000000158900, // USA
-
-                     // 3D Classics
-                     0x0004000000154000, // 1 (JPN)
-                     0x0004000000180E00, // 2 (JPN)
-                     0x000400000019A700, // 2 (EUR)
-                     0x0004000000185E00, // 2 (USA)
-                     0x00040000001AA300, // 3 (JPN)
-                 },
+             .affected_title_ids = {},
          }},
         {HackType::SPOOF_FRIEND_CODE_SEED,
          HackEntry{

--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -934,8 +934,8 @@ Result GSP_GPU::AcquireGpuRight(const Kernel::HLERequestContext& ctx,
     auto& gpu = system.GPU();
     gpu.ApplyPerProgramSettings(process->codeset->program_id);
     gpu.GetRightEyeDisabler().SetEnabled(right_eye_disable_allow);
-    gpu.PicaCore().vs_setup.requires_fixup = requires_shader_fixup;
-    gpu.PicaCore().gs_setup.requires_fixup = requires_shader_fixup;
+    gpu.PicaCore().vs_setup.SetRequiresShaderFixup(requires_shader_fixup);
+    gpu.PicaCore().gs_setup.SetRequiresShaderFixup(requires_shader_fixup);
 
     if (thread_id_with_rights == session_data->thread_id) {
         return {ErrorDescription::AlreadyDone, ErrorModule::GX, ErrorSummary::Success,

--- a/src/tests/video_core/shader.cpp
+++ b/src/tests/video_core/shader.cpp
@@ -92,8 +92,10 @@ public:
     Common::Vec4f Run(std::span<const Common::Vec4f> inputs) {
         Pica::ShaderUnit shader_unit;
         RunShader(shader_unit, inputs);
-        return {shader_unit.output[0].x.ToFloat32(), shader_unit.output[0].y.ToFloat32(),
-                shader_unit.output[0].z.ToFloat32(), shader_unit.output[0].w.ToFloat32()};
+        return {shader_unit.output[shader_unit.output_bank][0].x.ToFloat32(),
+                shader_unit.output[shader_unit.output_bank][0].y.ToFloat32(),
+                shader_unit.output[shader_unit.output_bank][0].z.ToFloat32(),
+                shader_unit.output[shader_unit.output_bank][0].w.ToFloat32()};
     }
 
     Common::Vec4f Run(std::initializer_list<float> inputs) {
@@ -711,7 +713,8 @@ TEMPLATE_TEST_CASE("Nested Loop", "[video_core][shader]", ShaderJitTest) {
         shader_test.Run(shader_unit, input);
 
         REQUIRE(shader_unit.address_registers[2] == expected_aL);
-        REQUIRE(shader_unit.output[0].x.ToFloat32() == Catch::Approx(expected_out));
+        REQUIRE(shader_unit.output[shader_unit.output_bank][0].x.ToFloat32() ==
+                Catch::Approx(expected_out));
     }
 }
 
@@ -760,7 +763,7 @@ SHADER_TEST_CASE("Conditional", "[video_core][shader]") {
         auto shader_test = TestType(std::move(shader_setup));
         shader_test.Run(shader_unit, 1.0f);
 
-        REQUIRE(shader_unit.output[0].x.ToFloat32() == result);
+        REQUIRE(shader_unit.output[shader_unit.output_bank][0].x.ToFloat32() == result);
     }
 
     // JustY
@@ -773,7 +776,7 @@ SHADER_TEST_CASE("Conditional", "[video_core][shader]") {
         auto shader_test = TestType(std::move(shader_setup));
         shader_test.Run(shader_unit, 1.0f);
 
-        REQUIRE(shader_unit.output[0].x.ToFloat32() == result);
+        REQUIRE(shader_unit.output[shader_unit.output_bank][0].x.ToFloat32() == result);
     }
 
     // OR
@@ -786,7 +789,7 @@ SHADER_TEST_CASE("Conditional", "[video_core][shader]") {
         auto shader_test = TestType(std::move(shader_setup));
         shader_test.Run(shader_unit, 1.0f);
 
-        REQUIRE(shader_unit.output[0].x.ToFloat32() == result);
+        REQUIRE(shader_unit.output[shader_unit.output_bank][0].x.ToFloat32() == result);
     }
 
     // AND
@@ -799,7 +802,7 @@ SHADER_TEST_CASE("Conditional", "[video_core][shader]") {
         auto shader_test = TestType(std::move(shader_setup));
         shader_test.Run(shader_unit, 1.0f);
 
-        REQUIRE(shader_unit.output[0].x.ToFloat32() == result);
+        REQUIRE(shader_unit.output[shader_unit.output_bank][0].x.ToFloat32() == result);
     }
 }
 

--- a/src/video_core/pica/shader_setup.cpp
+++ b/src/video_core/pica/shader_setup.cpp
@@ -75,6 +75,7 @@ void ShaderSetup::DoProgramCodeFixup() {
     // WARNING: If the hashing method is changed, the hashes of the different shaders will need
     // adjustment.
 
+    /*
     if (!requires_fixup || !program_code_pending_fixup) {
         return;
     }
@@ -85,103 +86,9 @@ void ShaderSetup::DoProgramCodeFixup() {
         has_fixup = true;
         program_code_hash_dirty = true;
     };
+    */
 
-    /**
-     * Affected games:
-     * Some Sega 3D Classics games.
-     *
-     * Problem:
-     * The geometry shaders used by some of the Sega 3D Classics have a shader
-     * (gf2_five_color_gshader.vsh) that presents two separate issues.
-     *
-     * - The shader does not have an "end" instruction. This causes the execution
-     *   to be unbounded and start running whatever is in the code buffer after the end of the
-     *   program. Usually this is filled with zeroes, which are add instructions that have no effect
-     *   due to no more vertices being emitted. It's not clear what happens when the PC reaches
-     *   0x3FFC and is incremented. The most likely scenario is that it overflows back to the start,
-     *   where there is an end instruction close by. This causes the game to execute around 4K
-     *   instructions per vertex, which is very slow on emulator.
-     *
-     * - The shader relies on a HW bug or quirk that we do not currently understand or implement.
-     *   The game builds a quad (4 vertices) using two inputs, the upper left coordinate, and the
-     *   bottom right coordinate. The generated vertex coordinates are put in output register o0
-     *   before being emitted. Here is the pseudocode of the shader:
-     *       o0.xyzw = leftTop.xyzw
-     *       emit                       <- Emits the top left vertex
-     *       o0._yzw = leftTop.xyzw
-     *       o0.x___ = rightBottom.xyzw
-     *       emit                       <- Emits the top right vertex
-     *       o0._y__ = rightBottom.xyzw
-     *       emit                       <- Emits the bottom left vertex (!)
-     *       o0.xyzw = rightBottom.xyzw
-     *       emit                       <- Emits the bottom right vertex
-     *
-     *   This shader code has a bug. When the bottom left vertex is emitted, the y element is
-     *   updated to the bottom coordinate, but the x element is left untouched. One would say that
-     *   since the x element was last set to the RIGHT coordinate, the vertex would end up being
-     *   drawn to the bottom RIGHT instead of the intended bottom LEFT (which is what we observe on
-     *   the emulator). But on real HW, the vertex is drawn to the bottom LEFT instead. This
-     *   suggests a HW bug or quirk that is triggered whenever some elements of an output register
-     *   are not written to between emits. In order for the quad to look proper, the xzw elements
-     *   should somehow keep the contents from the first emit, where the top left coordinate was
-     *   written. The specifics of the HW bug that causes this are unknown.
-     *
-     * Solution:
-     * The following patches are made to fix the shaders:
-     *
-     * - An end instruction is inserted at the end of the shader to prevent unbounded execution.
-     *
-     * - Before the third vertex is emited and the y element of o0 is adjusted, a mov o0.xywz
-     *   leftTop.xywz instruction is inserted to update the xzw elements of the output register to
-     *   the expected values. This requires making room in the shader code, but luckily there are no
-     *   jumps that need relocation.
-     *
-     */
-    constexpr u64 SEGA_3D_CLASSICS_THUNDER_BLADE = 0x0797513756f2c8c9;
-    constexpr u64 SEGA_3D_CLASSICS_AFTER_BURNER = 0x188e959fbe31324d;
-    constexpr u64 SEGA_3D_CLASSICS_COLLECTION_TB = 0x5954c8e4d13cdd86;
-    constexpr u64 SEGA_3D_CLASSICS_COLLECTION_PD = 0x27496993b307355b;
-
-    const auto fix_3d_classics_common = [this](u32 offset_base, u32 mov_swizzle) {
-        offset_base /= 4;
-
-        // Make some room to insert an instruction
-        std::memmove(program_code_fixup.data() + offset_base + 1,
-                     program_code_fixup.data() + offset_base, 0x1C);
-
-        // mov o0.xyzw v0.xyzw (out.pos <- vLeftTop)
-        program_code_fixup[offset_base] = 0x4c000000 | mov_swizzle;
-
-        // end
-        program_code_fixup[offset_base + 0x20] = 0x88000000;
-
-        // Adjust biggest program size
-        if (biggest_program_size <= offset_base + 0x20) {
-            biggest_program_size = offset_base + 0x20 + 1;
-        }
-    };
-
-    // Select shader fixup
-    switch (GetProgramCodeHash()) {
-    case SEGA_3D_CLASSICS_THUNDER_BLADE: {
-        prepare_for_fixup();
-        fix_3d_classics_common(0x510, 0xA);
-    } break;
-    case SEGA_3D_CLASSICS_AFTER_BURNER: {
-        prepare_for_fixup();
-        fix_3d_classics_common(0x50C, 0xA);
-    } break;
-    case SEGA_3D_CLASSICS_COLLECTION_TB: {
-        prepare_for_fixup();
-        fix_3d_classics_common(0xAE0, 0xC);
-    } break;
-    case SEGA_3D_CLASSICS_COLLECTION_PD: {
-        prepare_for_fixup();
-        fix_3d_classics_common(0xAF0, 0xC);
-    } break;
-    default:
-        break;
-    }
+    // No games require shader fixups right now
 }
 
 } // namespace Pica

--- a/src/video_core/pica/shader_setup.h
+++ b/src/video_core/pica/shader_setup.h
@@ -54,8 +54,8 @@ struct ShaderSetup {
 private:
     void MakeProgramCodeDirty() {
         program_code_hash_dirty = true;
-        program_code_pending_fixup = true;
-        has_fixup = false;
+        // program_code_pending_fixup = true;
+        // has_fixup = false;
     }
 
     void MakeSwizzleDataDirty() {
@@ -123,7 +123,8 @@ public:
     }
 
     const ProgramCode& GetProgramCode() const {
-        return (has_fixup) ? program_code_fixup : program_code;
+        // return (has_fixup) ? program_code_fixup : program_code;
+        return program_code;
     }
 
     const SwizzleData& GetSwizzleData() const {
@@ -138,26 +139,32 @@ public:
         return biggest_swizzle_size;
     }
 
+    void SetRequiresShaderFixup(bool _requires_fixup) {
+        // requires_fixup = _requires_fixup;
+    }
+
 public:
     Uniforms uniforms;
     PackedAttribute uniform_queue;
     u32 entry_point{};
     const void* cached_shader{};
     bool uniforms_dirty = true;
-    bool requires_fixup = false;
-    bool has_fixup = false;
+
+    // bool requires_fixup = false;
+    // bool has_fixup = false;
 
 private:
     ProgramCode program_code{};
-    ProgramCode program_code_fixup{};
     SwizzleData swizzle_data{};
     bool program_code_hash_dirty{true};
     bool swizzle_data_hash_dirty{true};
-    bool program_code_pending_fixup{true};
     u32 biggest_program_size = 0;
     u32 biggest_swizzle_size = 0;
     u64 program_code_hash{0};
     u64 swizzle_data_hash{0};
+
+    // ProgramCode program_code_fixup{};
+    // bool program_code_pending_fixup{true};
 
     friend class boost::serialization::access;
     template <class Archive>
@@ -165,17 +172,18 @@ private:
         ar & uniforms;
         ar & uniform_queue;
         ar & program_code;
-        ar & program_code_fixup;
         ar & swizzle_data;
         ar & program_code_hash_dirty;
         ar & swizzle_data_hash_dirty;
-        ar & program_code_pending_fixup;
         ar & biggest_program_size;
         ar & biggest_swizzle_size;
         ar & program_code_hash;
         ar & swizzle_data_hash;
-        ar & requires_fixup;
-        ar & has_fixup;
+
+        // ar & program_code_fixup;
+        // ar & program_code_pending_fixup;
+        // ar & requires_fixup;
+        // ar & has_fixup;
         if (Archive::is_loading::value) {
             uniforms_dirty = true;
         }

--- a/src/video_core/pica/shader_unit.cpp
+++ b/src/video_core/pica/shader_unit.cpp
@@ -24,7 +24,7 @@ void ShaderUnit::LoadInput(const ShaderRegs& config, const AttributeBuffer& buff
 void ShaderUnit::WriteOutput(const ShaderRegs& config, AttributeBuffer& buffer) {
     u32 output_index{};
     for (u32 reg : Common::BitSet<u32>(config.output_mask)) {
-        buffer[output_index++] = output[reg];
+        buffer[output_index++] = output[output_bank][reg];
     }
 }
 

--- a/src/video_core/pica/shader_unit.h
+++ b/src/video_core/pica/shader_unit.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <bit>
 #include <functional>
 #include <span>
 #include <boost/serialization/base_object.hpp>
@@ -41,16 +42,36 @@ struct ShaderUnit {
         return offsetof(ShaderUnit, output) + register_index * sizeof(Common::Vec4<f24>);
     }
 
+    static constexpr std::size_t OutputBankOffset() {
+        return offsetof(ShaderUnit, output_bank);
+    }
+
     static constexpr std::size_t TemporaryOffset(s32 register_index) {
         return offsetof(ShaderUnit, temporary) + register_index * sizeof(Common::Vec4<f24>);
     }
+
+    static constexpr std::size_t OutputBankSize = sizeof(std::array<Common::Vec4<f24>, 16>);
+    static_assert(std::has_single_bit(ShaderUnit::OutputBankSize));
 
 public:
     s32 address_registers[3] = {};
     bool conditional_code[2] = {};
     alignas(16) std::array<Common::Vec4<f24>, 16> input = {};
     alignas(16) std::array<Common::Vec4<f24>, 16> temporary = {};
-    alignas(16) std::array<Common::Vec4<f24>, 16> output = {};
+
+    // Programmers only have access to a single set of output registers (o0-o15),
+    // however there is a hardware quirk with output registers when
+    // used in geometry shaders.
+    // It appears that, when emitting a series of vertices with the emit instruction,
+    // if the output registers are not written between two consecutive emits, then the
+    // unmodified output registers take the values they had 2 emits ago.
+    // This behaviour may suggest the existance of 2 output register banks that the GPU
+    // switches between each emit. This has been verified on real HW.
+    // Fixes issues with M2 games such as 3D Thunderblade that have malformed shaders.
+    // (https://github.com/azahar-emu/azahar/blob/c711b0ab324d2ec116292b0db7c04a5733b8e559/src/video_core/pica/shader_setup.cpp#L105-L127)
+    alignas(16) std::array<std::array<Common::Vec4<f24>, 16>, 2> output = {};
+    bool output_bank = false;
+
     GeometryEmitter* emitter_ptr;
 
 private:
@@ -60,6 +81,7 @@ private:
         ar & input;
         ar & temporary;
         ar & output;
+        ar & output_bank;
         ar & conditional_code;
         ar & address_registers;
     }

--- a/src/video_core/shader/shader_interpreter.cpp
+++ b/src/video_core/shader/shader_interpreter.cpp
@@ -211,11 +211,12 @@ static void RunInterpreter(const ShaderSetup& setup, ShaderUnit& state,
                 src2[3] = -src2[3];
             }
 
-            f24* dest = (instr.common.dest.Value() < 0x10)
-                            ? &state.output[instr.common.dest.Value().GetIndex()][0]
-                        : (instr.common.dest.Value() < 0x20)
-                            ? &state.temporary[instr.common.dest.Value().GetIndex()][0]
-                            : dummy_vec4_float24_zeros;
+            f24* dest =
+                (instr.common.dest.Value() < 0x10)
+                    ? &state.output[state.output_bank][instr.common.dest.Value().GetIndex()][0]
+                : (instr.common.dest.Value() < 0x20)
+                    ? &state.temporary[instr.common.dest.Value().GetIndex()][0]
+                    : dummy_vec4_float24_zeros;
 
             debug_data.max_opdesc_id =
                 std::max<u32>(debug_data.max_opdesc_id, 1 + instr.common.operand_desc_id);
@@ -546,11 +547,12 @@ static void RunInterpreter(const ShaderSetup& setup, ShaderUnit& state,
                     src3[3] = -src3[3];
                 }
 
-                f24* dest = (instr.mad.dest.Value() < 0x10)
-                                ? &state.output[instr.mad.dest.Value().GetIndex()][0]
-                            : (instr.mad.dest.Value() < 0x20)
-                                ? &state.temporary[instr.mad.dest.Value().GetIndex()][0]
-                                : dummy_vec4_float24_zeros;
+                f24* dest =
+                    (instr.mad.dest.Value() < 0x10)
+                        ? &state.output[state.output_bank][instr.mad.dest.Value().GetIndex()][0]
+                    : (instr.mad.dest.Value() < 0x20)
+                        ? &state.temporary[instr.mad.dest.Value().GetIndex()][0]
+                        : dummy_vec4_float24_zeros;
 
                 Record<DebugDataRecord::SRC1>(debug_data, iteration, src1);
                 Record<DebugDataRecord::SRC2>(debug_data, iteration, src2);
@@ -664,7 +666,8 @@ static void RunInterpreter(const ShaderSetup& setup, ShaderUnit& state,
             case OpCode::Id::EMIT: {
                 auto* emitter = state.emitter_ptr;
                 ASSERT_MSG(emitter, "execute EMIT on VS");
-                emitter->Emit(state.output);
+                emitter->Emit(state.output[state.output_bank]);
+                state.output_bank = !state.output_bank;
                 break;
             }
 

--- a/src/video_core/shader/shader_jit_a64_compiler.cpp
+++ b/src/video_core/shader/shader_jit_a64_compiler.cpp
@@ -6,6 +6,7 @@
 #if CITRA_ARCH(arm64)
 
 #include <algorithm>
+#include <bit>
 #include <cmath>
 #include <cstdint>
 #include <memory>
@@ -328,15 +329,37 @@ void JitShader::Compile_DestEnable(Instruction instr, QReg src) {
         break;
     }
 
+    constexpr int OutputBankShift = std::countr_zero(ShaderUnit::OutputBankSize);
+
     // If all components are enabled, write the result to the destination register
     if (swiz.dest_mask == NO_DEST_REG_MASK) {
         // Store dest back to memory
-        STR(src, STATE, dest_offset_disp);
+        if (dest.GetRegisterType() == RegisterType::Output) {
+            ADD(XSCRATCH0, STATE, dest_offset_disp);
+
+            LDRB(XSCRATCH1.toW(), STATE, ShaderUnit::OutputBankOffset());
+            LSL(XSCRATCH1, XSCRATCH1, OutputBankShift);
+            ADD(XSCRATCH0, XSCRATCH0, XSCRATCH1);
+
+            STR(src, XSCRATCH0);
+        } else {
+            STR(src, STATE, dest_offset_disp);
+        }
 
     } else {
         // Not all components are enabled, so mask the result when storing to the destination
         // register...
-        LDR(VSCRATCH0, STATE, dest_offset_disp);
+        if (dest.GetRegisterType() == RegisterType::Output) {
+            ADD(XSCRATCH0, STATE, dest_offset_disp);
+
+            LDRB(XSCRATCH1.toW(), STATE, ShaderUnit::OutputBankOffset());
+            LSL(XSCRATCH1, XSCRATCH1, OutputBankShift);
+            ADD(XSCRATCH0, XSCRATCH0, XSCRATCH1);
+
+            LDR(VSCRATCH0, XSCRATCH0);
+        } else {
+            LDR(VSCRATCH0, STATE, dest_offset_disp);
+        }
 
         // MOVI encodes a 64-bit value into an 8-bit immidiate by replicating bits
         // The 8-bit immediate "a:b:c:d:e:f:g:h" maps to the 64-bit value:
@@ -371,7 +394,11 @@ void JitShader::Compile_DestEnable(Instruction instr, QReg src) {
         BSL(VSCRATCH2.B16(), src.B16(), VSCRATCH0.B16());
 
         // Store dest back to memory
-        STR(VSCRATCH2, STATE, dest_offset_disp);
+        if (dest.GetRegisterType() == RegisterType::Output) {
+            STR(VSCRATCH2, XSCRATCH0);
+        } else {
+            STR(VSCRATCH2, STATE, dest_offset_disp);
+        }
     }
 }
 
@@ -826,8 +853,9 @@ void JitShader::Compile_JMP(Instruction instr) {
     }
 }
 
-static void Emit(GeometryEmitter* emitter, Common::Vec4<f24> (*output)[16]) {
-    emitter->Emit(*output);
+static void Emit(GeometryEmitter* emitter, ShaderUnit* unit) {
+    emitter->Emit(unit->output[unit->output_bank]);
+    unit->output_bank = !unit->output_bank;
 }
 
 void JitShader::Compile_EMIT(Instruction instr) {
@@ -846,7 +874,6 @@ void JitShader::Compile_EMIT(Instruction instr) {
     ABI_PushRegisters(*this, PersistentCallerSavedRegs());
     MOV(ABI_PARAM1, XSCRATCH0);
     MOV(ABI_PARAM2, STATE);
-    ADD(ABI_PARAM2, ABI_PARAM2, u32(offsetof(ShaderUnit, output)));
     CallFarFunction(*this, Emit);
     ABI_PopRegisters(*this, PersistentCallerSavedRegs());
     l(end);

--- a/src/video_core/shader/shader_jit_x64_compiler.cpp
+++ b/src/video_core/shader/shader_jit_x64_compiler.cpp
@@ -5,6 +5,7 @@
 #include "common/arch.h"
 #if CITRA_ARCH(x86_64)
 
+#include <bit>
 #include <nihstro/shader_bytecode.h>
 #include <smmintrin.h>
 #include <xbyak/xbyak_util.h>
@@ -319,15 +320,37 @@ void JitShader::Compile_DestEnable(Instruction instr, Xmm src) {
         break;
     }
 
+    constexpr int OutputBankShift = std::countr_zero(ShaderUnit::OutputBankSize);
+
     // If all components are enabled, write the result to the destination register
     if (swiz.dest_mask == NO_DEST_REG_MASK) {
-        // Store dest back to memory
-        movaps(xword[STATE + dest_offset_disp], src);
+        if (dest.GetRegisterType() == RegisterType::Output) {
+            lea(rax, ptr[STATE + dest_offset_disp]);
 
+            movzx(ecx, byte[STATE + ShaderUnit::OutputBankOffset()]);
+            shl(rcx, OutputBankShift);
+            add(rax, rcx);
+
+            movaps(xword[rax], src);
+        } else {
+            // Store dest back to memory
+            movaps(xword[STATE + dest_offset_disp], src);
+        }
     } else {
         // Not all components are enabled, so mask the result when storing to the destination
         // register...
-        movaps(SCRATCH, xword[STATE + dest_offset_disp]);
+
+        if (dest.GetRegisterType() == RegisterType::Output) {
+            lea(rax, ptr[STATE + dest_offset_disp]);
+
+            movzx(ecx, byte[STATE + ShaderUnit::OutputBankOffset()]);
+            shl(rcx, OutputBankShift);
+            add(rax, rcx);
+
+            movaps(SCRATCH, xword[rax]);
+        } else {
+            movaps(SCRATCH, xword[STATE + dest_offset_disp]);
+        }
 
         if (host_caps.has(Cpu::tSSE41)) {
             u8 mask = ((swiz.dest_mask & 1) << 3) | ((swiz.dest_mask & 8) >> 3) |
@@ -348,7 +371,12 @@ void JitShader::Compile_DestEnable(Instruction instr, Xmm src) {
         }
 
         // Store dest back to memory
-        movaps(xword[STATE + dest_offset_disp], SCRATCH);
+        if (dest.GetRegisterType() == RegisterType::Output) {
+            movaps(xword[rax], SCRATCH);
+        } else {
+            // Store dest back to memory
+            movaps(xword[STATE + dest_offset_disp], SCRATCH);
+        }
     }
 }
 
@@ -868,8 +896,9 @@ void JitShader::Compile_JMP(Instruction instr) {
     }
 }
 
-static void Emit(GeometryEmitter* emitter, Common::Vec4<f24> (*output)[16]) {
-    emitter->Emit(*output);
+static void Emit(GeometryEmitter* emitter, ShaderUnit* unit) {
+    emitter->Emit(unit->output[unit->output_bank]);
+    unit->output_bank = !unit->output_bank;
 }
 
 void JitShader::Compile_EMIT(Instruction instr) {
@@ -888,7 +917,6 @@ void JitShader::Compile_EMIT(Instruction instr) {
     ABI_PushRegistersAndAdjustStack(*this, PersistentCallerSavedRegs(), 0);
     mov(ABI_PARAM1, rax);
     mov(ABI_PARAM2, STATE);
-    add(ABI_PARAM2, static_cast<Xbyak::uint32>(offsetof(ShaderUnit, output)));
     CallFarFunction(*this, Emit);
     ABI_PopRegistersAndAdjustStack(*this, PersistentCallerSavedRegs(), 0);
     L(end);


### PR DESCRIPTION
This PR implements a newly discovered PICA200 quirk that caused issues in some M2 games, such as 3D Thunderblade. Previously, this was addressed by adding a shader code fixup path for those games that would change the geometry shader code to evade the quirk. Following is a technical explanation of the discovery.

3D Thunderblade, being an arcade emulator, uses some tricks to emulate the arcade game on the 3DS. Relevant for us is how the arcade sprites are rendered. When generating the sprites, the GPU only receives the sprite's top left and bottom right coordinates, which are then used by the PICA's geometry shader stage to generate two triangles (composed of 4 vertices) that form the sprite.

Here is the pseudocode for the triangle generation:
```
; 1. Emit top left vertex
o0.xyzw = leftTop.xyzw      ; Load topLeft coords
emit                        ; Result: Emits the top left vertex

; 2. Emit top right vertex
o0._yzw = leftTop.xyzw      ; Load yzw of topLeft coords
o0.x___ = rightBottom.xyzw  ; Load x of rightBottom coords   
emit                        ; Result: Emits the top right vertex

; 3. Emit bottom left vertex
o0._y__ = rightBottom.xyzw  ; Load y of rightBottom coords
emit                        ; Intended: Emit the bottom left vertex, but ends up emitting bottom right vertex (!)

; 4. Emit bottom right vertex
o0.xyzw = rightBottom.xyzw  ; Load rightBottom coords
emit                        ; Result: Emits the bottom right vertex
```

In the pseudocode, the output register `o0` is used to output the position of the 4 vertices that form the 2 triangles. If we look closely there is something strange when emitting the bottom left vertex. Instead of loading the leftTop X position, it just loads the Y rightBottom position, with the X position carrying over from the top right vertex emit step. **This has the result of the bottom left vertex being emitted in the bottom right coordinate instead!** And this is what was happening on Citra and Azahar.

<img width="1920" height="947" alt="image" src="https://github.com/user-attachments/assets/f32c49dd-8ea5-4f59-8f8b-0e7e36adf302" />
3D Thunderblade on Azahar before the fix (please ignore the wrong colors, that has to be addressed separately).
<br/><br/>

Notice how the broken helicopter sprite is rendered weirdly as if the bottom left was folded to the bottom right. Of course, this doesn't happen on real harware, which raises the question if there something we don't understand regarding geometry shaders and output registers.

One thing that stands out in this specific geometry shader is how the `o0` register is not fully overwritten between emits, instead some of its xyzw elements are reused from the previous emit step. This doesn't happen in any other commercial game that uses geometry shaders, there the output registers are always fully written. It's possible that not writting the output registers causes some kind of undefined behaviour that makes it hold strange values, and the game developers used this to either take advantage and use less instructions, or they had a bug that was not noticed.

In any case, the only way for this shader code to work is if that somehow, the contents of `o0` were being kept from 2 emits ago. This would allow the 3rd emit to use the x coordinate written in the 1st emit instead of the one from the 2nd emit, which would generate the vertex in the intended bottom left position. **This behaviour may be explained by the presence of multiple banks of output registers that are swapped every emit call.**

In fact, we can write a homebrew application that can be used to test the theory. The [geoshader](https://github.com/devkitPro/3ds-examples/tree/master/graphics/gpu/geoshader) libctru example uses geometry shaders to draw 3 triangles where each vertex is red, green and blue. It does this by writing 3 times the corresponding vertex positions to register `o0` and the color values to register `o1`. For this test, the sample can be modified so that for the bottom 2 triangles, the color output register `o1` is not written to. Running it on real hardware displays the following.

<img width="2048" height="1152" alt="image" src="https://github.com/user-attachments/assets/75a3bdc1-6e75-46a8-b8bb-9e93fecae857" />
Modified geoshader sample running on the 3DS.
<br/><br/>

As you can see, the colors of the vertices of the top triangle are the intended red, green and blue written by the geometry shader. However the bottom triangles vertices, whose emits leave the color output register `o1` untouched, seem to alternate between green and blue. Keeping in mind render order (triangles are rendered in the order top, left, right, same way as the individual vertices in the triangles themselves) vertex colors alternate between the last 2 colors written to the `o1` register. This proves that indeed, for every vertex emit, the GPU appears to switch between 2 output register banks that hold their contents.

For comparation, here is the sample running on Azahar before implementing the hardware quirk, where the `o1` register only keeps the last written value (blue) instead of alternating between the last 2 values.

<img width="895" height="537" alt="image" src="https://github.com/user-attachments/assets/e465b984-54f9-4de4-a126-4c2ee8a157f8" />
Modified geoshader sample running on Azahar before this PR.
<br/><br/>

After implementing output register bank switching properly, both the geoshader sample and 3D Thunderblade started rendering correctly!

<img width="1043" height="626" alt="image" src="https://github.com/user-attachments/assets/2aa4ed7c-e0cc-4d8c-9e8f-fb1c6ac310dc" />
<img width="1250" height="605" alt="image" src="https://github.com/user-attachments/assets/c53a1a5a-7f45-4401-baff-d576e21d74c1" />
<br/><br/>

Here is the modified geoshader sample used to test the quirk: [geoshader_reusereg.zip](https://github.com/user-attachments/files/30280870/geoshader_reusereg.zip)
