### PR TITLE
libretro: expose render_3d/factor_3d core options

### DIFF
--- a/src/citra_libretro/core_settings.cpp
+++ b/src/citra_libretro/core_settings.cpp
@@ -72,6 +72,8 @@ static constexpr const char* swap_screen = citra_setting(BaseKeys::swap_screen);
 static constexpr const char* swap_screen_mode = citra_setting(BaseKeys::swap_screen_mode);
 static constexpr const char* large_screen_proportion =
     citra_setting(BaseKeys::large_screen_proportion);
+static constexpr const char* render_3d = citra_setting(BaseKeys::render_3d);
+static constexpr const char* factor_3d = citra_setting(BaseKeys::factor_3d);
 } // namespace layout
 
 namespace storage {
@@ -520,6 +522,48 @@ static constexpr retro_core_option_v2_definition option_definitions[] = {
         },
         "4.00"
     },
+    {
+        config::layout::render_3d,
+        "Stereoscopic 3D Mode",
+        "Stereo 3D Mode",
+        "Stereoscopic 3D output, used when a game is rendering in 3D. 'Off' shows a "
+        "single 2D image. 'Side by Side' places the left and right eye images beside "
+        "each other in one frame, each at half width. 'Side by Side (Full)' does the "
+        "same but keeps each eye at full width. 'Anaglyph' merges both eyes into a "
+        "single red/cyan image for use with red/cyan glasses. 'Interlaced' alternates "
+        "the eyes on odd and even scanlines for interlaced 3D displays, and 'Reverse "
+        "Interlaced' swaps which eye is on which line. 'Cardboard VR' outputs side by "
+        "side with lens-distortion correction for Cardboard-style viewers.",
+        nullptr,
+        config::category::layout,
+        {
+            { "off", "Off (2D)" },
+            { "side-by-side", "Side by Side" },
+            { "side-by-side-full", "Side by Side (Full)" },
+            { "anaglyph", "Anaglyph (Red/Cyan)" },
+            { "interlaced", "Interlaced" },
+            { "reverse-interlaced", "Reverse Interlaced" },
+            { "cardboard", "Cardboard VR" },
+            { nullptr, nullptr }
+        },
+        "off"
+    },
+    {
+        config::layout::factor_3d,
+        "Stereoscopic 3D Depth",
+        "Stereo 3D Depth",
+        "Depth intensity of the stereoscopic 3D effect, as a percentage. Only used "
+        "when a 3D mode is active.",
+        nullptr,
+        config::category::layout,
+        {
+            {   "0",   "0%" }, {  "10",  "10%" }, {  "20",  "20%" }, {  "30",  "30%" },
+            {  "40",  "40%" }, {  "50",  "50%" }, {  "60",  "60%" }, {  "70",  "70%" },
+            {  "80",  "80%" }, {  "90",  "90%" }, { "100", "100%" },
+            { nullptr, nullptr }
+        },
+        "0"
+    },
 
     // Storage Category
     {
@@ -948,9 +992,39 @@ static Settings::LayoutOption GetLayoutOption(const std::string& name) {
     return Settings::LayoutOption::Default;
 }
 
+static Settings::StereoRenderOption GetStereoRenderOption(const std::string& name) {
+    if (name == "side-by-side")
+        return Settings::StereoRenderOption::SideBySide;
+    if (name == "side-by-side-full")
+        return Settings::StereoRenderOption::SideBySideFull;
+    if (name == "anaglyph")
+        return Settings::StereoRenderOption::Anaglyph;
+    if (name == "interlaced")
+        return Settings::StereoRenderOption::Interlaced;
+    if (name == "reverse-interlaced")
+        return Settings::StereoRenderOption::ReverseInterlaced;
+    if (name == "cardboard")
+        return Settings::StereoRenderOption::CardboardVR;
+    return Settings::StereoRenderOption::Off;
+}
+
 static void ParseLayoutOptions(void) {
     Settings::values.layout_option =
         GetLayoutOption(LibRetro::FetchVariable(config::layout::layout_option, "default"));
+
+    Settings::values.render_3d =
+        GetStereoRenderOption(LibRetro::FetchVariable(config::layout::render_3d, "off"));
+
+    Settings::values.factor_3d =
+        static_cast<u32>(std::stoi(LibRetro::FetchVariable(config::layout::factor_3d, "0")));
+
+    // EmuWindow::get3DMode() forces the mode Off on mobile builds while
+    // render_3d_which_display is None, which is its default and which no
+    // libretro code path ever changes — so render_3d alone is inert on Android.
+    Settings::values.render_3d_which_display =
+        (Settings::values.render_3d.GetValue() == Settings::StereoRenderOption::Off)
+            ? Settings::StereoWhichDisplay::None
+            : Settings::StereoWhichDisplay::Both;
 
     Settings::values.swap_screen =
         LibRetro::FetchVariable(config::layout::swap_screen, "Top") == "Bottom";


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

The renderer and framebuffer layout already honour Settings::values.render_3d and factor_3d; the libretro glue was the only place that never surfaced them. Add citra_render_3d (off / side-by-side / side-by-side-full / anaglyph / interlaced / reverse-interlaced / cardboard) and citra_factor_3d (0-100%) to the Layout option category and parse them in ParseLayoutOptions(). With render_3d = off the behaviour is identical to before.

I could use some feedback on the granularity of the factor 3d. I just choose 10% arbitrarily as I thought that was enough as libretro doesn't really allow an `int` or a `float` input for an option...

AI disclosure: I did use AI to help write the description message for the render 3d method.