### PR TITLE
Bugfix for ps4/ps5 controller hang at launch

### DIFF
--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -350,7 +350,6 @@ Common::ParamPackage SDLState::GetSDLControllerAnalogBindByGUID(
 void SDLState::InitJoystick(int joystick_index) {
     SDL_Joystick* sdl_joystick = nullptr;
     SDL_GameController* sdl_gamecontroller = nullptr;
-
     if (SDL_IsGameController(joystick_index)) {
         sdl_gamecontroller = SDL_GameControllerOpen(joystick_index);
         if (sdl_gamecontroller) {
@@ -359,7 +358,6 @@ void SDLState::InitJoystick(int joystick_index) {
     } else {
         sdl_joystick = SDL_JoystickOpen(joystick_index);
     }
-
     if (!sdl_joystick) {
         LOG_ERROR(Input, "failed to open joystick {}, with error: {}", joystick_index,
                   SDL_GetError());
@@ -370,7 +368,6 @@ void SDLState::InitJoystick(int joystick_index) {
     std::lock_guard lock{joystick_map_mutex};
     if (joystick_map.find(guid) == joystick_map.end()) {
         auto joystick = std::make_shared<SDLJoystick>(guid, 0, sdl_joystick, sdl_gamecontroller);
-        joystick->EnableMotion();
         auto vec = std::make_shared<std::vector<std::shared_ptr<SDLJoystick>>>();
         vec->emplace_back(joystick);
         joystick_map[guid] = vec;
@@ -383,13 +380,11 @@ void SDLState::InitJoystick(int joystick_index) {
                                  [](const auto& joystick) { return !joystick->GetSDLJoystick(); });
     if (it != joystick_guid_list->end()) {
         (*it)->SetSDLJoystick(sdl_joystick, sdl_gamecontroller);
-        (*it)->EnableMotion();
         joystick_vector->emplace_back(*it);
         return;
     }
     const int port = static_cast<int>(joystick_guid_list->size());
     auto joystick = std::make_shared<SDLJoystick>(guid, port, sdl_joystick, sdl_gamecontroller);
-    joystick->EnableMotion();
     joystick_guid_list->emplace_back(joystick);
     joystick_vector->emplace_back(joystick);
 }

--- a/src/input_common/sdl/sdl_joystick.cpp
+++ b/src/input_common/sdl/sdl_joystick.cpp
@@ -11,9 +11,9 @@ SDLJoystick::SDLJoystick(std::string guid_, int port_, SDL_Joystick* joystick,
                          SDL_GameController* game_controller)
     : guid{std::move(guid_)}, port{port_}, sdl_joystick{joystick, &SDL_JoystickClose},
       sdl_controller{game_controller, &SDL_GameControllerClose} {
-    EnableMotion();
     CreateControllerButtonMap();
     CalibrateJoystickAxes();
+    EnableMotion();
 }
 
 void SDLJoystick::CalibrateJoystickAxes() {
@@ -171,7 +171,6 @@ void SDLJoystick::CreateControllerButtonMap() {
     for (int i = 0; i < SDL_CONTROLLER_BUTTON_MAX; i++) {
         auto bind = SDL_GameControllerGetBindForButton(sdl_controller.get(),
                                                        static_cast<SDL_GameControllerButton>(i));
-
         if (bind.bindType == SDL_CONTROLLER_BINDTYPE_BUTTON) {
             mapped_joystick_buttons.insert(bind.value.button);
         }


### PR DESCRIPTION
Calling EnableMotion before establishing button maps was causing a threading issue with the PS4/PS5 HIDAPI driver in SDL resulting in occasional hangs at launch when initializing the controller. This is a known issue that did not appear in earlier builds because it only affects the Controller API not the Joystick API.

Simply removing a duplicate call and changing the order of events seems to have solved the problem. 

Closes #2341 

**AI Disclosure**
Once I isolated where the bug was happening, Claude helped me connect it to other related SDL issues and proposed some potential solutions, one of which is the one that worked. 

- [x ] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

