### PR TITLE
Bugfix: add mutex guard to touchpad read

### DIFF
--- a/src/input_common/sdl/sdl_joystick.cpp
+++ b/src/input_common/sdl/sdl_joystick.cpp
@@ -141,6 +141,7 @@ int SDLJoystick::GetPort() const {
 }
 
 std::tuple<float, float, float> SDLJoystick::GetTouch(int pad) const {
+    std::lock_guard lock{mutex};
     if (state.touchpad.contains(pad))
         return state.touchpad.at(pad);
     else


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

I traced back the touchpad issue from #2313 and it seems it really was just an initialization issue. The fix from #2314 is probably enough but I think it makes sense to add this mutex guard as well and then we can call this closed and fixed.

Closes #2313
