### PR TITLE
Bugfix: various analog button issues

### DIFF
--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -83,9 +83,9 @@ static QString AnalogToText(const Common::ParamPackage& param, const std::string
     // It might be nice to move the GetKeyName code to input_common, but would need a non-QT way of
     // doing it
     if (param.Get("engine", "") == "analog_from_button") {
-        auto dirParam = Common::ParamPackage(param.Get(dir, ""));
-        if (dirParam.Get("engine", "") == "keyboard") {
-            return GetKeyName(dirParam.Get("code", 0));
+        auto dir_param = Common::ParamPackage(param.Get(dir, ""));
+        if (dir_param.Get("engine", "") == "keyboard") {
+            return GetKeyName(dir_param.Get("code", 0));
         }
     }
     return QString::fromStdString(InputCommon::AnalogToText(param, dir));
@@ -374,28 +374,30 @@ void ConfigureInput::ApplyConfiguration() {
                    [](Common::ParamPackage& param) {
                        if (param.Get("engine", "keyboard") == "sdl") {
                            if (Settings::values.current_input_profile.maptype ==
-                               Settings::InputMappingType::AllControllers)
+                               Settings::InputMappingType::AllControllers) {
                                param.Set("maptype", "all");
-                           else if (Settings::values.current_input_profile.maptype ==
-                                    Settings::InputMappingType::Guid)
+                           } else if (Settings::values.current_input_profile.maptype ==
+                                      Settings::InputMappingType::Guid) {
                                param.Set("maptype", "guid");
-                           else
+                           } else {
                                param.Set("maptype", "guid+port");
+                           }
                        } else if (param.Get("engine", "keyboard") == "analog_from_button") {
                            for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM - 1;
                                 ++sub_button_id) {
                                auto dir = param.Get(analog_sub_buttons[sub_button_id], "");
                                if (dir != "") {
-                                   auto dirParam = Common::ParamPackage(param.Get(dir, ""));
+                                   auto dir_param = Common::ParamPackage(param.Get(dir, ""));
                                    if (Settings::values.current_input_profile.maptype ==
-                                       Settings::InputMappingType::AllControllers)
-                                       dirParam.Set("maptype", "all");
-                                   else if (Settings::values.current_input_profile.maptype ==
-                                            Settings::InputMappingType::Guid)
-                                       dirParam.Set("maptype", "guid");
-                                   else
-                                       dirParam.Set("maptype", "guid+port");
-                                   param.Set(dir, dirParam.Serialize());
+                                       Settings::InputMappingType::AllControllers) {
+                                       dir_param.Set("maptype", "all");
+                                   } else if (Settings::values.current_input_profile.maptype ==
+                                              Settings::InputMappingType::Guid) {
+                                       dir_param.Set("maptype", "guid");
+                                   } else {
+                                       dir_param.Set("maptype", "guid+port");
+                                   }
+                                   param.Set(dir, dir_param.Serialize());
                                }
                            }
                        } else {
@@ -442,7 +444,6 @@ QList<QKeySequence> ConfigureInput::GetUsedKeyboardKeys() {
 }
 
 void ConfigureInput::LoadConfiguration() {
-
     ui->use_artic_controller->setChecked(Settings::values.use_artic_base_controller.GetValue());
     ui->comboBoxMappingType->setCurrentIndex(
         static_cast<int>(Settings::values.current_input_profile.maptype));

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -381,6 +381,23 @@ void ConfigureInput::ApplyConfiguration() {
                                param.Set("maptype", "guid");
                            else
                                param.Set("maptype", "guid+port");
+                       } else if (param.Get("engine", "keyboard") == "analog_from_button") {
+                           for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM - 1;
+                                ++sub_button_id) {
+                               auto dir = param.Get(analog_sub_buttons[sub_button_id], "");
+                               if (dir != "") {
+                                   auto dirParam = Common::ParamPackage(param.Get(dir, ""));
+                                   if (Settings::values.current_input_profile.maptype ==
+                                       Settings::InputMappingType::AllControllers)
+                                       dirParam.Set("maptype", "all");
+                                   else if (Settings::values.current_input_profile.maptype ==
+                                            Settings::InputMappingType::Guid)
+                                       dirParam.Set("maptype", "guid");
+                                   else
+                                       dirParam.Set("maptype", "guid+port");
+                                   param.Set(dir, dirParam.Serialize());
+                               }
+                           }
                        } else {
                            param.Erase("maptype");
                        }

--- a/src/input_common/main.cpp
+++ b/src/input_common/main.cpp
@@ -155,13 +155,13 @@ std::string AnalogToText(const Common::ParamPackage& param, const std::string& d
         }
         if (dir == "up") {
             if (name_y_str == "")
-                return "Axis " + axis_y_str + plus_str;
+                return "Axis " + axis_y_str + minus_str;
             else
-                return name_y_str + plus_str;
+                return name_y_str + minus_str;
         }
         if (dir == "down") {
             if (name_y_str == "")
-                return "Axis " + axis_y_str + minus_str;
+                return "Axis " + axis_y_str + plus_str;
             else
                 return name_y_str + plus_str;
         }

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -518,7 +518,14 @@ public:
     bool GetStatus() const override {
         if (port >= 0 && joysticks && static_cast<int>(joysticks->size()) > port &&
             joysticks->at(port)) {
-            return joysticks->at(port)->GetAxis(axis, isController);
+
+            float axis_value = joysticks->at(port)->GetAxis(axis, isController);
+            if (trigger_if_greater && axis_value > threshold)
+                return true;
+            else if (!trigger_if_greater && axis_value < threshold)
+                return true;
+            else
+                return false;
         }
         for (const auto& joystick : *joysticks) {
             if (!joystick)


### PR DESCRIPTION
Three small bugfixes:

1) Previously, the "maptype" parameter was not saved in analog_from_button parameters, meaning it always defaulted to using the old port+guid method. This fixes that.

2) If using an analog input as a digital mapping of an analog output (e.g. manually mapping X+ to X+ rather than using Set Analog Stick), and also using the port+guid method (as enforced by bug 1 above), the wrong value was returned. This fixes that. Ideally users will do analog mapping rather than digital mapping in these cases, but this allows for both to work acceptably.

3) The naming was wrong for auto-mapped Y axes, showing Left Stick Y+ for both up and down. This fixes it to correctly use + for down and - for up.

- [ x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

