### PR TITLE
pica: Fix floating point denormal accuracy

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(tests
     audio_core/lle/lle.cpp
     audio_core/audio_fixures.h
     audio_core/decoder_tests.cpp
+    video_core/pica_types.cpp
     video_core/shader.cpp
     audio_core/merryhime_3ds_audio/merry_audio/merry_audio.cpp
     audio_core/merryhime_3ds_audio/merry_audio/merry_audio.h

--- a/src/tests/video_core/pica_types.cpp
+++ b/src/tests/video_core/pica_types.cpp
@@ -1,0 +1,96 @@
+// Copyright Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <catch2/catch_test_macros.hpp>
+#include "video_core/pica_types.h"
+
+TEST_CASE("float24", "[video_core]") {
+    REQUIRE(Pica::f24::FromRaw(0x3F0000).ToFloat32() == +1.0f);
+    REQUIRE(Pica::f24::FromRaw(0xBF0000).ToFloat32() == -1.0f);
+    REQUIRE(Pica::f24::FromRaw(0x3E0000).ToFloat32() == +0.5f);
+    REQUIRE(Pica::f24::FromRaw(0xBE0000).ToFloat32() == -0.5f);
+    REQUIRE(Pica::f24::FromRaw(0x3D0000).ToFloat32() == +0.25f);
+    REQUIRE(Pica::f24::FromRaw(0xBD0000).ToFloat32() == -0.25f);
+    REQUIRE(Pica::f24::FromRaw(0x408000).ToFloat32() == +3.0f);
+
+    // Min/Max norm
+    REQUIRE(Pica::f24::FromRaw(0x010000).ToFloat32() == std::bit_cast<float>(0x20800000));
+    REQUIRE(Pica::f24::FromRaw(0x7EFFFF).ToFloat32() == std::bit_cast<float>(0x5F7FFF80));
+
+    // Zero
+    REQUIRE(Pica::f16::FromRaw(0x000000).ToFloat32() == +0.0f);
+    REQUIRE(Pica::f24::FromRaw(0x800000).ToFloat32() == -0.0f);
+
+    // Infinity
+    REQUIRE(Pica::f24::FromRaw(0x7F0000).ToFloat32() == std::bit_cast<float>(0x7F800000));
+    REQUIRE(Pica::f24::FromRaw(0xFF0000).ToFloat32() == std::bit_cast<float>(0xFF800000));
+
+    // Denormal/Subnormal
+    REQUIRE(Pica::f24::FromRaw(0x000001).ToFloat32() == std::bit_cast<float>(0x18800000));
+    REQUIRE(Pica::f24::FromRaw(0x00FFFF).ToFloat32() == std::bit_cast<float>(0x207FFF00));
+
+    // NaN
+    REQUIRE(std::bit_cast<u32>(Pica::f24::FromRaw(0x7F8000).ToFloat32()) == 0x7FC00000);
+    REQUIRE(std::bit_cast<u32>(Pica::f24::FromRaw(0xFF8000).ToFloat32()) == 0xFFC00000);
+}
+
+TEST_CASE("float20", "[video_core]") {
+    REQUIRE(Pica::f20::FromRaw(0x3f000).ToFloat32() == +1.0f);
+    REQUIRE(Pica::f20::FromRaw(0xBf000).ToFloat32() == -1.0f);
+    REQUIRE(Pica::f20::FromRaw(0x3E000).ToFloat32() == +0.5f);
+    REQUIRE(Pica::f20::FromRaw(0xBE000).ToFloat32() == -0.5f);
+    REQUIRE(Pica::f20::FromRaw(0x3D000).ToFloat32() == +0.25f);
+    REQUIRE(Pica::f20::FromRaw(0xBD000).ToFloat32() == -0.25f);
+    REQUIRE(Pica::f20::FromRaw(0x40800).ToFloat32() == +3.0f);
+
+    // Min/Max norm
+    REQUIRE(Pica::f20::FromRaw(0x01000).ToFloat32() == std::bit_cast<float>(0x20800000));
+    REQUIRE(Pica::f20::FromRaw(0x7EFFF).ToFloat32() == std::bit_cast<float>(0x5F7FF800));
+
+    // Zero
+    REQUIRE(Pica::f20::FromRaw(0x00000).ToFloat32() == +0.0f);
+    REQUIRE(Pica::f20::FromRaw(0x80000).ToFloat32() == -0.0f);
+
+    // Infinity
+    REQUIRE(Pica::f20::FromRaw(0x7F000).ToFloat32() == std::bit_cast<float>(0x7F800000));
+    REQUIRE(Pica::f20::FromRaw(0xFF000).ToFloat32() == std::bit_cast<float>(0xFF800000));
+
+    // Denormal/Subnormal
+    REQUIRE(Pica::f20::FromRaw(0x00001).ToFloat32() == std::bit_cast<float>(0x1A800000));
+    REQUIRE(Pica::f20::FromRaw(0x00FFF).ToFloat32() == std::bit_cast<float>(0x207FF000));
+
+    // NaN
+    REQUIRE(std::bit_cast<u32>(Pica::f20::FromRaw(0x7F800)) == 0x7FC00000);
+    REQUIRE(std::bit_cast<u32>(Pica::f20::FromRaw(0xFFFFF)) == 0xFFFFF800);
+}
+
+TEST_CASE("float16", "[video_core]") {
+    REQUIRE(Pica::f16::FromRaw(0x3C00).ToFloat32() == +1.0f);
+    REQUIRE(Pica::f16::FromRaw(0xBC00).ToFloat32() == -1.0f);
+    REQUIRE(Pica::f16::FromRaw(0x3800).ToFloat32() == +0.5f);
+    REQUIRE(Pica::f16::FromRaw(0xB800).ToFloat32() == -0.5f);
+    REQUIRE(Pica::f16::FromRaw(0x3400).ToFloat32() == +0.25f);
+    REQUIRE(Pica::f16::FromRaw(0xB400).ToFloat32() == -0.25f);
+    REQUIRE(Pica::f16::FromRaw(0x4200).ToFloat32() == +3.0f);
+
+    // Min/Max norm
+    REQUIRE(Pica::f16::FromRaw(0x0400).ToFloat32() == std::bit_cast<float>(0x38800000));
+    REQUIRE(Pica::f16::FromRaw(0x7BFF).ToFloat32() == std::bit_cast<float>(0x477FE000));
+
+    // Zero
+    REQUIRE(Pica::f16::FromRaw(0x0000).ToFloat32() == +0.0f);
+    REQUIRE(Pica::f16::FromRaw(0x8000).ToFloat32() == -0.0f);
+
+    // Infinity
+    REQUIRE(Pica::f16::FromRaw(0x7C00).ToFloat32() == std::bit_cast<float>(0x7F800000));
+    REQUIRE(Pica::f16::FromRaw(0xFC00).ToFloat32() == std::bit_cast<float>(0xFF800000));
+
+    // Denormal/Subnormal
+    REQUIRE(Pica::f16::FromRaw(0x0001).ToFloat32() == std::bit_cast<float>(0x33800000));
+    REQUIRE(Pica::f16::FromRaw(0x03FF).ToFloat32() == std::bit_cast<float>(0x387FC000));
+
+    // NaN
+    REQUIRE(std::bit_cast<u32>(Pica::f16::FromRaw(0x7E00)) == 0x7FC00000);
+    REQUIRE(std::bit_cast<u32>(Pica::f16::FromRaw(0xFFFF)) == 0xFFFFE000);
+}

--- a/src/video_core/pica_types.h
+++ b/src/video_core/pica_types.h
@@ -32,25 +32,39 @@ public:
     }
 
     static constexpr Float<M, E> FromRaw(u32 hex) {
+        constexpr s32 bias = 127 - ((1 << (E - 1)) - 1);
+
         Float<M, E> res;
+        s32 exponent = (hex >> M) & EXPONENT_MASK;
+        u32 mantissa = hex & MANTISSA_MASK;
+        const u32 fp32_sign = (hex >> (E + M)) << 31;
 
-        const s32 width = M + E + 1;
-        const s32 bias = 128 - (1 << (E - 1));
-        s32 exponent = (hex >> M) & ((1 << E) - 1);
-        const u32 mantissa = hex & ((1 << M) - 1);
-        const u32 sign = (hex >> (E + M)) << 31;
-
-        if (hex & ((1 << (width - 1)) - 1)) {
-            if (exponent == (1 << E) - 1)
-                exponent = 255;
-            else
-                exponent += bias;
-            hex = sign | (mantissa << (23 - M)) | (exponent << 23);
-        } else {
-            hex = sign;
+        if (exponent == 0 && mantissa == 0) {
+            // Zero
+            hex = fp32_sign;
+        } else [[likely]] {
+            if (exponent == 0) {
+                // PICA200 flushes denormals, but in our case, we want these values to be converted
+                // into 32-bit floats in a lossless way
+                // Denormals might map to normal values in fp32 and must be renormalized to have the
+                // exact same value
+                exponent = bias + 1;
+                while ((mantissa & (1 << M)) == 0) {
+                    exponent--;
+                    mantissa <<= 1;
+                }
+                mantissa &= MANTISSA_MASK;
+                hex = fp32_sign | (exponent << 23) | (mantissa << (23 - M));
+            } else if (exponent == EXPONENT_MASK) {
+                // Inf or NaN
+                hex = fp32_sign | (0xFF << 23) | (mantissa << (23 - M));
+            } else [[likely]] {
+                // Normal
+                hex = fp32_sign | ((bias + exponent) << 23) | (mantissa << (23 - M));
+            }
         }
 
-        std::memcpy(&res.value, &hex, sizeof(float));
+        res.value = std::bit_cast<float>(hex);
 
         return res;
     }
@@ -153,7 +167,6 @@ private:
     }
 };
 
-using f31 = Pica::Float<23, 7>;
 using f24 = Pica::Float<16, 7>;
 using f20 = Pica::Float<12, 7>;
 using f16 = Pica::Float<10, 5>;

--- a/src/video_core/pica_types.h
+++ b/src/video_core/pica_types.h
@@ -35,6 +35,14 @@ public:
         constexpr s32 bias = 127 - ((1 << (E - 1)) - 1);
 
         Float<M, E> res;
+
+#ifdef __FLT16_MANT_DIG__
+        if constexpr (M == 10 && E == 5) {
+            res.value = std::bit_cast<_Float16>(static_cast<u16>(hex));
+            return res;
+        }
+#endif
+
         s32 exponent = (hex >> M) & EXPONENT_MASK;
         u32 mantissa = hex & MANTISSA_MASK;
         const u32 fp32_sign = (hex >> (E + M)) << 31;


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Currently, PICA denormal/subnormal float-values were being converted into 32-bit floats in a somewhat lossy way due to the mishandling of denormals/subnormal values. Values that are considered denormal/subnormal to `fp{16,20,24}` might just be normal values in fp32 and should be properly renormalized in order for the fp32 value to match the same value as the `fp{16,20,24}`-type.

For example, `Pica::f16::FromRaw(0x03FF)`(a denormal fp16-value) returns `0.000061005` when it should be `0.000060976`.
https://float.exposed/0x03ff

I noticed some games have denormal fp16 values being converted inaccurately to fp32 for things like light-positions in games such as Pokémon Ultra Moon during the first opening cutscene with Lillie, the intro for Pokémon Omega Ruby, within matches of WWE All Stars, and likely some others.

In the case that the `_Float16`-type is available(GCC/Clang), `_Float16` will be used to help accelerate the conversion of fp16 types which should map to compiler-intrinsics that emit either hardware-instructions when available(such as on ARM) or a call to something like `__extendhfsf2`.

This should generally increase the precision of PICA values near `0.0` and includes some other tweaks to increase the precision/accuracy of converted floats like preserving NaN-payloads.