### PR TITLE
qt: Fix "New 3DS setup" and "Old 3DS setup" strings being erroneously swapped

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -2353,8 +2353,8 @@ void GMainWindow::OnMenuSetUpSystemFiles() {
 
     QRadioButton radio1(&dialog);
     QRadioButton radio2(&dialog);
-    QString new3dsSetupString = tr("Old 3DS setup");
-    QString old3dsSetupString = tr("New 3DS setup");
+    QString new3dsSetupString = tr("New 3DS setup");
+    QString old3dsSetupString = tr("Old 3DS setup");
     QString availableIcon = QStringLiteral("(\u2139\uFE0F) ");
     QString unavailableIcon = QStringLiteral("(\u26A0) ");
     QString installedIcon = QStringLiteral("(\u2705) ");


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Lol oops