### PR TITLE
ci: add a Linux aarch64 build

### DIFF
--- a/.ci/libretro-ci.yml
+++ b/.ci/libretro-ci.yml
@@ -57,6 +57,19 @@ stages:
 ##############################################################################
 #
 ################################### DESKTOPS #################################
+# Linux aarch64
+# No image override here: the :backports tag exists only for the amd64 image,
+# while the aarch64 one installs gcc-12 in its main Dockerfile, so the same
+# compiler the x64 job asks for is already on PATH.
+libretro-build-linux-aarch64:
+  extends:
+    - .core-defs
+    - .libretro-linux-cmake-aarch64
+  variables:
+    CORE_ARGS: ${BASE_CORE_ARGS} -DENABLE_LTO=OFF
+    CC: /usr/bin/gcc-12
+    CXX: /usr/bin/g++-12
+
 # Windows 64-bit
 libretro-build-windows-x64:
   extends:


### PR DESCRIPTION
Adds a `libretro-build-linux-aarch64` job to `.ci/libretro-ci.yml`, so the core lands in `nightly/linux/aarch64/` on the libretro buildbot. There is no Linux aarch64 build of azahar there today, while 160 other cores have one.

The job mirrors `libretro-build-linux-x64` and keeps its `CORE_ARGS` and `gcc-12`, with one deliberate difference: **no `image:` override**. The `:backports` tag the x64 job pins exists only for the amd64 image — `libretro-infrastructure/libretro-build-aarch64-ubuntu` publishes only `:latest` and `:main`, so mirroring it would kill the job in `prepare_executor` with `failed to resolve reference ...:backports: not found`. It is not needed either: that aarch64 image installs gcc-12 from `ppa:ubuntu-toolchain-r/test` in its main Dockerfile, so `/usr/bin/gcc-12` is already there.

### The build is clean on aarch64

Built natively on an aarch64 Linux machine (Snapdragon 7c / SC7180, Adreno 618, postmarketOS, GCC 15) with the CI's CMake arguments:

* **no source changes needed at all** — `azahar_libretro.so`, ELF 64-bit LSB shared object, ARM aarch64, 60 MB, zero errors

### But it does not run on this device, and I want to be upfront about that

With the core loaded in RetroArch (Asterix - The Mansions of the Gods, decrypted `.3ds`), emulation starts — the log shows services coming up, the Vulkan pipeline/shader disk cache being built — and then the process **deadlocks before producing a frame**. It is a genuine hang, not slowness: the process sits at 0 CPU ticks over 30s in state `S`, and stays there indefinitely.

`eu-stack` on the main thread puts it here:

```
#14 Vulkan::RendererVulkan::RenderToWindow(Vulkan::PresentWindow&, Layout::FramebufferLayout const&, bool)
#13..#10  (libretro / RetroArch frames)
#9..#6    (Vulkan driver — Mesa Turnip)
#5..#4    libc
#3..#0    do_sys_poll
```

so it is stuck waiting inside the presentation path. Everything below is Turnip, so this may well be a driver-side interaction rather than an azahar bug — I have other libretro cores rendering fine through both `glcore` and `vulkan` on this same machine, but none of them drive Vulkan the way azahar does.

I tried `citra_graphics_api = "OpenGL"` with RetroArch's `glcore` driver; the core stayed on Vulkan (auto-selection) and hung identically, so I could not get a comparison against the GL path.

**None of this blocks the CI job** — the buildbot only compiles cores, and the build is clean. I am reporting it so nobody is surprised when the resulting nightly turns out not to boot on an Adreno/Turnip device. If you would like, I can open this as a separate issue with the full log and a proper backtrace, or test a patch on this hardware.

**What I could not test:** the GitLab pipeline itself, since a GitHub PR does not trigger it.

*(One aside that cost me an hour and may be worth a note in the docs: `externals/teakra` is LFS-tracked, and on a machine without `git-lfs` its checkout fails half-way — leaving a directory that `git submodule status` reports as fine while `src/timer.cpp` is missing, so `git submodule update --init` then silently skips it forever. Setting `filter.lfs.smudge=cat` and `filter.lfs.required=false` in that submodule works around it.)*
