### PR TITLE
ci: add Linux aarch64 and Android x86_64 builds

### DIFF
--- a/.ci/libretro-ci.yml
+++ b/.ci/libretro-ci.yml
@@ -57,6 +57,19 @@ stages:
 ##############################################################################
 #
 ################################### DESKTOPS #################################
+# Linux aarch64
+# No image override here: the :backports tag exists only for the amd64 image,
+# while the aarch64 one installs gcc-12 in its main Dockerfile, so the same
+# compiler the x64 job asks for is already on PATH.
+libretro-build-linux-aarch64:
+  extends:
+    - .core-defs
+    - .libretro-linux-cmake-aarch64
+  variables:
+    CORE_ARGS: ${BASE_CORE_ARGS} -DENABLE_LTO=OFF
+    CC: /usr/bin/gcc-12
+    CXX: /usr/bin/g++-12
+
 # Windows 64-bit
 libretro-build-windows-x64:
   extends:

--- a/.ci/libretro-ci.yml
+++ b/.ci/libretro-ci.yml
@@ -123,6 +123,19 @@ android-arm64-v8a:
     paths:
       - $LIBNAME
 
+# Android x86_64
+android-x86_64:
+  extends:
+    - .libretro-android-cmake-x86_64
+    - .core-defs
+  variables:
+    ANDROID_NDK_VERSION: 27.3.13750724
+    NDK_ROOT: /android-sdk-linux/ndk/$ANDROID_NDK_VERSION
+    LIBNAME: ${CORENAME}_libretro.so
+  artifacts:
+    paths:
+      - $LIBNAME
+
 # iOS arm64
 libretro-build-ios-arm64:
   extends:


### PR DESCRIPTION
Two jobs missing from `.ci/libretro-ci.yml`, so the buildbot ships neither target.

**Linux aarch64** mirrors the x64 job, minus its `:backports` image override — that tag exists only for the amd64 image, while the aarch64 image ships gcc-12 in its main Dockerfile.

**Android x86_64** mirrors the arm64-v8a job (same NDK pin and `LIBNAME` override). It is the ABI used by Android emulators and x86 Chromebooks. 32-bit x86 is deliberately left out — the core needs a 64-bit address space.