### PR TITLE
Add bundle ROM support (.bcia/.bcci/.bcxi)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -106,3 +106,6 @@
 [submodule "externals/cryptopp"]
 	path = externals/cryptopp
 	url = https://github.com/cryptopp-modern/cryptopp-modern.git
+[submodule "microtar"]
+	path = externals/microtar
+	url = https://github.com/azahar-emu/microtar

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -156,6 +156,10 @@ else()
     target_compile_definitions(microprofile INTERFACE MICROPROFILE_ENABLED=0)
 endif()
 
+# microtar
+add_library(microtar STATIC ./microtar/src/microtar.c)
+target_include_directories(microtar PUBLIC ./microtar/src)
+
 # Nihstro
 add_library(nihstro-headers INTERFACE)
 target_include_directories(nihstro-headers INTERFACE ./nihstro/include)

--- a/src/android/app/src/main/java/org/citra/citra_emu/model/Game.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/model/Game.kt
@@ -97,7 +97,10 @@ class Game(
 
     companion object {
         val extensions: Set<String> = HashSet(
-            listOf("3dsx", "app", "axf", "cci", "cxi", "elf", "z3dsx", "zcci", "zcxi", "3ds")
+            listOf(
+                "3dsx", "app", "axf", "cci", "cxi", "elf",
+                "z3dsx", "zcci", "zcxi", "bcci", "bcxi", "3ds"
+            )
         )
     }
 }

--- a/src/android/app/src/main/jni/game_info.cpp
+++ b/src/android/app/src/main/jni/game_info.cpp
@@ -50,34 +50,13 @@ GameInfoData* GetNewGameInfoData(const std::string& path) {
 
     std::vector<u8> smdh = [program_id, &loader, &is_encrypted]() -> std::vector<u8> {
         std::vector<u8> original_smdh;
-        auto result = loader->ReadIcon(original_smdh);
+        auto result = loader->ReadIcon(original_smdh, true);
         if (result != Loader::ResultStatus::Success) {
             is_encrypted = result == Loader::ResultStatus::ErrorEncrypted;
             return {};
         }
 
-        if (program_id < 0x00040000'00000000 || program_id > 0x00040000'FFFFFFFF)
-            return original_smdh;
-
-        u64 update_tid = (program_id & 0xFFFFFFFFULL) | UPDATE_TID_HIGH;
-        std::string update_path =
-            Service::AM::GetTitleContentPath(Service::FS::MediaType::SDMC, update_tid);
-
-        if (!FileUtil::Exists(update_path))
-            return original_smdh;
-
-        std::unique_ptr<Loader::AppLoader> update_loader = Loader::GetLoader(update_path);
-
-        if (!update_loader)
-            return original_smdh;
-
-        std::vector<u8> update_smdh;
-        result = update_loader->ReadIcon(update_smdh);
-        if (result != Loader::ResultStatus::Success) {
-            is_encrypted = result == Loader::ResultStatus::ErrorEncrypted;
-            return original_smdh;
-        }
-        return update_smdh;
+        return original_smdh;
     }();
 
     GameInfoData* gid = new GameInfoData();
@@ -89,7 +68,8 @@ GameInfoData* GetNewGameInfoData(const std::string& path) {
     gid->loaded = true;
     gid->is_encrypted = is_encrypted;
     gid->title_id = program_id;
-    gid->file_type = Loader::GetFileTypeString(loader->GetFileType(), loader->IsFileCompressed());
+    gid->file_type = Loader::GetFileTypeString(loader->GetFileType(), loader->IsFileCompressed(),
+                                               loader->IsFileBundle());
     gid->is_insertable = loader->GetFileType() == Loader::FileType::CCI;
 
     return gid;

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -465,7 +465,7 @@
     <!-- ROM loading errors -->
     <string name="loader_error_generic_title">Error loading application</string>
     <string name="loader_error_invalid_format">Invalid application format</string>
-    <string name="loader_error_invalid_format_description"><![CDATA[The application file format not supported.<br>Please make sure you are using one of the compatible file formats:<ul><li>Cartridge images: <b>.cci/.zcci/.3ds</b></li><li>Installable archives: <b>.cia/.zcia</b></li><li>Homebrew titles: <b>.3dsx/.z3dsx</b></li><li>NCCH containers: <b>.cxi/.zcxi/.app</b></li><li>ELF files: <b>.elf/.axf</b></li></ul>]]></string>
+    <string name="loader_error_invalid_format_description"><![CDATA[The application file format not supported.<br>Please make sure you are using one of the compatible file formats:<ul><li>Cartridge images: <b>.cci/.zcci/.bcci/.3ds</b></li><li>Installable archives: <b>.cia/.zcia/.bcia</b></li><li>Homebrew titles: <b>.3dsx/.z3dsx</b></li><li>NCCH containers: <b>.cxi/.zcxi/.bcxi/.app</b></li><li>ELF files: <b>.elf/.axf</b></li></ul>]]></string>
     <string name="loader_error_invalid_system_mode">Invalid system mode</string>
     <string name="loader_error_invalid_system_mode_description">New 3DS exclusive applications cannot be loaded without enabling the New 3DS mode.</string>
     <string name="loader_error_applying_patches">Error applying patches</string>

--- a/src/citra_libretro/environment.cpp
+++ b/src/citra_libretro/environment.cpp
@@ -269,7 +269,7 @@ void retro_get_system_info(struct retro_system_info* info) {
     info->library_name = "Azahar";
     info->library_version = Common::g_build_fullname;
     info->need_fullpath = true;
-    info->valid_extensions = "3ds|3dsx|z3dsx|elf|axf|cci|zcci|cxi|zcxi|app";
+    info->valid_extensions = "3ds|3dsx|z3dsx|elf|axf|cci|zcci|cxi|zcxi|app|bcci|bcxi";
 }
 
 void LibRetro::SubmitAudio(const int16_t* data, size_t frames) {

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -1378,9 +1378,10 @@ bool GMainWindow::LoadROM(const QString& filename) {
         QString invalid_format_description =
             tr("The application file format not supported.<br>Please make sure you are using one "
                "of the compatible file formats:<ul><li>Cartridge images: "
-               "<b>.cci/.zcci/.3ds</b></li><li>Installable archives: "
-               "<b>.cia/.zcia</b></li><li>Homebrew titles: <b>.3dsx/.z3dsx</b></li><li>NCCH "
-               "containers: <b>.cxi/.zcxi/.app</b></li><li>ELF files: <b>.elf/.axf</b></li></ul>");
+               "<b>.cci/.zcci/.bcci/.3ds</b></li><li>Installable archives: "
+               "<b>.cia/.zcia/.bcia</b></li><li>Homebrew titles: <b>.3dsx/.z3dsx</b></li><li>NCCH "
+               "containers: <b>.cxi/.zcxi/.bcxi/.app</b></li><li>ELF files: "
+               "<b>.elf/.axf</b></li></ul>");
 
         switch (result) {
         case Core::System::ResultStatus::ErrorGetLoader:
@@ -1450,7 +1451,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
     }
 
     std::string title;
-    system.GetAppLoader().ReadTitle(title);
+    system.GetAppLoader().ReadTitle(title, true);
     game_title = QString::fromStdString(title);
     UpdateWindowTitle();
 
@@ -2139,7 +2140,7 @@ void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& ga
     // Get title from game file
     const auto loader = Loader::GetLoader(game_path);
     std::string game_title = fmt::format("{:016X}", program_id);
-    if (loader->ReadTitle(game_title) != Loader::ResultStatus::Success) {
+    if (loader->ReadTitle(game_title, false) != Loader::ResultStatus::Success) {
         game_title = fmt::format("{:016x}", program_id);
     }
 
@@ -2153,7 +2154,7 @@ void GMainWindow::OnGameListCreateShortcut(u64 program_id, const std::string& ga
 
     // Get icon from game file
     std::vector<u8> icon_image_file;
-    if (loader->ReadIcon(icon_image_file) != Loader::ResultStatus::Success) {
+    if (loader->ReadIcon(icon_image_file, false) != Loader::ResultStatus::Success) {
         LOG_WARNING(Frontend, "Could not read icon from {:s}", game_path);
     }
 
@@ -2407,9 +2408,10 @@ void GMainWindow::OnMenuSetUpSystemFiles() {
 }
 
 void GMainWindow::OnMenuInstallCIA() {
-    QStringList filepaths = QFileDialog::getOpenFileNames(
-        this, tr("Load Files"), UISettings::values.roms_path,
-        tr("3DS Installation File (*.cia *.zcia)") + QStringLiteral(";;") + tr("All Files (*.*)"));
+    QStringList filepaths =
+        QFileDialog::getOpenFileNames(this, tr("Load Files"), UISettings::values.roms_path,
+                                      tr("3DS Installation File (*.cia *.zcia *.bcia)") +
+                                          QStringLiteral(";;") + tr("All Files (*.*)"));
 
     if (filepaths.isEmpty()) {
         return;
@@ -3996,8 +3998,9 @@ static bool IsSingleFileDropEvent(const QMimeData* mime) {
     return mime->hasUrls() && mime->urls().length() == 1;
 }
 
-static const std::array<std::string, 11> AcceptedExtensions = {
-    "cci", "cxi", "bin", "3dsx", "app", "elf", "axf", "zcci", "zcxi", "z3dsx", "3ds"};
+static const std::array<std::string, 13> AcceptedExtensions = {
+    "cci",  "cxi",  "bin",   "3dsx", "app",  "elf", "axf",
+    "zcci", "zcxi", "z3dsx", "3ds",  "bcci", "bcxi"};
 
 static bool IsCorrectFileExtension(const QMimeData* mime) {
     const QString& filename = mime->urls().at(0).toLocalFile();

--- a/src/citra_qt/configuration/configure_per_game.cpp
+++ b/src/citra_qt/configuration/configure_per_game.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 Citra Emulator Project / Azahar Emulator Project
+// Copyright 2022-2026 Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -159,11 +159,11 @@ void ConfigurePerGame::LoadConfiguration() {
     }
 
     std::string title;
-    if (loader->ReadTitle(title) == Loader::ResultStatus::Success)
+    if (loader->ReadTitle(title, false) == Loader::ResultStatus::Success)
         ui->display_name->setText(QString::fromStdString(title));
 
     std::vector<u8> bytes;
-    if (loader->ReadIcon(bytes) == Loader::ResultStatus::Success) {
+    if (loader->ReadIcon(bytes, false) == Loader::ResultStatus::Success) {
         scene->clear();
 
         QPixmap map = GetQPixmapFromSMDH(bytes);
@@ -173,8 +173,8 @@ void ConfigurePerGame::LoadConfiguration() {
 
     ui->display_filepath->setText(QString::fromStdString(filename));
 
-    ui->display_format->setText(QString::fromStdString(
-        Loader::GetFileTypeString(loader->GetFileType(), loader->IsFileCompressed())));
+    ui->display_format->setText(QString::fromStdString(Loader::GetFileTypeString(
+        loader->GetFileType(), loader->IsFileCompressed(), loader->IsFileBundle())));
 
     const auto valueText = ReadableByteSize(FileUtil::GetSize(filename));
     ui->display_size->setText(valueText);

--- a/src/citra_qt/discord_impl.cpp
+++ b/src/citra_qt/discord_impl.cpp
@@ -43,7 +43,7 @@ void DiscordImpl::Update(bool is_powered_on) {
 
     std::string title;
     if (is_powered_on) {
-        system.GetAppLoader().ReadTitle(title);
+        system.GetAppLoader().ReadTitle(title, true);
         title = truncate("Playing: " + title);
     }
 

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -1126,9 +1126,9 @@ void GameList::LoadInterfaceLayout() {
 }
 
 const QStringList GameList::supported_file_extensions = {
-    QStringLiteral("3dsx"), QStringLiteral("elf"), QStringLiteral("axf"),   QStringLiteral("cci"),
-    QStringLiteral("cxi"),  QStringLiteral("app"), QStringLiteral("z3dsx"), QStringLiteral("zcci"),
-    QStringLiteral("zcxi"), QStringLiteral("3ds"),
+    QStringLiteral("3dsx"), QStringLiteral("elf"),  QStringLiteral("axf"),   QStringLiteral("cci"),
+    QStringLiteral("cxi"),  QStringLiteral("app"),  QStringLiteral("z3dsx"), QStringLiteral("zcci"),
+    QStringLiteral("zcxi"), QStringLiteral("bcci"), QStringLiteral("3ds"),
 };
 
 void GameList::RefreshGameDirectory() {

--- a/src/citra_qt/game_list_worker.cpp
+++ b/src/citra_qt/game_list_worker.cpp
@@ -70,23 +70,7 @@ void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsign
             loader->ReadExtdataId(extdata_id);
 
             std::vector<u8> smdh;
-            // Look for an update icon if available
-            if (!(program_id & ~0x00040000FFFFFFFF)) {
-                std::string update_path = Service::AM::GetTitleContentPath(
-                    Service::FS::MediaType::SDMC, program_id | 0x0000000E00000000);
-                if (FileUtil::Exists(update_path)) {
-                    std::unique_ptr<Loader::AppLoader> update_loader =
-                        Loader::GetLoader(update_path);
-                    if (update_loader) {
-                        update_loader->ReadIcon(smdh);
-                    }
-                }
-            }
-
-            if (!Loader::IsValidSMDH(smdh)) {
-                // Read the original smdh if there is no valid update smdh
-                loader->ReadIcon(smdh);
-            }
+            loader->ReadIcon(smdh, true);
 
             const auto system_title = ((program_id >> 32) & 0xFFFFFFFF) == 0x00040010;
             if (Loader::IsValidSMDH(smdh)) {
@@ -117,8 +101,9 @@ void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsign
                                          loader->GetFileType() == Loader::FileType::CCI),
                     new GameListItemCompat(compatibility),
                     new GameListItemRegion(smdh),
-                    new GameListItem(QString::fromStdString(Loader::GetFileTypeString(
-                        loader->GetFileType(), loader->IsFileCompressed()))),
+                    new GameListItem(QString::fromStdString(
+                        Loader::GetFileTypeString(loader->GetFileType(), loader->IsFileCompressed(),
+                                                  loader->IsFileBundle()))),
                     new GameListItemSize(FileUtil::GetSize(physical_name)),
                     new GameListItemPlayTime(play_time_manager.GetPlayTime(program_id)),
                 },

--- a/src/citra_qt/loading_screen.cpp
+++ b/src/citra_qt/loading_screen.cpp
@@ -115,14 +115,14 @@ void LoadingScreen::Prepare(Loader::AppLoader& loader) {
     std::vector<u8> buffer;
     // TODO when banner becomes supported, decode it and add it as a movie
 
-    if (loader.ReadIcon(buffer) == Loader::ResultStatus::Success) {
+    if (loader.ReadIcon(buffer, true) == Loader::ResultStatus::Success) {
         QPixmap icon = GetQPixmapFromSMDH(buffer);
         ui->icon->setPixmap(icon);
     } else {
         ui->icon->clear();
     }
     std::string title;
-    if (loader.ReadTitle(title) != Loader::ResultStatus::Success) {
+    if (loader.ReadTitle(title, true) != Loader::ResultStatus::Success) {
         u64 program_id;
         if (loader.ReadProgramId(program_id) == Loader::ResultStatus::Success) {
             title = fmt::format("{:016x}", program_id);

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -88,6 +88,8 @@ add_library(citra_common STATIC EXCLUDE_FROM_ALL
     string_util.cpp
     string_util.h
     swap.h
+    tar_file.cpp
+    tar_file.h
     texture.cpp
     texture.h
     thread.cpp
@@ -107,7 +109,7 @@ add_library(citra_common STATIC EXCLUDE_FROM_ALL
     x64/xbyak_util.h
     zstd_compression.cpp
     zstd_compression.h
-)
+  )
 
 target_include_directories(citra_common PUBLIC ${CMAKE_BINARY_DIR}/src)
 
@@ -155,7 +157,7 @@ endif()
 create_target_directory_groups(citra_common)
 
 target_link_libraries(citra_common PUBLIC fmt library-headers microprofile Boost::boost Boost::serialization Boost::iostreams)
-target_link_libraries(citra_common PRIVATE cryptopp zstd)
+target_link_libraries(citra_common PRIVATE cryptopp microtar zstd)
 
 if ("x86_64" IN_LIST ARCHITECTURE)
     target_link_libraries(citra_common PRIVATE xbyak)

--- a/src/common/file_derived.h
+++ b/src/common/file_derived.h
@@ -87,7 +87,7 @@ private:
 // File that exposes a fragment [sub_file_offset, sub_file_offset + sub_file_size) of
 // the underlying file. The file can only be opened in replace or read modes, without
 // create, truncate or append. Resizing is only possible if new size is smaller.
-class SubIOFile final : public IOFileBase {
+class SubIOFile : public IOFileBase {
 public:
     SubIOFile();
 

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -306,6 +306,7 @@ public:
         CryptoFile,
         Z3DSWriteIOFile,
         Z3DSReadIOFile,
+        TarIOFile,
 
         MAX,
     };
@@ -335,6 +336,7 @@ public:
             "CryptoFile",
             "Z3DSWriteIOFile",
             "Z3DSReadIOFile",
+            "TarIOFile",
         }};
 
         std::string ret;

--- a/src/common/tar_file.cpp
+++ b/src/common/tar_file.cpp
@@ -1,0 +1,170 @@
+// Copyright 2026 Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <memory>
+#include <optional>
+#include <ranges>
+#include <tuple>
+#include <unordered_set>
+#include <vector>
+#include "common/file_derived.h"
+#include "common/tar_file.h"
+
+#include "microtar.h"
+
+namespace FileUtil {
+
+struct TarArchiveImpl {
+    std::unique_ptr<IOFileBase> file;
+    mtar_t tar;
+    bool m_good;
+
+    std::vector<TarArchive::TarFileInfo> file_infos;
+
+    TarArchiveImpl() {
+        file = std::make_unique<NullIOFile>();
+        m_good = false;
+    }
+
+    TarArchiveImpl(const std::string& filename) {
+        file = std::make_unique<IOFile>(filename, "rb");
+        Open();
+    }
+
+    TarArchiveImpl(std::unique_ptr<IOFileBase>&& _file) {
+        file = std::move(_file);
+        Open();
+    }
+
+    void Open() {
+        file->Seek(0, SEEK_SET);
+        memset(&tar, 0, sizeof(tar));
+
+        tar.read = [](mtar_t* tar, void* data, size_t size) {
+            size_t res = reinterpret_cast<TarArchiveImpl*>(tar->stream)
+                             ->file->ReadBytes(reinterpret_cast<char*>(data), size);
+            return static_cast<int>(res == size ? MTAR_ESUCCESS : MTAR_EWRITEFAIL);
+        };
+        tar.write = [](mtar_t* tar, const void* data, size_t size) {
+            size_t res = reinterpret_cast<TarArchiveImpl*>(tar->stream)
+                             ->file->WriteBytes(reinterpret_cast<const char*>(data), size);
+            return static_cast<int>(res == size ? MTAR_ESUCCESS : MTAR_EREADFAIL);
+        };
+        tar.seek = [](mtar_t* tar, size_t set_offset) {
+            return static_cast<int>(
+                reinterpret_cast<TarArchiveImpl*>(tar->stream)->file->Seek(set_offset, SEEK_SET)
+                    ? MTAR_ESUCCESS
+                    : MTAR_ESEEKFAIL);
+        };
+        tar.close = [](mtar_t* tar) {
+            // NO-OP: This is only used with mtar_close to close the stream, but we have ownership
+            // of the file and it will be auto-closed when we are destroyed.
+            return static_cast<int>(MTAR_ESUCCESS);
+        };
+        tar.stream = this;
+
+        mtar_header_t h;
+        m_good = mtar_read_header(&tar, &h) == 0;
+    }
+
+    const std::vector<TarArchive::TarFileInfo>& GetFileList() {
+        if (!m_good) {
+            return {};
+        }
+        if (!file_infos.empty()) {
+            return file_infos;
+        }
+        if (mtar_rewind(&tar) != MTAR_ESUCCESS) {
+            m_good = false;
+            return {};
+        }
+
+        mtar_header_t h;
+        int err = MTAR_ESUCCESS;
+        constexpr size_t MAX_FILES = 50;
+
+        while ((err = mtar_read_header(&tar, &h)) != MTAR_ENULLRECORD &&
+               file_infos.size() < MAX_FILES) {
+            if (err != MTAR_ESUCCESS) {
+                file_infos.clear();
+                m_good = false;
+                return {};
+            }
+
+            constexpr size_t TAR_HEADER_SIZE = 512;
+
+            file_infos.emplace_back(TarArchive::TarFileInfo{
+                .name = h.name,
+                // File starts at the current header position plus TAR_HEADER_SIZE
+                .position = file->Tell() + TAR_HEADER_SIZE,
+                .size = h.size});
+
+            if (mtar_next(&tar) != MTAR_ESUCCESS) {
+                file_infos.clear();
+                m_good = false;
+                return {};
+            }
+        }
+
+        std::unordered_set<std::string> temp;
+        bool has_duplicates =
+            std::ranges::any_of(file_infos, [&temp](const TarArchive::TarFileInfo& file) {
+                return !temp.insert(file.name).second;
+            });
+        if (has_duplicates) {
+            file_infos.clear();
+            m_good = false;
+            return {};
+        }
+
+        return file_infos;
+    }
+
+    std::unique_ptr<FileUtil::IOFileBase> OpenSubFile(const std::string& filename) {
+        if (file_infos.empty() || !m_good) {
+            return std::make_unique<FileUtil::NullIOFile>();
+        }
+        auto it = std::find_if(
+            file_infos.begin(), file_infos.end(),
+            [&filename](const TarArchive::TarFileInfo& info) { return info.name == filename; });
+        if (it == file_infos.end()) {
+            return std::unique_ptr<FileUtil::NullIOFile>();
+        }
+
+        auto ret = std::make_unique<FileUtil::TarIOFile>(file->OpenCopy(), it->position, it->size);
+        if (!ret->IsGood()) {
+            return std::unique_ptr<FileUtil::NullIOFile>();
+        }
+
+        return ret;
+    }
+};
+
+TarArchive::TarArchive() {
+    impl = std::make_unique<TarArchiveImpl>();
+}
+
+TarArchive::~TarArchive() {}
+
+TarArchive::TarArchive(const std::string& filename) {
+    impl = std::make_unique<TarArchiveImpl>(filename);
+}
+
+TarArchive::TarArchive(std::unique_ptr<IOFileBase>&& _file) {
+    impl = std::make_unique<TarArchiveImpl>(std::move(_file));
+}
+
+bool TarArchive::IsGood() {
+    return impl->m_good;
+}
+
+const std::vector<TarArchive::TarFileInfo>& TarArchive::GetFileList() {
+    return impl->GetFileList();
+}
+
+std::unique_ptr<FileUtil::IOFileBase> TarArchive::OpenSubFile(const std::string& filename) {
+    return impl->OpenSubFile(filename);
+}
+
+} // namespace FileUtil

--- a/src/common/tar_file.h
+++ b/src/common/tar_file.h
@@ -1,0 +1,76 @@
+// Copyright 2026 Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
+#include <common/file_derived.h>
+#include <common/file_util.h>
+
+namespace FileUtil {
+
+struct TarArchiveImpl;
+
+// Derived from SubIOFile so that callers can detect if a file comes
+// from a TarArchive. Should not override anything other than MyType().
+class TarIOFile : public SubIOFile {
+public:
+    using SubIOFile::SubIOFile;
+
+protected:
+    IOType::Type MyType() const override {
+        return IOType::Type::TarIOFile;
+    }
+
+private:
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int) {
+        ar& boost::serialization::base_object<IOFileBase>(*this);
+    }
+    friend class boost::serialization::access;
+};
+
+class TarArchive {
+public:
+    struct TarFileInfo {
+        std::string name;
+        std::size_t position;
+        std::size_t size;
+    };
+
+    static std::unique_ptr<TarArchive> OpenTarArchive(const std::string& filename) {
+        std::unique_ptr<TarArchive> ret = std::make_unique<TarArchive>(filename);
+        return ret->IsGood() ? std::move(ret) : nullptr;
+    }
+
+    static std::unique_ptr<TarArchive> OpenTarArchive(std::unique_ptr<IOFileBase>&& file) {
+        std::unique_ptr<TarArchive> ret = std::make_unique<TarArchive>(std::move(file));
+        return ret->IsGood() ? std::move(ret) : nullptr;
+    }
+
+    TarArchive();
+
+    ~TarArchive();
+
+    TarArchive(const std::string& filename);
+
+    TarArchive(std::unique_ptr<IOFileBase>&& file);
+
+    bool IsGood();
+
+    const std::vector<TarArchive::TarFileInfo>& GetFileList();
+
+    std::unique_ptr<FileUtil::IOFileBase> OpenSubFile(const std::string& filename);
+
+private:
+    std::unique_ptr<TarArchiveImpl> impl;
+};
+
+} // namespace FileUtil
+
+BOOST_CLASS_EXPORT_KEY(FileUtil::TarIOFile)

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -11,8 +11,10 @@
 #include "common/arch.h"
 #include "common/logging/log.h"
 #include "common/settings.h"
+#include "common/tar_file.h"
 #include "core/arm/arm_interface.h"
 #include "core/arm/exclusive_monitor.h"
+#include "core/hle/service/am/am.h"
 #include "core/hle/service/cam/cam.h"
 #include "core/hle/service/hid/hid.h"
 #include "core/hle/service/ir/ir_user.h"
@@ -434,6 +436,22 @@ System::ResultStatus System::Load(Frontend::EmuWindow& emu_window, const std::st
 
     if (restore_ipc_recorder) {
         kernel->RestoreIPCRecorder(std::move(restore_ipc_recorder));
+    }
+
+    if (auto am = Service::AM::GetModule(*this)) {
+        bool bundle_registered = false;
+        if (!GetCartridge().empty()) {
+            auto tar = FileUtil::TarArchive::OpenTarArchive(GetCartridge());
+            if (tar) {
+                tar.reset();
+                am->GetBundleCIAHandler()->RegisterBundle(GetCartridge());
+                bundle_registered = true;
+            }
+        }
+        if (!bundle_registered) {
+            app_loader->LoadBundle();
+        }
+        am->ScanForAllTitles();
     }
 
     std::shared_ptr<Kernel::Process> process;

--- a/src/core/file_sys/archive_ncch.cpp
+++ b/src/core/file_sys/archive_ncch.cpp
@@ -9,6 +9,7 @@
 #include "bad_word_list.app.romfs.h"
 #include "common/archives.h"
 #include "common/common_types.h"
+#include "common/file_derived.h"
 #include "common/file_util.h"
 #include "common/logging/log.h"
 #include "common/settings.h"
@@ -87,7 +88,7 @@ ResultVal<std::unique_ptr<FileBackend>> NCCHArchive::OpenFile(const Path& path, 
     NCCHFilePath openfile_path;
     std::memcpy(&openfile_path, binary.data(), sizeof(NCCHFilePath));
 
-    std::string file_path;
+    std::unique_ptr<FileUtil::IOFileBase> file = std::make_unique<FileUtil::NullIOFile>();
 
     if (media_type == Service::FS::MediaType::GameCard) {
         const auto& cartridge = Core::System::GetInstance().GetCartridge();
@@ -102,23 +103,24 @@ ResultVal<std::unique_ptr<FileBackend>> NCCHArchive::OpenFile(const Path& path, 
             card_program_id != title_id) {
             return ResultNotFound;
         }
-        file_path = cartridge;
+
+        file = std::make_unique<FileUtil::IOFile>(cartridge, "rb");
     } else {
         if (Settings::values.is_new_3ds) {
             // Try the New 3DS specific variant first.
-            file_path = Service::AM::GetTitleContentPath(media_type, title_id | 0x20000000,
-                                                         openfile_path.content_index);
+            file = Service::AM::GetTitleContent(media_type, title_id | 0x20000000,
+                                                openfile_path.content_index);
         }
-        if (!Settings::values.is_new_3ds || !FileUtil::Exists(file_path)) {
-            file_path =
-                Service::AM::GetTitleContentPath(media_type, title_id, openfile_path.content_index);
+        if (!Settings::values.is_new_3ds || !file->IsOpen()) {
+            file = Service::AM::GetTitleContent(media_type, title_id, openfile_path.content_index);
         }
     }
 
-    auto ncch_container = NCCHContainer(file_path, 0, openfile_path.content_index);
+    auto ncch_container = NCCHContainer(file.get(), openfile_path.content_index);
+    file.reset();
 
     Loader::ResultStatus result;
-    std::unique_ptr<FileBackend> file;
+    std::unique_ptr<FileBackend> file_backend;
 
     // NCCH RomFS
     if (openfile_path.filepath_type == NCCHFilePathType::RomFS) {
@@ -126,7 +128,8 @@ ResultVal<std::unique_ptr<FileBackend>> NCCHArchive::OpenFile(const Path& path, 
 
         result = ncch_container.ReadRomFS(romfs_file);
         std::unique_ptr<DelayGenerator> delay_generator = std::make_unique<RomFSDelayGenerator>();
-        file = std::make_unique<IVFCFile>(std::move(romfs_file), std::move(delay_generator));
+        file_backend =
+            std::make_unique<IVFCFile>(std::move(romfs_file), std::move(delay_generator));
     } else if (openfile_path.filepath_type == NCCHFilePathType::Code ||
                openfile_path.filepath_type == NCCHFilePathType::ExeFS) {
         std::vector<u8> buffer;
@@ -143,7 +146,7 @@ ResultVal<std::unique_ptr<FileBackend>> NCCHArchive::OpenFile(const Path& path, 
             smdh->region_lockout = REGION_LOCKOUT_REGION_FREE;
         }
         std::unique_ptr<DelayGenerator> delay_generator = std::make_unique<ExeFSDelayGenerator>();
-        file = std::make_unique<NCCHFile>(std::move(buffer), std::move(delay_generator));
+        file_backend = std::make_unique<NCCHFile>(std::move(buffer), std::move(delay_generator));
     } else {
         LOG_ERROR(Service_FS, "Unknown NCCH archive type {}!", openfile_path.filepath_type);
         result = Loader::ResultStatus::Error;
@@ -213,7 +216,7 @@ ResultVal<std::unique_ptr<FileBackend>> NCCHArchive::OpenFile(const Path& path, 
         return ResultNotFound;
     }
 
-    return file;
+    return file_backend;
 }
 
 Result NCCHArchive::DeleteFile(const Path& path) const {

--- a/src/core/file_sys/archive_selfncch.cpp
+++ b/src/core/file_sys/archive_selfncch.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2024 Citra Emulator Project / Azahar Emulator Project
+// Copyright 2017-2026 Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -280,7 +280,7 @@ void ArchiveFactory_SelfNCCH::Register(Loader::AppLoader& app_loader) {
 
     std::vector<u8> buffer;
 
-    if (Loader::ResultStatus::Success == app_loader.ReadIcon(buffer))
+    if (Loader::ResultStatus::Success == app_loader.ReadIcon(buffer, false))
         data.icon = std::make_shared<std::vector<u8>>(std::move(buffer));
 
     buffer.clear();

--- a/src/core/file_sys/cia_container.cpp
+++ b/src/core/file_sys/cia_container.cpp
@@ -4,6 +4,7 @@
 
 #include <cryptopp/sha.h>
 #include "common/alignment.h"
+#include "common/file_derived.h"
 #include "common/file_util.h"
 #include "common/logging/log.h"
 #include "core/file_sys/cia_container.h"
@@ -128,6 +129,11 @@ Loader::ResultStatus CIAContainer::Load(FileUtil::IOFileBase* file) {
     return Loader::ResultStatus::Success;
 }
 
+Loader::ResultStatus CIAContainer::Load(std::unique_ptr<FileUtil::IOFileBase>&& file) {
+    cia_io_file = std::move(file);
+    return Load(cia_io_file.get());
+}
+
 Loader::ResultStatus CIAContainer::Load(std::span<const u8> file_data) {
     Loader::ResultStatus result = LoadHeader(file_data);
     if (result != Loader::ResultStatus::Success)
@@ -215,6 +221,10 @@ Ticket& CIAContainer::GetTicket() {
     return cia_ticket;
 }
 
+const Ticket& CIAContainer::GetTicket() const {
+    return cia_ticket;
+}
+
 const TitleMetadata& CIAContainer::GetTitleMetadata() const {
     return cia_tmd;
 }
@@ -288,6 +298,24 @@ u64 CIAContainer::GetContentSize(std::size_t index) const {
     }
 
     return cia_tmd.GetContentSizeByIndex(index);
+}
+
+std::unique_ptr<FileUtil::IOFileBase> CIAContainer::GetContentFile(std::size_t index) const {
+    if (!cia_io_file) {
+        LOG_ERROR(Service_FS, "missing cia_io_file");
+        return std::make_unique<FileUtil::NullIOFile>();
+    }
+    if (cia_tmd.HasEncryptedContent(&cia_header)) {
+        LOG_ERROR(Service_FS, "not supported for encrypted CIA files");
+        return std::make_unique<FileUtil::NullIOFile>();
+    }
+    u64 size = GetContentSize(index);
+    u64 offset = GetContentOffset(index);
+    if (!size) {
+        LOG_ERROR(Service_FS, "index {} not found", index);
+        return std::make_unique<FileUtil::NullIOFile>();
+    }
+    return std::make_unique<FileUtil::SubIOFile>(cia_io_file->OpenCopy(), offset, size);
 }
 
 void CIAContainer::Print() const {

--- a/src/core/file_sys/cia_container.h
+++ b/src/core/file_sys/cia_container.h
@@ -65,6 +65,8 @@ public:
     // Load whole CIAs outright
     Loader::ResultStatus Load(const FileBackend& backend);
     Loader::ResultStatus Load(FileUtil::IOFileBase* file);
+    Loader::ResultStatus Load(
+        std::unique_ptr<FileUtil::IOFileBase>&& file); // Allows calling GetContentFile
     Loader::ResultStatus Load(std::span<const u8> header_data);
 
     // Load parts of CIAs (for CIAs streamed in)
@@ -78,6 +80,7 @@ public:
 
     const CIAHeader* GetHeader();
     Ticket& GetTicket();
+    const Ticket& GetTicket() const;
     const TitleMetadata& GetTitleMetadata() const;
     std::array<u64, 0x30>& GetDependencies();
     u32 GetCoreVersion() const;
@@ -95,6 +98,8 @@ public:
     u32 GetMetadataSize() const;
     u64 GetTotalContentSize() const;
     u64 GetContentSize(std::size_t index = 0) const;
+
+    std::unique_ptr<FileUtil::IOFileBase> GetContentFile(std::size_t index = 0) const;
 
     void Print() const;
 
@@ -114,6 +119,7 @@ private:
     std::unique_ptr<Loader::SMDH> cia_smdh;
     Ticket cia_ticket;
     TitleMetadata cia_tmd;
+    std::unique_ptr<FileUtil::IOFileBase> cia_io_file;
 };
 
 } // namespace FileSys

--- a/src/core/file_sys/ncch_container.cpp
+++ b/src/core/file_sys/ncch_container.cpp
@@ -11,6 +11,7 @@
 #include "common/common_types.h"
 #include "common/file_derived.h"
 #include "common/logging/log.h"
+#include "common/tar_file.h"
 #include "core/core.h"
 #include "core/file_sys/layered_fs.h"
 #include "core/file_sys/ncch_container.h"
@@ -135,6 +136,21 @@ std::unique_ptr<FileUtil::IOFileBase> NCCHContainer::AutoOpenNCCHNCSD(
 
     std::unique_ptr<FileUtil::IOFileBase> file = in_file->OpenCopy();
 
+    // Check if it is a bundle
+    if (auto tar = FileUtil::TarArchive::OpenTarArchive(file->OpenCopy())) {
+        auto files = tar->GetFileList();
+        for (const auto& f : files) {
+            if (f.name.ends_with(".cci") || f.name.ends_with(".zcci") || f.name.ends_with(".3ds")) {
+                file = tar->OpenSubFile(f.name);
+                if (has_ncch_magic(file.get())) {
+                    return std::move(file);
+                }
+                break;
+            }
+        }
+        tar.reset();
+    }
+
     // Check in loop for special files, including nested files.
     while (true) {
         // 1st: Crypto file
@@ -164,9 +180,14 @@ std::unique_ptr<FileUtil::IOFileBase> NCCHContainer::AutoOpenNCCHNCSD(
     }
 }
 
-NCCHContainer::NCCHContainer(const std::string& filepath, u32 ncch_offset, u32 partition)
+NCCHContainer::NCCHContainer(const std::string& filepath, u32 partition)
     : partition(partition), filepath(filepath) {
     file = AutoOpenNCCHNCSD(filepath);
+}
+
+NCCHContainer::NCCHContainer(FileUtil::IOFileBase* _file, u32 partition)
+    : partition(partition), filepath(_file->Filename()) {
+    file = AutoOpenNCCHNCSD(_file);
 }
 
 Loader::ResultStatus NCCHContainer::OpenFile(const std::string& filepath_, u32 ncch_offset_,

--- a/src/core/file_sys/ncch_container.h
+++ b/src/core/file_sys/ncch_container.h
@@ -240,7 +240,8 @@ public:
     static std::unique_ptr<FileUtil::IOFileBase> AutoOpenNCCHNCSD(const std::string& filepath);
     static std::unique_ptr<FileUtil::IOFileBase> AutoOpenNCCHNCSD(FileUtil::IOFileBase* file);
 
-    NCCHContainer(const std::string& filepath, u32 ncch_offset = 0, u32 partition = 0);
+    NCCHContainer(const std::string& filepath, u32 partition = 0);
+    NCCHContainer(FileUtil::IOFileBase* file, u32 partition = 0);
     NCCHContainer() {}
 
     Loader::ResultStatus OpenFile(const std::string& filepath, u32 ncch_offset = 0,
@@ -353,6 +354,18 @@ public:
 
     bool IsFileCompressed() {
         return file->GetType().HasCompressedType();
+    }
+
+    bool IsFileBundle() {
+        return file->GetType().HasType(FileUtil::IOType::Type::TarIOFile);
+    }
+
+    const std::unique_ptr<FileUtil::IOFileBase>& GetFile() {
+        return file;
+    }
+
+    bool IsLoaded() {
+        return is_loaded;
     }
 
     NCCH_Header ncch_header;

--- a/src/core/file_sys/ticket.cpp
+++ b/src/core/file_sys/ticket.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 Citra Emulator Project / Azahar Emulator Project
+// Copyright 2018-2026 Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -65,23 +65,28 @@ Loader::ResultStatus Ticket::DoTitlekeyFixup() {
 Loader::ResultStatus Ticket::Load(std::span<const u8> file_data, std::size_t offset) {
     std::size_t total_size = static_cast<std::size_t>(file_data.size() - offset);
     serialized_size = total_size;
-    if (total_size < sizeof(u32))
-        return Loader::ResultStatus::Error;
+    if (total_size < sizeof(u32)) {
+        load_result = Loader::ResultStatus::Error;
+        return load_result;
+    }
 
     std::memcpy(&signature_type, &file_data[offset], sizeof(u32));
 
     // Signature lengths are variable, and the body follows the signature
     u32 signature_size = GetSignatureSize(signature_type);
     if (signature_size == 0) {
-        return Loader::ResultStatus::Error;
+        load_result = Loader::ResultStatus::Error;
+        return load_result;
     }
 
     // The ticket body start position is rounded to the nearest 0x40 after the signature
     std::size_t body_start = Common::AlignUp(signature_size + sizeof(u32), 0x40);
     std::size_t body_end = body_start + sizeof(Body);
 
-    if (total_size < body_end)
-        return Loader::ResultStatus::Error;
+    if (total_size < body_end) {
+        load_result = Loader::ResultStatus::Error;
+        return load_result;
+    }
 
     // Read signature + ticket body
     ticket_signature.resize(signature_size);
@@ -89,8 +94,10 @@ Loader::ResultStatus Ticket::Load(std::span<const u8> file_data, std::size_t off
     std::memcpy(&ticket_body, &file_data[offset + body_start], sizeof(Body));
 
     std::size_t content_index_start = body_end;
-    if (total_size < content_index_start + (2 * sizeof(u32)))
-        return Loader::ResultStatus::Error;
+    if (total_size < content_index_start + (2 * sizeof(u32))) {
+        load_result = Loader::ResultStatus::Error;
+        return load_result;
+    }
 
     // Read content index size from the second u32 into it. Actual format is undocumented.
     const size_t content_index_size =
@@ -98,21 +105,25 @@ Loader::ResultStatus Ticket::Load(std::span<const u8> file_data, std::size_t off
             &file_data[offset + content_index_start + 1 * sizeof(u32)])));
     const size_t content_index_end = content_index_start + content_index_size;
 
-    if (total_size < content_index_end)
-        return Loader::ResultStatus::Error;
+    if (total_size < content_index_end) {
+        load_result = Loader::ResultStatus::Error;
+        return load_result;
+    }
     std::vector<u8> content_index_vec;
     content_index_vec.resize(content_index_size);
     std::memcpy(content_index_vec.data(), &file_data[offset + content_index_start],
                 content_index_size);
     content_index.Load(this, content_index_vec);
 
-    return Loader::ResultStatus::Success;
+    load_result = Loader::ResultStatus::Success;
+    return load_result;
 }
 
 Loader::ResultStatus Ticket::Load(u64 title_id, u64 ticket_id) {
     FileUtil::IOFile f(Service::AM::GetTicketPath(title_id, ticket_id), "rb");
     if (!f.IsOpen()) {
-        return Loader::ResultStatus::Error;
+        load_result = Loader::ResultStatus::Error;
+        return load_result;
     }
 
     std::vector<u8> ticket_data(f.GetSize());
@@ -185,8 +196,8 @@ bool Ticket::IsPersonal() const {
     return ticket_body.console_id == otp.GetDeviceID();
 }
 
-void Ticket::ContentIndex::Initialize() {
-    if (!parent || initialized) {
+void Ticket::ContentIndex::Initialize(Ticket* parent) {
+    if (initialized) {
         return;
     }
 
@@ -231,9 +242,9 @@ void Ticket::ContentIndex::Initialize() {
     initialized = true;
 }
 
-bool Ticket::ContentIndex::HasRights(u16 content_index) {
+bool Ticket::ContentIndex::HasRights(Ticket* parent, u16 content_index) {
     if (!initialized) {
-        Initialize();
+        Initialize(parent);
         if (!initialized)
             return false;
     }

--- a/src/core/file_sys/ticket.h
+++ b/src/core/file_sys/ticket.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 Citra Emulator Project / Azahar Emulator Project
+// Copyright 2018-2026 Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -76,7 +76,11 @@ public:
     bool IsPersonal() const;
 
     bool HasRights(u16 index) {
-        return content_index.HasRights(index);
+        return content_index.HasRights(this, index);
+    }
+
+    Loader::ResultStatus LoadResult() {
+        return load_result;
     }
 
     class ContentIndex {
@@ -109,7 +113,6 @@ public:
         ContentIndex() {}
 
         void Load(Ticket* p, const std::vector<u8>& data) {
-            parent = p;
             content_index = data;
         }
 
@@ -117,15 +120,14 @@ public:
             return content_index;
         }
 
-        bool HasRights(u16 content_index);
+        bool HasRights(Ticket* parent, u16 content_index);
 
     private:
-        void Initialize();
+        void Initialize(Ticket* parent);
 
         bool initialized = false;
         std::vector<u8> content_index;
         std::vector<RightsField> rights;
-        Ticket* parent = nullptr;
     };
 
 private:
@@ -133,6 +135,7 @@ private:
     u32_be signature_type;
     std::vector<u8> ticket_signature;
     ContentIndex content_index;
+    Loader::ResultStatus load_result;
 
     size_t serialized_size = 0;
 };

--- a/src/core/file_sys/title_metadata.cpp
+++ b/src/core/file_sys/title_metadata.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2025 Citra Emulator Project / Azahar Emulator Project
+// Copyright 2017-2026 Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -15,13 +15,17 @@ namespace FileSys {
 
 Loader::ResultStatus TitleMetadata::Load(const std::string& file_path) {
     FileUtil::IOFile file(file_path, "rb");
-    if (!file.IsOpen())
-        return Loader::ResultStatus::Error;
+    if (!file.IsOpen()) {
+        load_result = Loader::ResultStatus::Error;
+        return load_result;
+    }
 
     std::vector<u8> file_data(file.GetSize());
 
-    if (!file.ReadBytes(file_data.data(), file.GetSize()))
-        return Loader::ResultStatus::Error;
+    if (!file.ReadBytes(file_data.data(), file.GetSize())) {
+        load_result = Loader::ResultStatus::Error;
+        return load_result;
+    }
 
     Loader::ResultStatus result = Load(file_data);
     if (result != Loader::ResultStatus::Success)
@@ -33,7 +37,8 @@ Loader::ResultStatus TitleMetadata::Load(const std::string& file_path) {
 Loader::ResultStatus TitleMetadata::Load(std::span<const u8> file_data, std::size_t offset) {
     std::size_t total_size = static_cast<std::size_t>(file_data.size() - offset);
     if (total_size < sizeof(u32_be)) {
-        return Loader::ResultStatus::Error;
+        load_result = Loader::ResultStatus::Error;
+        return load_result;
     }
 
     std::memcpy(&signature_type, &file_data[offset], sizeof(u32_be));
@@ -41,7 +46,8 @@ Loader::ResultStatus TitleMetadata::Load(std::span<const u8> file_data, std::siz
     // Signature lengths are variable, and the body follows the signature
     u32 signature_size = GetSignatureSize(signature_type);
     if (signature_size == 0) {
-        return Loader::ResultStatus::Error;
+        load_result = Loader::ResultStatus::Error;
+        return load_result;
     }
 
     // The TMD body start position is rounded to the nearest 0x40 after the signature
@@ -49,7 +55,8 @@ Loader::ResultStatus TitleMetadata::Load(std::span<const u8> file_data, std::siz
     std::size_t body_end = body_start + sizeof(Body);
 
     if (total_size < body_end) {
-        return Loader::ResultStatus::Error;
+        load_result = Loader::ResultStatus::Error;
+        return load_result;
     }
 
     // Read signature + TMD body, then load the amount of ContentChunks specified
@@ -62,7 +69,8 @@ Loader::ResultStatus TitleMetadata::Load(std::span<const u8> file_data, std::siz
     if (total_size < expected_size) {
         LOG_ERROR(Service_FS, "Malformed TMD, expected size 0x{:x}, got 0x{:x}!", expected_size,
                   total_size);
-        return Loader::ResultStatus::ErrorInvalidFormat;
+        load_result = Loader::ResultStatus::ErrorInvalidFormat;
+        return load_result;
     }
 
     for (u16 i = 0; i < tmd_body.content_count; i++) {
@@ -73,7 +81,8 @@ Loader::ResultStatus TitleMetadata::Load(std::span<const u8> file_data, std::siz
         tmd_chunks.push_back(chunk);
     }
 
-    return Loader::ResultStatus::Success;
+    load_result = Loader::ResultStatus::Success;
+    return load_result;
 }
 
 Loader::ResultStatus TitleMetadata::Save(const std::string& file_path) {

--- a/src/core/file_sys/title_metadata.h
+++ b/src/core/file_sys/title_metadata.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2025 Citra Emulator Project / Azahar Emulator Project
+// Copyright 2017-2026 Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -111,12 +111,16 @@ public:
     void AddContentChunk(const ContentChunk& chunk);
 
     void Print() const;
+    Loader::ResultStatus LoadResult() {
+        return load_result;
+    }
 
 private:
     Body tmd_body;
     u32_be signature_type;
     std::vector<u8> tmd_signature;
     std::vector<ContentChunk> tmd_chunks;
+    Loader::ResultStatus load_result;
 };
 
 } // namespace FileSys

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -17,6 +17,7 @@
 #include "common/hacks/hack_manager.h"
 #include "common/logging/log.h"
 #include "common/string_util.h"
+#include "common/tar_file.h"
 #include "common/zstd_compression.h"
 #include "core/core.h"
 #include "core/file_sys/certificate.h"
@@ -1056,6 +1057,106 @@ void ContentFile::Cancel(FS::MediaType media_type, u64 title_id) {
     FileUtil::Delete(path);
 }
 
+BundleCIAHandler::BundleCIAHandler() = default;
+
+bool BundleCIAHandler::RegisterBundle(const std::string& filename) {
+    auto tar = FileUtil::TarArchive(filename);
+    auto files = tar.GetFileList();
+    if (files.empty()) {
+        LOG_ERROR(Service_AM, "Failed to parse bundle file");
+        return false;
+    }
+    for (auto f : files) {
+        if (f.name.ends_with(".cia") || f.name.ends_with(".zcia")) {
+            auto sub_file = tar.OpenSubFile(f.name);
+            if (!sub_file->IsGood()) {
+                LOG_ERROR(Service_AM, "Failed to open sub file {}", f.name);
+                cia_containers.clear();
+                return false;
+            }
+            cia_containers.emplace_back();
+            auto res = cia_containers.back().Load(std::move(sub_file));
+            if (res != Loader::ResultStatus::Success) {
+                LOG_ERROR(Service_AM, "Failed to parse bundled cia file {}: (error {})", f.name,
+                          res);
+            }
+            if (cia_containers.back().GetTitleMetadata().HasEncryptedContent(
+                    cia_containers.back().GetHeader())) {
+                LOG_ERROR(Service_AM, "Bundle contains encrypted cia file {}", f.name);
+                cia_containers.clear();
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+std::vector<std::pair<u64, FS::MediaType>> BundleCIAHandler::List() const {
+    std::vector<std::pair<u64, FS::MediaType>> ret;
+    for (auto& c : cia_containers) {
+        u64 title_id = c.GetTitleMetadata().GetTitleID();
+        ret.push_back({title_id, Service::AM::GetTitleMediaType(title_id)});
+    }
+    return ret;
+}
+
+bool BundleCIAHandler::HasTitle(u64 title_id, FS::MediaType mediatype, u64 content_index) const {
+    for (auto& c : cia_containers) {
+        if (c.GetTitleMetadata().GetTitleID() == title_id &&
+            Service::AM::GetTitleMediaType(title_id) == mediatype &&
+            (content_index == std::numeric_limits<u64>::max() ||
+             content_index < c.GetTitleMetadata().GetContentCount())) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool BundleCIAHandler::HasContent(u64 title_id, FS::MediaType mediatype, u64 content_index) {
+    for (auto& c : cia_containers) {
+        if (c.GetTitleMetadata().GetTitleID() == title_id &&
+            Service::AM::GetTitleMediaType(title_id) == mediatype) {
+            return c.GetHeader()->IsContentPresent(content_index);
+        }
+    }
+    return false;
+}
+
+const FileSys::Ticket* BundleCIAHandler::GetTicket(u64 title_id) const {
+    for (const auto& c : cia_containers) {
+        if (c.GetTitleMetadata().GetTitleID() == title_id) {
+            return &c.GetTicket();
+        }
+    }
+    return nullptr;
+}
+
+const FileSys::TitleMetadata* BundleCIAHandler::GetTitleMetadata(u64 title_id,
+                                                                 FS::MediaType mediatype,
+                                                                 u64 content_index) const {
+    for (const auto& c : cia_containers) {
+        if (c.GetTitleMetadata().GetTitleID() == title_id &&
+            Service::AM::GetTitleMediaType(title_id) == mediatype &&
+            (content_index == std::numeric_limits<u64>::max() ||
+             content_index < c.GetTitleMetadata().GetContentCount())) {
+            return &c.GetTitleMetadata();
+        }
+    }
+    return nullptr;
+}
+
+std::unique_ptr<FileUtil::IOFileBase> BundleCIAHandler::OpenContentFile(u64 title_id,
+                                                                        FS::MediaType mediatype,
+                                                                        u64 content_index) const {
+    for (const auto& c : cia_containers) {
+        if (c.GetTitleMetadata().GetTitleID() == title_id &&
+            Service::AM::GetTitleMediaType(title_id) == mediatype &&
+            content_index < c.GetTitleMetadata().GetContentCount()) {
+            return c.GetContentFile(content_index);
+        }
+    }
+}
+
 InstallStatus InstallCIA(const std::string& path,
                          std::function<ProgressCallback>&& update_callback) {
     LOG_INFO(Service_AM, "Installing {}...", path);
@@ -1065,73 +1166,103 @@ InstallStatus InstallCIA(const std::string& path,
         return InstallStatus::ErrorFileNotFound;
     }
 
-    std::unique_ptr<FileUtil::IOFileBase> in_file = std::make_unique<FileUtil::IOFile>(path, "rb");
-    bool is_compressed =
-        FileUtil::Z3DSReadIOFile::GetUnderlyingFileMagic(in_file.get()) != std::nullopt;
-    if (is_compressed) {
-        in_file = std::make_unique<FileUtil::Z3DSReadIOFile>(std::move(in_file));
+    auto install_single_cia = [&update_callback](std::unique_ptr<FileUtil::IOFileBase> in_file,
+                                                 const std::string& path) {
+        bool is_compressed =
+            FileUtil::Z3DSReadIOFile::GetUnderlyingFileMagic(in_file.get()) != std::nullopt;
+        if (is_compressed) {
+            in_file = std::make_unique<FileUtil::Z3DSReadIOFile>(std::move(in_file));
+        }
+
+        FileSys::CIAContainer container;
+        if (container.Load(in_file.get()) == Loader::ResultStatus::Success) {
+            in_file->Seek(0, SEEK_SET);
+            Service::AM::CIAFile installFile(
+                Core::System::GetInstance(),
+                Service::AM::GetTitleMediaType(container.GetTitleMetadata().GetTitleID()));
+
+            if (container.GetTitleMetadata().HasEncryptedContent(container.GetHeader())) {
+                LOG_ERROR(Service_AM, "File {} is encrypted! Aborting...", path);
+                return InstallStatus::ErrorEncrypted;
+            }
+
+            std::vector<u8> buffer;
+            buffer.resize(0x10000);
+            auto file_size = in_file->GetSize();
+            std::size_t total_bytes_read = 0;
+            while (total_bytes_read != file_size) {
+                std::size_t bytes_read = in_file->ReadBytes(buffer.data(), buffer.size());
+                auto result = installFile.Write(static_cast<u64>(total_bytes_read), bytes_read,
+                                                true, false, static_cast<u8*>(buffer.data()));
+
+                if (update_callback) {
+                    update_callback(total_bytes_read, file_size);
+                }
+                if (result.Failed()) {
+                    LOG_ERROR(Service_AM, "CIA file installation aborted with error code {:08x}",
+                              result.Code().raw);
+                    return InstallStatus::ErrorAborted;
+                }
+                total_bytes_read += bytes_read;
+            }
+            installFile.Close();
+
+            InstallStatus install_res = InstallStatus::Success;
+            for (auto result : installFile.GetInstallResults()) {
+                if (result.type != CIAFile::InstallResult::Type::APP || result.result.IsError()) {
+                    continue;
+                }
+
+                std::unique_ptr<Loader::AppLoader> loader =
+                    Loader::GetLoader(result.install_full_path);
+                if (!loader) {
+                    continue;
+                }
+
+                bool executable = false;
+                const auto res = loader->IsExecutable(executable);
+                if (res == Loader::ResultStatus::ErrorEncrypted) {
+                    LOG_ERROR(Service_AM, "CIA contains encrypted content: {}", path,
+                              result.install_full_path);
+                    install_res = InstallStatus::ErrorEncrypted;
+                }
+            }
+            if (install_res == InstallStatus::Success) {
+                LOG_INFO(Service_AM, "Installed {} successfully.", path);
+            }
+            return install_res;
+        }
+
+        LOG_ERROR(Service_AM, "CIA file {} is invalid!", path);
+        return InstallStatus::ErrorInvalid;
+    };
+
+    // Check bcia first
+    if (auto tar = FileUtil::TarArchive::OpenTarArchive(path)) {
+        auto files = tar->GetFileList();
+        if (files.empty()) {
+            LOG_ERROR(Service_AM, "Failed to parse BCIA file");
+            return InstallStatus::ErrorInvalid;
+        }
+        for (auto f : files) {
+            if (f.name.ends_with(".cia") || f.name.ends_with(".zcia")) {
+                auto sub_file = tar->OpenSubFile(f.name);
+                if (!sub_file->IsGood()) {
+                    LOG_ERROR(Service_AM, "Failed to open sub file");
+                }
+                auto res = install_single_cia(std::move(sub_file), path + ":" + f.name);
+                if (res != InstallStatus::Success) {
+                    LOG_ERROR(Service_AM, "Aborting BCIA install");
+                    return res;
+                }
+            } else {
+                LOG_WARNING(Service_AM, "Skipping unknown file {}", f.name);
+            }
+        }
+        return InstallStatus::Success;
+    } else {
+        return install_single_cia(std::make_unique<FileUtil::IOFile>(path, "rb"), path);
     }
-
-    FileSys::CIAContainer container;
-    if (container.Load(in_file.get()) == Loader::ResultStatus::Success) {
-        in_file->Seek(0, SEEK_SET);
-        Service::AM::CIAFile installFile(
-            Core::System::GetInstance(),
-            Service::AM::GetTitleMediaType(container.GetTitleMetadata().GetTitleID()));
-
-        if (container.GetTitleMetadata().HasEncryptedContent(container.GetHeader())) {
-            LOG_ERROR(Service_AM, "File {} is encrypted! Aborting...", path);
-            return InstallStatus::ErrorEncrypted;
-        }
-
-        std::vector<u8> buffer;
-        buffer.resize(0x10000);
-        auto file_size = in_file->GetSize();
-        std::size_t total_bytes_read = 0;
-        while (total_bytes_read != file_size) {
-            std::size_t bytes_read = in_file->ReadBytes(buffer.data(), buffer.size());
-            auto result = installFile.Write(static_cast<u64>(total_bytes_read), bytes_read, true,
-                                            false, static_cast<u8*>(buffer.data()));
-
-            if (update_callback) {
-                update_callback(total_bytes_read, file_size);
-            }
-            if (result.Failed()) {
-                LOG_ERROR(Service_AM, "CIA file installation aborted with error code {:08x}",
-                          result.Code().raw);
-                return InstallStatus::ErrorAborted;
-            }
-            total_bytes_read += bytes_read;
-        }
-        installFile.Close();
-
-        InstallStatus install_res = InstallStatus::Success;
-        for (auto result : installFile.GetInstallResults()) {
-            if (result.type != CIAFile::InstallResult::Type::APP || result.result.IsError()) {
-                continue;
-            }
-
-            std::unique_ptr<Loader::AppLoader> loader = Loader::GetLoader(result.install_full_path);
-            if (!loader) {
-                continue;
-            }
-
-            bool executable = false;
-            const auto res = loader->IsExecutable(executable);
-            if (res == Loader::ResultStatus::ErrorEncrypted) {
-                LOG_ERROR(Service_AM, "CIA contains encrypted content: {}", path,
-                          result.install_full_path);
-                install_res = InstallStatus::ErrorEncrypted;
-            }
-        }
-        if (install_res == InstallStatus::Success) {
-            LOG_INFO(Service_AM, "Installed {} successfully.", path);
-        }
-        return install_res;
-    }
-
-    LOG_ERROR(Service_AM, "CIA file {} is invalid!", path);
-    return InstallStatus::ErrorInvalid;
 }
 
 InstallStatus CheckCIAToInstall(const std::string& path, bool& is_compressed,
@@ -1233,8 +1364,46 @@ std::string GetTicketDirectory() {
     return fmt::format("{}/dbs/ticket.db/", FileUtil::GetUserPath(FileUtil::UserPath::NANDDir));
 }
 
+FileSys::Ticket GetTicket(u64 title_id, u64 ticket_id) {
+    FileSys::Ticket ticket;
+    ticket.Load(title_id, ticket_id);
+    if (ticket.LoadResult() == Loader::ResultStatus::Success) {
+        return ticket;
+    }
+
+    auto am = GetModule(Core::Global<Core::System>());
+    if (am) {
+        auto& bundle_handler = am->GetBundleCIAHandler();
+        auto* bundle_ticket = bundle_handler->GetTicket(title_id);
+        if (bundle_ticket) {
+            return *bundle_ticket;
+        }
+    }
+
+    return ticket;
+}
+
 std::string GetTicketPath(u64 title_id, u64 ticket_id) {
     return GetTicketDirectory() + fmt::format("{:016X}.{:016X}.tik", title_id, ticket_id);
+}
+
+FileSys::TitleMetadata GetTitleMetadata(Service::FS::MediaType media_type, u64 tid, bool update) {
+    auto path = GetTitleMetadataPath(media_type, tid, update);
+    FileSys::TitleMetadata tmd;
+    tmd.Load(path);
+    if (tmd.LoadResult() == Loader::ResultStatus::Success) {
+        return tmd;
+    }
+
+    auto am = GetModule(Core::Global<Core::System>());
+    if (am && !update) {
+        auto& bundle_handler = am->GetBundleCIAHandler();
+        if (bundle_handler->HasTitle(tid, media_type)) {
+            return *bundle_handler->GetTitleMetadata(tid, media_type);
+        }
+    }
+
+    return tmd;
 }
 
 std::string GetTitleMetadataPath(Service::FS::MediaType media_type, u64 tid, bool update) {
@@ -1273,6 +1442,41 @@ std::string GetTitleMetadataPath(Service::FS::MediaType media_type, u64 tid, boo
         update_id++;
 
     return content_path + fmt::format("{:08x}.tmd", (update ? update_id : base_id));
+}
+
+bool TitleContentExists(Service::FS::MediaType media_type, u64 tid, std::size_t index,
+                        bool update) {
+    if (FileUtil::Exists(GetTitleContentPath(media_type, tid, index, update))) {
+        return true;
+    }
+
+    auto am = GetModule(Core::Global<Core::System>());
+    if (am && !update) {
+        auto& bundle_handler = am->GetBundleCIAHandler();
+        if (bundle_handler->HasTitle(tid, media_type)) {
+            return bundle_handler->HasContent(tid, media_type, index);
+        }
+    }
+
+    return false;
+}
+
+std::unique_ptr<FileUtil::IOFileBase> GetTitleContent(Service::FS::MediaType media_type, u64 tid,
+                                                      std::size_t index, bool update) {
+    std::string path = GetTitleContentPath(media_type, tid, index, update);
+    if (FileUtil::Exists(path)) {
+        return std::make_unique<FileUtil::IOFile>(path, "rb");
+    }
+
+    auto am = GetModule(Core::Global<Core::System>());
+    if (am && !update) {
+        auto& bundle_handler = am->GetBundleCIAHandler();
+        if (bundle_handler->HasTitle(tid, media_type, index)) {
+            return bundle_handler->OpenContentFile(tid, media_type, index);
+        }
+    }
+
+    return std::make_unique<FileUtil::NullIOFile>();
 }
 
 std::string GetTitleContentPath(Service::FS::MediaType media_type, u64 tid, std::size_t index,
@@ -1393,6 +1597,19 @@ void Module::ScanForTicketsImpl() {
             }
         }
     }
+
+    // Scan the bundle if it exists
+    auto am = GetModule(Core::Global<Core::System>());
+    if (am) {
+        auto& bundle_handler = am->GetBundleCIAHandler();
+        auto list = bundle_handler->List();
+        for (auto& e : list) {
+            if (am_ticket_list.find(e.first) == am_ticket_list.end()) {
+                auto ticket = bundle_handler->GetTicket(e.first);
+                am_ticket_list.insert(std::make_pair(e.first, ticket->GetTicketID()));
+            }
+        }
+    }
     LOG_DEBUG(Service_AM, "Finished ticket scan");
 }
 
@@ -1453,6 +1670,21 @@ void Module::ScanForTitlesImpl(Service::FS::MediaType media_type) {
                             am_title_list[static_cast<u32>(media_type)].push_back(tid);
                         }
                     }
+                }
+            }
+        }
+
+        // Scan the bundle if it exists
+        auto am = GetModule(Core::Global<Core::System>());
+        if (am) {
+            auto& bundle_handler = am->GetBundleCIAHandler();
+            auto list = bundle_handler->List();
+            for (auto& e : list) {
+                if (e.second == media_type &&
+                    std::find(am_title_list[static_cast<u32>(media_type)].begin(),
+                              am_title_list[static_cast<u32>(media_type)].end(),
+                              e.first) == am_title_list[static_cast<u32>(media_type)].end()) {
+                    am_title_list[static_cast<u32>(media_type)].push_back(e.first);
                 }
             }
         }
@@ -1646,8 +1878,8 @@ void Module::Interface::FindDLCContentInfos(Kernel::HLERequestContext& ctx) {
                     return 0;
                 }
 
-                std::string tmd_path =
-                    GetTitleMetadataPath(async_data->media_type, async_data->title_id);
+                FileSys::TitleMetadata tmd =
+                    GetTitleMetadata(async_data->media_type, async_data->title_id);
 
                 // In normal circumstances, if there is no ticket we shouldn't be able to have
                 // any contents either. However to keep compatibility with older emulator builds,
@@ -1656,14 +1888,14 @@ void Module::Interface::FindDLCContentInfos(Kernel::HLERequestContext& ctx) {
                 FileSys::Ticket ticket;
                 std::scoped_lock lock(am->am_lists_mutex);
                 auto entries = am->am_ticket_list.find(async_data->title_id);
-                if (entries != am->am_ticket_list.end() &&
-                    ticket.Load(async_data->title_id, (*entries).second) ==
-                        Loader::ResultStatus::Success) {
-                    has_ticket = true;
+                if (entries != am->am_ticket_list.end()) {
+                    ticket = GetTicket(async_data->title_id, (*entries).second);
+                    if (ticket.LoadResult() == Loader::ResultStatus::Success) {
+                        has_ticket = true;
+                    }
                 }
 
-                FileSys::TitleMetadata tmd;
-                if (tmd.Load(tmd_path) == Loader::ResultStatus::Success) {
+                if (tmd.LoadResult() == Loader::ResultStatus::Success) {
                     // Get info for each content index requested
                     for (std::size_t i = 0; i < async_data->content_requested.size(); i++) {
                         u16_le index = async_data->content_requested[i];
@@ -1685,8 +1917,8 @@ void Module::Interface::FindDLCContentInfos(Kernel::HLERequestContext& ctx) {
                         content_info.ownership =
                             (!has_ticket || ticket.HasRights(index)) ? OWNERSHIP_OWNED : 0;
 
-                        if (FileUtil::Exists(GetTitleContentPath(async_data->media_type,
-                                                                 async_data->title_id, index))) {
+                        if (TitleContentExists(async_data->media_type, async_data->title_id,
+                                               index)) {
                             bool pending = false;
                             for (auto& import_ctx : am->import_content_contexts) {
                                 if (import_ctx.first == async_data->title_id &&
@@ -1826,8 +2058,8 @@ void Module::Interface::ListDLCContentInfos(Kernel::HLERequestContext& ctx) {
                     return 0;
                 }
 
-                std::string tmd_path =
-                    GetTitleMetadataPath(async_data->media_type, async_data->title_id);
+                FileSys::TitleMetadata tmd =
+                    GetTitleMetadata(async_data->media_type, async_data->title_id);
 
                 // In normal circumstances, if there is no ticket we shouldn't be able to have
                 // any contents either. However to keep compatibility with older emulator builds,
@@ -1836,14 +2068,14 @@ void Module::Interface::ListDLCContentInfos(Kernel::HLERequestContext& ctx) {
                 FileSys::Ticket ticket;
                 std::scoped_lock lock(am->am_lists_mutex);
                 auto entries = am->am_ticket_list.find(async_data->title_id);
-                if (entries != am->am_ticket_list.end() &&
-                    ticket.Load(async_data->title_id, (*entries).second) ==
-                        Loader::ResultStatus::Success) {
-                    has_ticket = true;
+                if (entries != am->am_ticket_list.end()) {
+                    ticket = GetTicket(async_data->title_id, (*entries).second);
+                    if (ticket.LoadResult() == Loader::ResultStatus::Success) {
+                        has_ticket = true;
+                    }
                 }
 
-                FileSys::TitleMetadata tmd;
-                if (tmd.Load(tmd_path) == Loader::ResultStatus::Success) {
+                if (tmd.LoadResult() == Loader::ResultStatus::Success) {
                     u32 end_index = std::min(async_data->start_index + async_data->content_count,
                                              static_cast<u32>(tmd.GetContentCount()));
                     for (u32 i = async_data->start_index; i < end_index; i++) {
@@ -1856,8 +2088,7 @@ void Module::Interface::ListDLCContentInfos(Kernel::HLERequestContext& ctx) {
                             (!has_ticket || ticket.HasRights(static_cast<u16>(i))) ? OWNERSHIP_OWNED
                                                                                    : 0;
 
-                        if (FileUtil::Exists(GetTitleContentPath(async_data->media_type,
-                                                                 async_data->title_id, i))) {
+                        if (TitleContentExists(async_data->media_type, async_data->title_id, i)) {
                             bool pending = false;
                             for (auto& import_ctx : am->import_content_contexts) {
                                 if (import_ctx.first == async_data->title_id &&
@@ -2050,13 +2281,12 @@ Result GetTitleInfoFromList(Core::System& system, std::span<const u64> title_id_
                       title_info.version);
             title_info_out.push_back(title_info);
         } else {
-            std::string tmd_path = GetTitleMetadataPath(media_type, title_id_list[i]);
+            FileSys::TitleMetadata tmd = GetTitleMetadata(media_type, title_id_list[i]);
 
             TitleInfo title_info = {};
             title_info.tid = title_id_list[i];
 
-            FileSys::TitleMetadata tmd;
-            if (tmd.Load(tmd_path) == Loader::ResultStatus::Success) {
+            if (tmd.LoadResult() == Loader::ResultStatus::Success) {
                 // TODO(shinyquagsire23): This is the total size of all files this process owns,
                 // including savefiles and other content. This comes close but is off.
                 title_info.size = tmd.GetContentSizeByIndex(FileSys::TMDContentIndex::Main);
@@ -2264,11 +2494,11 @@ void Module::Interface::GetProductCode(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     FS::MediaType media_type = rp.PopEnum<FS::MediaType>();
     u64 title_id = rp.Pop<u64>();
-    std::string path = GetTitleContentPath(media_type, title_id);
+    auto content_file = GetTitleContent(media_type, title_id, 0);
 
     LOG_DEBUG(Service_AM, "title_id={:016X}", title_id);
 
-    if (!FileUtil::Exists(path)) {
+    if (!content_file->IsOpen()) {
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
         rb.Push(Result(ErrorDescription::NotFound, ErrorModule::AM, ErrorSummary::InvalidState,
                        ErrorLevel::Permanent));
@@ -2280,7 +2510,7 @@ void Module::Interface::GetProductCode(Kernel::HLERequestContext& ctx) {
         ProductCode product_code;
 
         IPC::RequestBuilder rb = rp.MakeBuilder(5, 0);
-        FileSys::NCCHContainer ncch(path);
+        FileSys::NCCHContainer ncch(content_file.get());
         ncch.Load();
         std::memcpy(&product_code.code, &ncch.ncch_header.product_code, 0x10);
         rb.Push(ResultSuccess);
@@ -2666,8 +2896,8 @@ void Module::Interface::ListDataTitleTicketInfos(Kernel::HLERequestContext& ctx)
 
         u32 written = 0;
         for (; it != range.second && written < ticket_count; it++) {
-            FileSys::Ticket ticket;
-            if (ticket.Load(title_id, it->second) != Loader::ResultStatus::Success)
+            FileSys::Ticket ticket = GetTicket(title_id, it->second);
+            if (ticket.LoadResult() != Loader::ResultStatus::Success)
                 continue;
 
             TicketInfo info = {};
@@ -2756,10 +2986,8 @@ void Module::Interface::GetDLCContentInfoCount(Kernel::HLERequestContext& ctx) {
         IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
         rb.Push(ResultSuccess); // No error
 
-        std::string tmd_path = GetTitleMetadataPath(media_type, title_id);
-
-        FileSys::TitleMetadata tmd;
-        if (tmd.Load(tmd_path) == Loader::ResultStatus::Success) {
+        FileSys::TitleMetadata tmd = GetTitleMetadata(media_type, title_id);
+        if (tmd.LoadResult() == Loader::ResultStatus::Success) {
             rb.Push<u32>(static_cast<u32>(tmd.GetContentCount()));
         } else {
             rb.Push<u32>(1); // Number of content infos plus one
@@ -2783,15 +3011,22 @@ void Module::Interface::DeleteTicket(Kernel::HLERequestContext& ctx) {
                        ErrorLevel::Success));
         return;
     }
-    auto it = range.first;
-    for (; it != range.second; it++) {
+    bool found = false;
+    for (auto it = range.first; it != range.second;) {
         auto path = GetTicketPath(title_id, it->second);
-        FileUtil::Delete(path);
+
+        if (FileUtil::Exists(path)) {
+            FileUtil::Delete(path);
+            it = am->am_ticket_list.erase(it);
+            found = true;
+        } else {
+            ++it;
+        }
     }
 
-    am->am_ticket_list.erase(range.first, range.second);
-
-    rb.Push(ResultSuccess);
+    rb.Push(found ? ResultSuccess
+                  : Result(ErrorDescription::NotFound, ErrorModule::AM, ErrorSummary::NotFound,
+                           ErrorLevel::Permanent));
 }
 
 void Module::Interface::GetNumTickets(Kernel::HLERequestContext& ctx) {
@@ -3181,9 +3416,8 @@ void Module::Interface::GetPersonalizedTicketInfoList(Kernel::HLERequestContext&
                 if ((tid_high & 0x00048010) == 0x00040010 || (tid_high & 0x00048001) == 0x00048001)
                     continue;
 
-                FileSys::Ticket ticket;
-                if (ticket.Load(title_id, it->second) != Loader::ResultStatus::Success ||
-                    !ticket.IsPersonal())
+                FileSys::Ticket ticket = GetTicket(title_id, it->second);
+                if (ticket.LoadResult() != Loader::ResultStatus::Success || !ticket.IsPersonal())
                     continue;
 
                 TicketInfo info = {};
@@ -3247,9 +3481,11 @@ void Module::Interface::CheckContentRights(Kernel::HLERequestContext& ctx) {
     FileSys::Ticket ticket;
     std::scoped_lock lock(am->am_lists_mutex);
     auto entries = am->am_ticket_list.find(tid);
-    if (entries != am->am_ticket_list.end() &&
-        ticket.Load(tid, (*entries).second) == Loader::ResultStatus::Success) {
-        has_ticket = true;
+    if (entries != am->am_ticket_list.end()) {
+        ticket = GetTicket(tid, (*entries).second);
+        if (ticket.LoadResult() == Loader::ResultStatus::Success) {
+            has_ticket = true;
+        }
     }
 
     bool has_rights = (!has_ticket || ticket.HasRights(content_index));
@@ -3270,9 +3506,11 @@ void Module::Interface::CheckContentRightsIgnorePlatform(Kernel::HLERequestConte
     FileSys::Ticket ticket;
     std::scoped_lock lock(am->am_lists_mutex);
     auto entries = am->am_ticket_list.find(tid);
-    if (entries != am->am_ticket_list.end() &&
-        ticket.Load(tid, (*entries).second) == Loader::ResultStatus::Success) {
-        has_ticket = true;
+    if (entries != am->am_ticket_list.end()) {
+        ticket = GetTicket(tid, (*entries).second);
+        if (ticket.LoadResult() == Loader::ResultStatus::Success) {
+            has_ticket = true;
+        }
     }
 
     bool has_rights = (!has_ticket || ticket.HasRights(content_index));
@@ -4554,11 +4792,16 @@ void Module::Interface::DeleteTicketId(Kernel::HLERequestContext& ctx) {
     }
 
     auto path = GetTicketPath(title_id, ticket_id);
-    FileUtil::Delete(path);
+    bool found = false;
+    if (FileUtil::Exists(path)) {
+        FileUtil::Delete(path);
+        am->am_ticket_list.erase(it);
+        found = true;
+    }
 
-    am->am_ticket_list.erase(it);
-
-    rb.Push(ResultSuccess);
+    rb.Push(found ? ResultSuccess
+                  : Result(ErrorDescription::NotFound, ErrorModule::AM, ErrorSummary::NotFound,
+                           ErrorLevel::Permanent));
 }
 
 void Module::Interface::GetNumTicketIds(Kernel::HLERequestContext& ctx) {
@@ -4631,8 +4874,8 @@ void Module::Interface::ListTicketInfos(Kernel::HLERequestContext& ctx) {
 
     u32 written = 0;
     for (; it != range.second && written < ticket_count; it++) {
-        FileSys::Ticket ticket;
-        if (ticket.Load(title_id, it->second) != Loader::ResultStatus::Success)
+        FileSys::Ticket ticket = GetTicket(title_id, it->second);
+        if (ticket.LoadResult() != Loader::ResultStatus::Success)
             continue;
 
         TicketInfo info = {};
@@ -4934,8 +5177,8 @@ void Module::Interface::ExportTicketWrapped(Kernel::HLERequestContext& ctx) {
         return;
     }
 
-    FileSys::Ticket ticket;
-    if (ticket.Load(title_id, ticket_id) != Loader::ResultStatus::Success) {
+    FileSys::Ticket ticket = GetTicket(title_id, ticket_id);
+    if (ticket.LoadResult() != Loader::ResultStatus::Success) {
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
         rb.Push(Result(ErrorDescription::NotFound, ErrorModule::AM, ErrorSummary::InvalidState,
                        ErrorLevel::Permanent));
@@ -4986,7 +5229,7 @@ void Module::Interface::ExportTicketWrapped(Kernel::HLERequestContext& ctx) {
 
 Module::Module(Core::System& _system) : system(_system) {
     FileUtil::CreateFullPath(GetTicketDirectory());
-    ScanForAllTitles();
+    bundle_cia_handler = std::make_unique<BundleCIAHandler>();
     system_updater_mutex = system.Kernel().CreateMutex(false, "AM::SystemUpdaterMutex");
 }
 
@@ -4995,6 +5238,10 @@ Module::~Module() {
 }
 
 std::shared_ptr<Module> GetModule(Core::System& system) {
+    if (!system.IsPoweredOn()) {
+        return nullptr;
+    }
+
     auto am = system.ServiceManager().GetService<Service::AM::Module::Interface>("am:u");
     if (!am)
         return nullptr;

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <functional>
 #include <future>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -368,6 +369,32 @@ private:
     u16 index;
 };
 
+class BundleCIAHandler {
+public:
+    BundleCIAHandler();
+
+    bool RegisterBundle(const std::string& filename);
+
+    std::vector<std::pair<u64, FS::MediaType>> List() const;
+
+    bool HasTitle(u64 title_id, FS::MediaType mediatype,
+                  u64 content_index = std::numeric_limits<u64>::max()) const;
+
+    bool HasContent(u64 title_id, FS::MediaType mediatype, u64 content_index);
+
+    const FileSys::Ticket* GetTicket(u64 title_id) const;
+
+    const FileSys::TitleMetadata* GetTitleMetadata(
+        u64 title_id, FS::MediaType mediatype,
+        u64 content_index = std::numeric_limits<u64>::max()) const;
+
+    std::unique_ptr<FileUtil::IOFileBase> OpenContentFile(u64 title_id, FS::MediaType mediatype,
+                                                          u64 content_index) const;
+
+private:
+    std::vector<FileSys::CIAContainer> cia_containers;
+};
+
 /**
  * Installs a CIA file from a specified file path.
  * @param path file path of the CIA file to install
@@ -404,10 +431,18 @@ u64 GetTitleUpdateId(u64 title_id);
  */
 Service::FS::MediaType GetTitleMediaType(u64 titleId);
 
+FileSys::Ticket GetTicket(u64 title_id, u64 ticket_id);
+
 /**
  * Get the .tik path for a title_id and ticket_id.
  */
 std::string GetTicketPath(u64 title_id, u64 ticket_id);
+
+/**
+ * Get the .tmd for a title, unlike GetTitleMetadataPath, this supports bundled archives.
+ */
+FileSys::TitleMetadata GetTitleMetadata(Service::FS::MediaType media_type, u64 tid,
+                                        bool update = false);
 
 /**
  * Get the .tmd path for a title
@@ -417,6 +452,18 @@ std::string GetTicketPath(u64 title_id, u64 ticket_id);
  * @returns string path to the .tmd file if it exists, otherwise a path to create one is given.
  */
 std::string GetTitleMetadataPath(Service::FS::MediaType media_type, u64 tid, bool update = false);
+
+/**
+ * Check if the content is present (intalled or in bundle)
+ */
+bool TitleContentExists(Service::FS::MediaType media_type, u64 tid, std::size_t index,
+                        bool update = false);
+
+/**
+ * Opens a file to the specified content (installed or in bundle)
+ */
+std::unique_ptr<FileUtil::IOFileBase> GetTitleContent(Service::FS::MediaType media_type, u64 tid,
+                                                      std::size_t index, bool update = false);
 
 /**
  * Get the .app path for a title's installed content index.
@@ -1103,6 +1150,15 @@ public:
         force_new_device_id = true;
     }
 
+    std::unique_ptr<BundleCIAHandler>& GetBundleCIAHandler() {
+        return bundle_cia_handler;
+    }
+
+    /**
+     * Scans all storage mediums for titles for listing.
+     */
+    void ScanForAllTitles();
+
 private:
     void ScanForTickets();
 
@@ -1115,11 +1171,6 @@ private:
     void ScanForTitles(Service::FS::MediaType media_type);
 
     void ScanForTitlesImpl(Service::FS::MediaType media_type);
-
-    /**
-     * Scans all storage mediums for titles for listing.
-     */
-    void ScanForAllTitles();
 
     Core::System& system;
     bool cia_installing = false;
@@ -1138,6 +1189,7 @@ private:
     std::shared_ptr<CurrentImportingTitle> importing_title;
     std::map<u64, ImportTitleContext> import_title_contexts;
     std::multimap<u64, ImportContentContext> import_content_contexts;
+    std::unique_ptr<BundleCIAHandler> bundle_cia_handler;
 
     template <class Archive>
     void serialize(Archive& ar, const unsigned int);

--- a/src/core/loader/3dsx.cpp
+++ b/src/core/loader/3dsx.cpp
@@ -14,6 +14,7 @@
 #include "core/hle/service/fs/archive.h"
 #include "core/hle/service/fs/fs_user.h"
 #include "core/loader/3dsx.h"
+#include "core/loader/smdh.h"
 #include "core/memory.h"
 
 namespace Loader {
@@ -346,6 +347,27 @@ ResultStatus AppLoader_THREEDSX::ReadRomFS(std::shared_ptr<FileSys::RomFSReader>
     return ResultStatus::ErrorNotUsed;
 }
 
+ResultStatus Loader::AppLoader_THREEDSX::ReadTitle(std::string& title, bool prefer_update_title) {
+    std::vector<u8> data;
+    Loader::SMDH smdh;
+    ResultStatus result = ReadIcon(data, prefer_update_title);
+    if (result != ResultStatus::Success) {
+        return result;
+    }
+
+    if (!Loader::IsValidSMDH(data)) {
+        return ResultStatus::ErrorInvalidFormat;
+    }
+
+    std::memcpy(&smdh, data.data(), sizeof(Loader::SMDH));
+
+    const auto& short_title = smdh.GetShortTitle(SMDH::TitleLanguage::English);
+    auto title_end = std::find(short_title.begin(), short_title.end(), u'\0');
+    title = Common::UTF16ToUTF8(std::u16string{short_title.begin(), title_end});
+
+    return ResultStatus::Success;
+}
+
 AppLoader::CompressFileInfo AppLoader_THREEDSX::GetCompressFileInfo() {
     CompressFileInfo info;
     info.is_supported = true;
@@ -360,7 +382,8 @@ bool AppLoader_THREEDSX::IsFileCompressed() {
     return file->GetType().HasCompressedType();
 }
 
-ResultStatus AppLoader_THREEDSX::ReadIcon(std::vector<u8>& buffer) {
+ResultStatus AppLoader_THREEDSX::ReadIcon(std::vector<u8>& buffer,
+                                          [[maybe_unused]] bool prefer_update_icon) {
     if (!file->IsOpen())
         return ResultStatus::Error;
 

--- a/src/core/loader/3dsx.h
+++ b/src/core/loader/3dsx.h
@@ -34,9 +34,11 @@ public:
 
     ResultStatus Load(std::shared_ptr<Kernel::Process>& process) override;
 
-    ResultStatus ReadIcon(std::vector<u8>& buffer) override;
+    ResultStatus ReadIcon(std::vector<u8>& buffer, bool prefer_update_icon) override;
 
     ResultStatus ReadRomFS(std::shared_ptr<FileSys::RomFSReader>& romfs_file) override;
+
+    ResultStatus ReadTitle(std::string& title, bool prefer_update_title) override;
 
     CompressFileInfo GetCompressFileInfo() override;
 

--- a/src/core/loader/artic.cpp
+++ b/src/core/loader/artic.cpp
@@ -136,7 +136,7 @@ Apploader_Artic::LoadNew3dsHwCapabilities() {
 
 bool Apploader_Artic::IsN3DSExclusive() {
     std::vector<u8> smdh_buffer;
-    if (ReadIcon(smdh_buffer) == ResultStatus::Success && IsValidSMDH(smdh_buffer)) {
+    if (ReadIcon(smdh_buffer, false) == ResultStatus::Success && IsValidSMDH(smdh_buffer)) {
         SMDH* smdh = reinterpret_cast<SMDH*>(smdh_buffer.data());
         return smdh->flags.n3ds_exclusive != 0;
     }
@@ -273,7 +273,8 @@ void Apploader_Artic::ParseRegionLockoutInfo(u64 program_id) {
     preferred_regions.clear();
 
     std::vector<u8> smdh_buffer;
-    if (ReadIcon(smdh_buffer) == ResultStatus::Success && smdh_buffer.size() >= sizeof(SMDH)) {
+    if (ReadIcon(smdh_buffer, false) == ResultStatus::Success &&
+        smdh_buffer.size() >= sizeof(SMDH)) {
         SMDH smdh;
         std::memcpy(&smdh, smdh_buffer.data(), sizeof(SMDH));
         u32 region_lockout = smdh.region_lockout;
@@ -403,7 +404,7 @@ ResultStatus Apploader_Artic::Load(std::shared_ptr<Kernel::Process>& process) {
 
     if (auto room_member = Network::GetRoomMember().lock()) {
         Network::GameInfo game_info;
-        ReadTitle(game_info.name);
+        ReadTitle(game_info.name, true);
         game_info.id = ncch_program_id;
         room_member->SendGameInfo(game_info);
     }
@@ -662,7 +663,8 @@ ResultStatus Apploader_Artic::ReadCode(std::vector<u8>& buffer) {
     return ResultStatus::Success;
 }
 
-ResultStatus Apploader_Artic::ReadIcon(std::vector<u8>& buffer) {
+ResultStatus Apploader_Artic::ReadIcon(std::vector<u8>& buffer,
+                                       [[maybe_unused]] bool prefer_update_icon) {
     if (!cached_icon.empty()) {
         buffer = cached_icon;
         return ResultStatus::Success;
@@ -811,10 +813,10 @@ ResultStatus Apploader_Artic::DumpUpdateRomFS(const std::string& target_path) {
     return ResultStatus::ErrorNotImplemented;
 }
 
-ResultStatus Apploader_Artic::ReadTitle(std::string& title) {
+ResultStatus Apploader_Artic::ReadTitle(std::string& title, bool prefer_update_title) {
     std::vector<u8> data;
     Loader::SMDH smdh;
-    ResultStatus result = ReadIcon(data);
+    ResultStatus result = ReadIcon(data, prefer_update_title);
     if (result != ResultStatus::Success) {
         return result;
     }

--- a/src/core/loader/artic.h
+++ b/src/core/loader/artic.h
@@ -62,7 +62,7 @@ public:
 
     ResultStatus ReadCode(std::vector<u8>& buffer) override;
 
-    ResultStatus ReadIcon(std::vector<u8>& buffer) override;
+    ResultStatus ReadIcon(std::vector<u8>& buffer, bool prefer_update_icon) override;
 
     ResultStatus ReadBanner(std::vector<u8>& buffer) override;
 
@@ -80,7 +80,7 @@ public:
 
     ResultStatus DumpUpdateRomFS(const std::string& target_path) override;
 
-    ResultStatus ReadTitle(std::string& title) override;
+    ResultStatus ReadTitle(std::string& title, bool prefer_update_icon) override;
 
     bool SupportsSaveStates() override {
         return false;

--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -51,29 +51,29 @@ FileType GuessFromExtension(const std::string& extension_) {
     if (extension == ".elf" || extension == ".axf")
         return FileType::ELF;
 
-    if (extension == ".cci" || extension == ".zcci" || extension == ".3ds")
+    if (extension == ".cci" || extension == ".zcci" || extension == ".bcci" || extension == ".3ds")
         return FileType::CCI;
 
-    if (extension == ".cxi" || extension == ".app" || extension == ".zcxi")
+    if (extension == ".cxi" || extension == ".app" || extension == ".zcxi" || extension == ".bcxi")
         return FileType::CXI;
 
     if (extension == ".3dsx" || extension == ".z3dsx")
         return FileType::THREEDSX;
 
-    if (extension == ".cia" || extension == ".zcia")
+    if (extension == ".cia" || extension == ".zcia" || extension == ".bcia")
         return FileType::CIA;
 
     return FileType::Unknown;
 }
 
-const char* GetFileTypeString(FileType type, bool is_compressed) {
+const char* GetFileTypeString(FileType type, bool is_compressed, bool is_bundle) {
     switch (type) {
     case FileType::CCI:
-        return is_compressed ? "NCSD (Z)" : "NCSD";
+        return is_bundle ? "NCSD (B)" : (is_compressed ? "NCSD (Z)" : "NCSD");
     case FileType::CXI:
-        return is_compressed ? "NCCH (Z)" : "NCCH";
+        return is_bundle ? "NCCH (B)" : (is_compressed ? "NCCH (Z)" : "NCCH");
     case FileType::CIA:
-        return is_compressed ? "CIA (Z)" : "CIA";
+        return is_bundle ? "CIA (B)" : (is_compressed ? "CIA (Z)" : "CIA");
     case FileType::ELF:
         return "ELF";
     case FileType::THREEDSX:

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -60,7 +60,7 @@ FileType GuessFromExtension(const std::string& extension);
 /**
  * Convert a FileType into a string which can be displayed to the user.
  */
-const char* GetFileTypeString(FileType type, bool is_compressed = false);
+const char* GetFileTypeString(FileType type, bool is_compressed = false, bool is_bundle = false);
 
 /// Return type for functions in Loader namespace
 enum class ResultStatus {
@@ -187,9 +187,11 @@ public:
     /**
      * Get the icon (typically icon section) of the application
      * @param buffer Reference to buffer to store data
+     * @param prefer_update_icon Prefer reading the update data icon if available
      * @return ResultStatus result of function
      */
-    virtual ResultStatus ReadIcon([[maybe_unused]] std::vector<u8>& buffer) {
+    virtual ResultStatus ReadIcon([[maybe_unused]] std::vector<u8>& buffer,
+                                  [[maybe_unused]] bool prefer_update_icon) {
         return ResultStatus::ErrorNotImplemented;
     }
 
@@ -272,9 +274,11 @@ public:
     /**
      * Get the title of the application
      * @param title Reference to store the application title into
+     * @param prefer_update_title Prefer reading the update data title if available
      * @return ResultStatus result of function
      */
-    virtual ResultStatus ReadTitle([[maybe_unused]] std::string& title) {
+    virtual ResultStatus ReadTitle([[maybe_unused]] std::string& title,
+                                   [[maybe_unused]] bool prefer_update_title) {
         return ResultStatus::ErrorNotImplemented;
     }
 
@@ -300,9 +304,15 @@ public:
         return false;
     }
 
+    virtual bool IsFileBundle() {
+        return false;
+    }
+
     virtual std::string GetFilePath() {
         return file ? file->Filename() : "";
     }
+
+    virtual void LoadBundle() {}
 
 protected:
     Core::System& system;

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -37,6 +37,8 @@ using namespace Common::Literals;
 static constexpr u64 UPDATE_TID_HIGH = 0x0004000e00000000;
 static constexpr u64 DLP_CHILD_TID_HIGH = 0x0004000100000000;
 
+AppLoader_NCCH::~AppLoader_NCCH() {}
+
 FileType AppLoader_NCCH::IdentifyType(FileUtil::IOFileBase* in_file) {
     u32 magic{};
 
@@ -111,7 +113,7 @@ bool AppLoader_NCCH::IsN3DSExclusive() {
     }
 
     std::vector<u8> smdh_buffer;
-    if (ReadIcon(smdh_buffer) == ResultStatus::Success && IsValidSMDH(smdh_buffer)) {
+    if (ReadIcon(smdh_buffer, false) == ResultStatus::Success && IsValidSMDH(smdh_buffer)) {
         SMDH* smdh = reinterpret_cast<SMDH*>(smdh_buffer.data());
         return smdh->flags.n3ds_exclusive != 0;
     }
@@ -255,7 +257,8 @@ void AppLoader_NCCH::ParseRegionLockoutInfo(u64 program_id) {
     preferred_regions.clear();
 
     std::vector<u8> smdh_buffer;
-    if (ReadIcon(smdh_buffer) == ResultStatus::Success && smdh_buffer.size() >= sizeof(SMDH)) {
+    if (ReadIcon(smdh_buffer, false) == ResultStatus::Success &&
+        smdh_buffer.size() >= sizeof(SMDH)) {
         SMDH smdh;
         std::memcpy(&smdh, smdh_buffer.data(), sizeof(SMDH));
         u32 region_lockout = smdh.region_lockout;
@@ -284,6 +287,46 @@ bool AppLoader_NCCH::IsGbaVirtualConsole(std::span<const u8> code) {
     return gbaVcHeader[0] == FileUtil::MakeMagic('.', 'C', 'A', 'A') && gbaVcHeader[1] == 1;
 }
 
+ResultStatus AppLoader_NCCH::OpenUpdateNCCH() {
+    u64 program_id;
+    ReadProgramId(program_id);
+
+    bool is_dlp_child = (program_id & 0xFFFFFFFF00000000) == DLP_CHILD_TID_HIGH;
+    if (is_dlp_child) {
+        return ResultStatus::ErrorNotFound;
+    }
+
+    u64 update_tid = (program_id & 0xFFFFFFFFULL) | UPDATE_TID_HIGH;
+
+    Loader::ResultStatus result = Loader::ResultStatus::Success;
+
+    if (!update_ncch.IsLoaded()) {
+        auto open_update = [&](std::unique_ptr<FileUtil::IOFileBase>&& file) {
+            update_ncch = FileSys::NCCHContainer(file.get());
+            file.reset();
+            return update_ncch.Load();
+        };
+
+        result =
+            open_update(Service::AM::GetTitleContent(Service::FS::MediaType::SDMC, update_tid, 0));
+        if (result != ResultStatus::Success) {
+            // Try bundle, if this is the main loader AM may not be registered yet.
+            if (base_ncch.IsFileBundle()) {
+                if (!bundle_cia_handler) {
+                    bundle_cia_handler = std::make_unique<Service::AM::BundleCIAHandler>();
+                    bundle_cia_handler->RegisterBundle(base_ncch.GetFile()->Filename());
+                }
+                if (bundle_cia_handler->HasTitle(update_tid, Service::FS::MediaType::SDMC, 0)) {
+                    result = open_update(bundle_cia_handler->OpenContentFile(
+                        update_tid, Service::FS::MediaType::SDMC, 0));
+                }
+            }
+        }
+    }
+
+    return result;
+}
+
 ResultStatus AppLoader_NCCH::Load(std::shared_ptr<Kernel::Process>& process) {
     u64_le ncch_program_id;
 
@@ -299,21 +342,13 @@ ResultStatus AppLoader_NCCH::Load(std::shared_ptr<Kernel::Process>& process) {
 
     LOG_INFO(Loader, "Program ID: {}", program_id);
 
-    bool is_dlp_child = (ncch_program_id & 0xFFFFFFFF00000000) == DLP_CHILD_TID_HIGH;
-
-    if (!is_dlp_child) {
-        u64 update_tid = (ncch_program_id & 0xFFFFFFFFULL) | UPDATE_TID_HIGH;
-        update_ncch.OpenFile(
-            Service::AM::GetTitleContentPath(Service::FS::MediaType::SDMC, update_tid));
-        result = update_ncch.Load();
-        if (result == ResultStatus::Success) {
-            overlay_ncch = &update_ncch;
-        }
+    if (OpenUpdateNCCH() == ResultStatus::Success) {
+        overlay_ncch = &update_ncch;
     }
 
     if (auto room_member = Network::GetRoomMember().lock()) {
         Network::GameInfo game_info;
-        ReadTitle(game_info.name);
+        ReadTitle(game_info.name, false);
         game_info.id = ncch_program_id;
         room_member->SendGameInfo(game_info);
     }
@@ -344,8 +379,18 @@ ResultStatus AppLoader_NCCH::ReadCode(std::vector<u8>& buffer) {
     return overlay_ncch->LoadSectionExeFS(".code", buffer);
 }
 
-ResultStatus AppLoader_NCCH::ReadIcon(std::vector<u8>& buffer) {
-    return overlay_ncch->LoadSectionExeFS("icon", buffer);
+ResultStatus AppLoader_NCCH::ReadIcon(std::vector<u8>& buffer, bool prefer_update_icon) {
+    if (prefer_update_icon) {
+        ResultStatus result = OpenUpdateNCCH();
+        if (result == Loader::ResultStatus::Success) {
+            result = update_ncch.LoadSectionExeFS("icon", buffer);
+            if (result == Loader::ResultStatus::Success) {
+                return result;
+            }
+        }
+    }
+
+    return base_ncch.LoadSectionExeFS("icon", buffer);
 }
 
 ResultStatus AppLoader_NCCH::ReadBanner(std::vector<u8>& buffer) {
@@ -390,18 +435,14 @@ ResultStatus AppLoader_NCCH::DumpRomFS(const std::string& target_path) {
 }
 
 ResultStatus AppLoader_NCCH::DumpUpdateRomFS(const std::string& target_path) {
-    u64 program_id;
-    ReadProgramId(program_id);
-    u64 update_tid = (program_id & 0xFFFFFFFFULL) | UPDATE_TID_HIGH;
-    update_ncch.OpenFile(
-        Service::AM::GetTitleContentPath(Service::FS::MediaType::SDMC, update_tid));
-    return update_ncch.DumpRomFS(target_path);
+    Loader::ResultStatus result = OpenUpdateNCCH();
+    return result == ResultStatus::Success ? update_ncch.DumpRomFS(target_path) : result;
 }
 
-ResultStatus AppLoader_NCCH::ReadTitle(std::string& title) {
+ResultStatus AppLoader_NCCH::ReadTitle(std::string& title, bool prefer_update_title) {
     std::vector<u8> data;
     Loader::SMDH smdh;
-    ReadIcon(data);
+    ReadIcon(data, prefer_update_title);
 
     if (!Loader::IsValidSMDH(data)) {
         return ResultStatus::ErrorInvalidFormat;
@@ -451,6 +492,21 @@ bool AppLoader_NCCH::IsFileCompressed() {
         return false;
     }
     return base_ncch.IsFileCompressed();
+}
+
+bool AppLoader_NCCH::IsFileBundle() {
+    if (base_ncch.LoadHeader() != ResultStatus::Success) {
+        return false;
+    }
+    return base_ncch.IsFileBundle();
+}
+
+void AppLoader_NCCH::LoadBundle() {
+    if (base_ncch.IsFileBundle()) {
+        if (auto am = Service::AM::GetModule(system)) {
+            am->GetBundleCIAHandler()->RegisterBundle(base_ncch.GetFile()->Filename());
+        }
+    }
 }
 
 } // namespace Loader

--- a/src/core/loader/ncch.h
+++ b/src/core/loader/ncch.h
@@ -10,6 +10,10 @@
 #include "core/file_sys/ncch_container.h"
 #include "core/loader/loader.h"
 
+namespace Service::AM {
+class BundleCIAHandler;
+}
+
 namespace Loader {
 
 /// Loads an NCCH file (e.g. from a CCI, or the first NCCH in a CXI)
@@ -21,6 +25,8 @@ public:
         filetype = IdentifyType(this->file.get());
         this->file.reset();
     }
+
+    ~AppLoader_NCCH();
 
     /**
      * Returns the type of the file
@@ -56,7 +62,7 @@ public:
 
     ResultStatus ReadCode(std::vector<u8>& buffer) override;
 
-    ResultStatus ReadIcon(std::vector<u8>& buffer) override;
+    ResultStatus ReadIcon(std::vector<u8>& buffer, bool prefer_update_icon) override;
 
     ResultStatus ReadBanner(std::vector<u8>& buffer) override;
 
@@ -74,15 +80,19 @@ public:
 
     ResultStatus DumpUpdateRomFS(const std::string& target_path) override;
 
-    ResultStatus ReadTitle(std::string& title) override;
+    ResultStatus ReadTitle(std::string& title, bool prefer_update_title) override;
 
     CompressFileInfo GetCompressFileInfo() override;
 
     bool IsFileCompressed() override;
 
+    bool IsFileBundle() override;
+
     std::string GetFilePath() override {
         return filepath;
     }
+
+    void LoadBundle() override;
 
 private:
     /**
@@ -100,9 +110,12 @@ private:
     /// Detects whether the NCCH contains GBA Virtual Console.
     bool IsGbaVirtualConsole(std::span<const u8> code);
 
+    ResultStatus OpenUpdateNCCH();
+
     FileSys::NCCHContainer base_ncch;
     FileSys::NCCHContainer update_ncch;
     FileSys::NCCHContainer* overlay_ncch;
+    std::unique_ptr<Service::AM::BundleCIAHandler> bundle_cia_handler;
 
     std::vector<u32> preferred_regions;
 


### PR DESCRIPTION
This PR adds bundle ROM support to Azahar.

# What are Bundle ROMS
Bundle ROMs are a new type of ROM files supported by Azahar.
They are basically uncompressed `tar` archives that bundle together several `cci/zcci`, `cia/zcia` or `cxi/zcxi` files. The idea of this new file type is to make it easier for users to load updates and DLC on environments where their installation is more complicated, such as `libretro`.

This change was initially proposed as a feature to [GodMode9](https://github.com/d0k3/GodMode9/issues/962).

## Bundle CIA files (`.bcia`)
Bundle CIA files are the simpler ones, they are a `tar` archive that only contains `.cia/.zcia` files. They can be installed on Desktop and Android, which will just install the bundled `cia` files. This is really only useful for users that want to pack several `cia` files together for archiving or transfering purposes.

## Bundle CCI (3DS) and CXI files (`.bcxi` and `.bcci`)
Bundle CCI and CXI is where the real magic happens, they are a `tar` archive that contains a single `.cci/.3ds/.zcci` or `.cxi/.zcxi` file, and as many `.cia/.zcia` files. The main CCI/CXI will be the bootable application, while all bundled CIA files will be simulated as being installed to the emulated system without taking extra space.

A few use cases for bundle CCI files are the following:
  - Bundle applications together with its update data.
  - Bundle applications together with its DLC data.
  - Bundle applications with system files, such as the Mii models or system font (allows using games that rely on setting up system files without having to do so).

In conclusion, bundled CCI files will make it easier for users of `libretro` to use applications with updates, DLC and system files. It also helps reducing disk usage by not having to permanently install updates for applications that may be used sporadically.

The emulator will simulate all the bundled CIA files as being installed, so that applications can access them. However, if the same title ID is already installed to the virtual system, that specific bundled CIA will be ignored. Bundle CCI files can also be inserted with the "Insert Cartridge" option, which will load all the bundled CIA files too (if another bundled CCI is launched, the inserted one will take preference).

# Creating Bundle ROMS
Support for creating bundle ROMS will be added to the QT frontend later in this PR, and to the Android frontent in a future PR. For now, you can create bundle ROMS using the GNU `tar` command. For example:
```
tar -cf out.bcci application.cci update.cia dlc.cia
```

# To do:
- [ ] More testing in all platforms
- [ ] Ensure savestates are still working
- [ ] Add bundle creation and extraction support to QT