### PR TITLE
libretro: update android NDK to v29

### DIFF
--- a/.ci/libretro-ci.yml
+++ b/.ci/libretro-ci.yml
@@ -103,7 +103,7 @@ android-arm64-v8a:
     - .libretro-android-cmake-arm64-v8a
     - .core-defs
   variables:
-    ANDROID_NDK_VERSION: 27.3.13750724
+    ANDROID_NDK_VERSION: 29.0.14206865
     NDK_ROOT: /android-sdk-linux/ndk/$ANDROID_NDK_VERSION
     LIBNAME: ${CORENAME}_libretro.so
   artifacts:

--- a/.github/workflows/libretro.yml
+++ b/.github/workflows/libretro.yml
@@ -23,7 +23,7 @@ jobs:
       OS: android
       TARGET: arm64-v8a
       API_LEVEL: 21
-      ANDROID_NDK_VERSION: 27.3.13750724
+      ANDROID_NDK_VERSION: 29.0.14206865
       ANDROID_ABI: arm64-v8a
       BUILD_DIR: build/android-arm64-v8a
       EXTRA_PATH: bin/Release


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

---

![Ignore Until Your PR has been created!](../blob/master/.github/ignore_unless_human.png?raw=true)
---

As part of move back on to the play store, RA is now migrated the Android NDK to 29.0.14206865. This is for 16kb pages support, which is a requirement on the play store. It automatically sets 16kb pages.

Tested building locally. 29.0.14206865 is already on the buildbot and used daily.