### PR TITLE
dist: add compressed ROM globs and fix MIME icon name

### DIFF
--- a/dist/org.azahar_emu.Azahar.xml
+++ b/dist/org.azahar_emu.Azahar.xml
@@ -4,8 +4,9 @@
         <comment>Nintendo 3DS homebrew executable</comment>
         <comment xml:lang="fr">Exécutable non-officiel pour Nintendo 3DS </comment>
         <acronym>3DSX</acronym>
-        <icon name="azahar"/>
+        <icon name="org.azahar_emu.Azahar"/>
         <glob pattern="*.3dsx"/>
+        <glob pattern="*.z3dsx"/>
         <magic><match value="3DSX" type="string" offset="0"/></magic>
     </mime-type>
 
@@ -14,9 +15,10 @@
         <comment xml:lang="fr">Image de cartouche Nintendo 3DS</comment>
         <acronym>CCI</acronym>
         <expanded-acronym>CTR Cart Image</expanded-acronym>
-        <icon name="azahar"/>
+        <icon name="org.azahar_emu.Azahar"/>
         <glob pattern="*.cci"/>
         <glob pattern="*.3ds"/>
+        <glob pattern="*.zcci"/>
         <magic><match value="NCSD" type="string" offset="256"/></magic>
     </mime-type>
 
@@ -25,8 +27,9 @@
         <comment xml:lang="fr">Exécutable Nintendo 3DS</comment>
         <acronym>CXI</acronym>
         <expanded-acronym>CTR eXecutable Image</expanded-acronym>
-        <icon name="azahar"/>
+        <icon name="org.azahar_emu.Azahar"/>
         <glob pattern="*.cxi"/>
+        <glob pattern="*.zcxi"/>
         <magic><match value="NCCH" type="string" offset="256"/></magic>
     </mime-type>
 
@@ -35,8 +38,9 @@
         <comment xml:lang="fr">Archive installable Nintendo 3DS</comment>
         <acronym>CIA</acronym>
         <expanded-acronym>CTR Importable Archive</expanded-acronym>
-        <icon name="azahar"/>
+        <icon name="org.azahar_emu.Azahar"/>
         <glob pattern="*.cia"/>
+        <glob pattern="*.zcia"/>
     </mime-type>
 
     <mime-type type="application/x-ctr-smdh">


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

---
<!--
If you are contributing to Azahar for the first time please
keep the block of text between `---` and write your 
PR description below it. Do not write anything inside 
or change this block of text!

If you are a recurrent contributor, remove this entire
block of text and proceed as normal.
-->

![Ignore Until Your PR has been created!](../blob/master/.github/ignore_unless_human.png?raw=true)
---

The installed MIME package does not recognise the compressed ROM formats Azahar itself writes, and names an icon that no install rule creates.

**Globs.** `Loader::IdentifyFile` accepts `.zcci`, `.zcxi`, `.z3dsx` and `.zcia` (`src/core/loader/loader.cpp:51-64`), and Azahar produces them via "Save 3DS Compressed ROM File". The Qt scanner, the libretro core and the Android frontend all list them; `dist/org.azahar_emu.Azahar.xml` does not, so a file Azahar just wrote is unidentifiable to the desktop and "Open With → Azahar" is not offered.

The existing `<magic>` rules match the uncompressed `NCSD`/`NCCH`/`3DSX` headers, which a compressed container will not match, so these are added as globs.

`.app`, `.elf` and `.axf` are deliberately left out: ELF is already covered by shared-mime-info, and `.app` is too ambiguous to claim.

**Icon.** `CMakeLists.txt:595-600` and `CMakeModules/BundleTarget.cmake:127` install the icons renamed to `org.azahar_emu.Azahar`. `dist/azahar.desktop` was migrated to that name; the MIME package still asks for `azahar`, which is never installed, so file managers fall through to the generic icon.

### Testing

Installed the package into a scratch prefix, `update-mime-database`, then `gio info`.

Before:

```
a.zcia   -> application/octet-stream
a.zcci   -> application/octet-stream
a.zcxi   -> application/octet-stream
a.z3dsx  -> application/octet-stream
a.cia    -> application/x-ctr-cia      icon=azahar          (no such icon installed)
```

After:

```
a.zcia   -> application/x-ctr-cia      icon=org.azahar_emu.Azahar
a.zcci   -> application/x-ctr-cci      icon=org.azahar_emu.Azahar
a.zcxi   -> application/x-ctr-cxi      icon=org.azahar_emu.Azahar
a.z3dsx  -> application/x-ctr-3dsx     icon=org.azahar_emu.Azahar
a.cia    -> application/x-ctr-cia      icon=org.azahar_emu.Azahar
```

Uncompressed types are unchanged. `desktop-file-validate` on both `dist/*.desktop` still passes.

Note: #2369 adds `.bcia`/`.bcci`/`.bcxi`; those globs will want adding here too once it lands.

AI assisted
