### PR TITLE
Lower minimum sensitivity to 0.001(fix #1153)

### DIFF
--- a/src/citra_qt/configuration/configure_motion_touch.ui
+++ b/src/citra_qt/configuration/configure_motion_touch.ui
@@ -52,7 +52,7 @@
            <number>4</number>
           </property>
           <property name="minimum">
-           <double>0.010000000000000</double>
+           <double>0.001000000000000</double>
           </property>
           <property name="maximum">
            <double>10.000000000000000</double>


### PR DESCRIPTION
- [ x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

This allows for the sensitivity to be set lower than 0.01, I encountered the same issue as #1153 where Dream Team's motion controls where too sensitive. 
