### PR TITLE
android: Fix inability to access files in the Download folder in some circumstances

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
@@ -13,6 +13,7 @@ import android.content.res.Configuration
 import android.net.Uri
 import android.os.Bundle
 import android.os.Environment
+import android.provider.OpenableColumns
 import android.text.Html
 import android.text.method.LinkMovementMethod
 import android.view.Surface
@@ -768,6 +769,7 @@ object NativeLibrary {
     fun getNativePath(uri: Uri): String {
         BuildUtil.assertNotGooglePlay()
 
+        val context = CitraApplication.appContext
         val dirSep = "/"
 
         val uriString = uri.toString()
@@ -781,11 +783,42 @@ object NativeLibrary {
 
         val pathSegment = uri.lastPathSegment ?: return ""
         val virtualPath = pathSegment.substringAfter(":")
+        val primaryStoragePath = Environment.getExternalStorageDirectory().absolutePath
 
-        if (pathSegment.startsWith("primary:")) { // User directory is located in primary storage
-            val primaryStoragePath = Environment.getExternalStorageDirectory().absolutePath
+        if (pathSegment.startsWith("primary:")) { // Path is located in primary storage
+            android.util.Log.v(
+                "NativeLibrary",
+                "Successfully resolved URI of type PRIMARY: $uri)"
+            )
             return primaryStoragePath + dirSep + virtualPath
-        } else { // User directory probably located on a removable storage device
+        } else if (uriString // Path is likely located in the /Download folder
+                .startsWith("content://com.android.providers.downloads.documents/document/msf")
+        ) {
+            var fileName: String? = null
+            context.contentResolver.query(
+                uri,
+                arrayOf(OpenableColumns.DISPLAY_NAME),
+                null,
+                null,
+                null
+            )?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    fileName = cursor.getString(0)
+                }
+            }
+            if (fileName == null) {
+                android.util.Log.e(
+                    "NativeLibrary",
+                    "Unable to resolve URI to real file (URI: $uri)"
+                )
+                return ""
+            }
+            android.util.Log.v(
+                "NativeLibrary",
+                "Successfully resolved URI of type DOWNLOAD with fileName '$fileName': $uri)"
+            )
+            return primaryStoragePath + dirSep + "Download" + dirSep + fileName
+        } else { // Path is probably located on a removable storage device
             val storageIdString = pathSegment.substringBefore(":")
             val removablePath = RemovableStorageHelper.getRemovableStoragePath(
                 CitraApplication.appContext,
@@ -799,6 +832,10 @@ object NativeLibrary {
                 )
                 return ""
             }
+            android.util.Log.v(
+                "NativeLibrary",
+                "Successfully resolved URI of type EXTERNAL: $uri)"
+            )
             return removablePath + dirSep + virtualPath
         }
     }

--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
@@ -783,9 +783,9 @@ object NativeLibrary {
 
         val pathSegment = uri.lastPathSegment ?: return ""
         val virtualPath = pathSegment.substringAfter(":")
-        val primaryStoragePath = Environment.getExternalStorageDirectory().absolutePath
 
         if (pathSegment.startsWith("primary:")) { // Path is located in primary storage
+            val primaryStoragePath = Environment.getExternalStorageDirectory().absolutePath
             android.util.Log.v(
                 "NativeLibrary",
                 "Successfully resolved URI of type PRIMARY: $uri)"
@@ -813,11 +813,14 @@ object NativeLibrary {
                 )
                 return ""
             }
+            val downloadsPath = Environment.getExternalStoragePublicDirectory(
+                Environment.DIRECTORY_DOWNLOADS
+            ).absolutePath
             android.util.Log.v(
                 "NativeLibrary",
                 "Successfully resolved URI of type DOWNLOAD with fileName '$fileName': $uri)"
             )
-            return primaryStoragePath + dirSep + "Download" + dirSep + fileName
+            return downloadsPath + dirSep + fileName
         } else { // Path is probably located on a removable storage device
             val storageIdString = pathSegment.substringBefore(":")
             val removablePath = RemovableStorageHelper.getRemovableStoragePath(


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Closes #2083

Depending on whether or not a file is selected from the "Downloads" sidebar in the file selector or navigated to manually from the phone's root/home directory, the URI passed to Azahar would be different. In the case of the former, a URI would be passed to Azahar which it didn't know how to handle. This PR adds code to allow Azahar to handle this kind of URI.

This bug only affects the `vanilla` variant of Azahar on Android due to its different method of accessing files. The Google Play version is unaffected.

This PR also adds some additional verbose logging calls which display the type of URI resolution which was performed and the URI which was passed.

Qwen was used to generate a basic template for the `context.contentResolver.query(...)?.use { cursor -> }` pattern used here. Otherwise human-written and human-tested.