### PR TITLE
android: Strip VERBOSE type logs from Release builds

### DIFF
--- a/src/android/app/proguard-rules.pro
+++ b/src/android/app/proguard-rules.pro
@@ -23,3 +23,8 @@
 -dontwarn java.beans.Introspector
 -dontwarn java.beans.VetoableChangeListener
 -dontwarn java.beans.VetoableChangeSupport
+
+# Don't include VERBOSE log calls in release builds
+-assumenosideeffects class android.util.Log {
+    public static int v(...);
+}


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

This log type, which is the lowest priority type, is to be used for successful URI resolution attempts as of #2385. Certain apps such as FBI cause URI resolution to occur *constantly*, to the extent that these logs may actually, to some extent, result in increased processing strain. This PR simply strips out these log calls for builds of the `Release` type via a proguard rule.