### PR TITLE
Adjustments to accommodate move to LLVM-based MXE build environment

### DIFF
--- a/.ci/mxe.sh
+++ b/.ci/mxe.sh
@@ -2,7 +2,7 @@
 
 # TODO: Why doesn't the CI environment use the PATH set in the Dockerimage?
 #       It works fine when using the image locally.
-export PATH="/mxe/usr/bin:${PATH}"
+export PATH="/opt/mxe/usr/bin:${PATH}"
 
 mkdir build && cd build
 
@@ -14,9 +14,11 @@ x86_64-w64-mingw32.shared-cmake .. \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER_LAUNCHER=ccache \
     -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER_AR=x86_64-w64-mingw32.shared-ar \
+    -DCMAKE_CXX_COMPILER_RANLIB=x86_64-w64-mingw32.shared-ranlib \
     -DENABLE_DISCORD_RPC=ON \
-    -DUSE_SYSTEM_BOOST=ON \
-    -DUSE_SYSTEM_CRYPTOPP=ON \
 	"${EXTRA_CMAKE_FLAGS[@]}"
 x86_64-w64-mingw32.shared-cmake --build . -- -j$(nproc)
 x86_64-w64-mingw32.shared-strip -s bin/Release/*.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -284,7 +284,7 @@ jobs:
       - name: Generate installer (MXE)
         if: ${{ github.ref_type == 'tag' && matrix.target == 'mxe' }}
         run: |
-          export PATH="/mxe/usr/bin:${PATH}" # TODO: Why do we have to do this if it's in the image?
+          export PATH="/opt/mxe/usr/bin:${PATH}" # TODO: Why do we have to do this if it's in the image?
           cd src/installer
           x86_64-w64-mingw32.shared-makensis -DPRODUCT_VARIANT=${{ matrix.target }} -DPRODUCT_VERSION=${{ github.ref_name }} citra.nsi
           mkdir -p ../../artifacts

--- a/src/citra_meta/CMakeLists.txt
+++ b/src/citra_meta/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 
 if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" AND MINGW)
     # TODO: Do this for all executables, not just citra_meta
-    # TODO: Don't hardcode MXE directory to root?
+    # TODO: Don't hardcode MXE directory?
     set(dllwalker_command "${CMAKE_SOURCE_DIR}/externals/dllwalker/dllwalker.rb"
                           $<TARGET_FILE:citra_meta>
                           /opt/mxe/usr/x86_64-w64-mingw32.shared/bin/

--- a/src/citra_meta/CMakeLists.txt
+++ b/src/citra_meta/CMakeLists.txt
@@ -55,8 +55,9 @@ if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" AND MINGW)
     # TODO: Don't hardcode MXE directory to root?
     set(dllwalker_command "${CMAKE_SOURCE_DIR}/externals/dllwalker/dllwalker.rb"
                           $<TARGET_FILE:citra_meta>
-                          /mxe/usr/x86_64-w64-mingw32.shared/bin/
-                          /mxe/usr/x86_64-w64-mingw32.shared/qt6/bin/)
+                          /opt/mxe/usr/x86_64-w64-mingw32.shared/bin/
+                          /opt/mxe/usr/x86_64-w64-mingw32.shared/qt6/bin/
+                          /opt/mxe/usr/x86_64-w64-mingw32.shared/x86_64-w64-mingw32/bin/)
     set(dll_list_filename "${CMAKE_CURRENT_BINARY_DIR}/required_dlls_list.txt")
     add_custom_command(TARGET citra_meta POST_BUILD
         COMMAND ${dllwalker_command} > ${dll_list_filename}
@@ -64,7 +65,7 @@ if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" AND MINGW)
     add_custom_command(TARGET citra_meta POST_BUILD
         COMMAND cat ${dll_list_filename} | xargs -I {} ${CMAKE_COMMAND} -E copy {} $<TARGET_FILE_DIR:citra_meta>
         COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:citra_meta>/plugins/"
-        COMMAND ${CMAKE_COMMAND} -E copy_directory /mxe/usr/x86_64-w64-mingw32.shared/qt6/plugins/ "$<TARGET_FILE_DIR:citra_meta>/plugins/"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory /opt/mxe/usr/x86_64-w64-mingw32.shared/qt6/plugins/ "$<TARGET_FILE_DIR:citra_meta>/plugins/"
         COMMAND_EXPAND_LISTS
         DEPENDS ${dll_list_filename}
     )


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Closes #2355 
Closes #2135

Changes which have been made to the Azahar build environment to address the above issues are not backwards compatible, and require the following adjustments in the Azahar codebase to build correctly.