### PR TITLE
video_core: Add missing cull mode type

### DIFF
--- a/src/video_core/pica/regs_rasterizer.h
+++ b/src/video_core/pica/regs_rasterizer.h
@@ -20,7 +20,7 @@ struct RasterizerRegs {
         KeepAll = 0,
         KeepClockWise = 1,
         KeepCounterClockWise = 2,
-        // TODO: What does the third value imply?
+        KeepAll2 = 3,
     };
 
     union {

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -260,7 +260,8 @@ void RasterizerOpenGL::SyncDrawState() {
     // SyncClipEnabled();
     state.clip_distance[1] = regs.rasterizer.clip_enable != 0;
     // SyncCullMode();
-    state.cull.enabled = regs.rasterizer.cull_mode != Pica::RasterizerRegs::CullMode::KeepAll;
+    state.cull.enabled = regs.rasterizer.cull_mode != Pica::RasterizerRegs::CullMode::KeepAll &&
+                         regs.rasterizer.cull_mode != Pica::RasterizerRegs::CullMode::KeepAll2;
     if (state.cull.enabled) {
         state.cull.front_face =
             regs.rasterizer.cull_mode == Pica::RasterizerRegs::CullMode::KeepClockWise ? GL_CW

--- a/src/video_core/renderer_software/sw_rasterizer.cpp
+++ b/src/video_core/renderer_software/sw_rasterizer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 Citra Emulator Project
+// Copyright Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -243,7 +243,8 @@ void RasterizerSoftware::ProcessTriangle(const Vertex& v0, const Vertex& v1, con
         screen_to_rasterizer_coords(v2.screenpos),
     };
 
-    if (regs.rasterizer.cull_mode == RasterizerRegs::CullMode::KeepAll) {
+    if (regs.rasterizer.cull_mode == RasterizerRegs::CullMode::KeepAll ||
+        regs.rasterizer.cull_mode == RasterizerRegs::CullMode::KeepAll2) {
         // Make sure we always end up with a triangle wound counter-clockwise
         if (!reversed && SignedArea(vtxpos[0].xy(), vtxpos[1].xy(), vtxpos[2].xy()) <= 0) {
             ProcessTriangle(v0, v2, v1, true);

--- a/src/video_core/renderer_vulkan/pica_to_vk.h
+++ b/src/video_core/renderer_vulkan/pica_to_vk.h
@@ -180,6 +180,7 @@ inline vk::PrimitiveTopology PrimitiveTopology(Pica::PipelineRegs::TriangleTopol
 inline vk::CullModeFlags CullMode(Pica::RasterizerRegs::CullMode mode, bool flip_viewport) {
     switch (mode) {
     case Pica::RasterizerRegs::CullMode::KeepAll:
+    case Pica::RasterizerRegs::CullMode::KeepAll2:
         return vk::CullModeFlagBits::eNone;
     case Pica::RasterizerRegs::CullMode::KeepClockWise:
     case Pica::RasterizerRegs::CullMode::KeepCounterClockWise:
@@ -193,6 +194,7 @@ inline vk::CullModeFlags CullMode(Pica::RasterizerRegs::CullMode mode, bool flip
 inline vk::FrontFace FrontFace(Pica::RasterizerRegs::CullMode mode) {
     switch (mode) {
     case Pica::RasterizerRegs::CullMode::KeepAll:
+    case Pica::RasterizerRegs::CullMode::KeepAll2:
     case Pica::RasterizerRegs::CullMode::KeepClockWise:
         return vk::FrontFace::eCounterClockwise;
     case Pica::RasterizerRegs::CullMode::KeepCounterClockWise:


### PR DESCRIPTION
Adds proper handling for cull mode type 3.
Triangle cull modes are:
- 0: No culling
- 1: Front face culling
- 2: Back face culling

Since the cull mode is represented by 2 bits, it's possible to set the cull mode to 3, which just acts the same way as mode 0 (no culling). This has been verified on real hardware.

Fixes crashes on Teenage Mutant Ninja Turtles: Danger of the Ooze