### PR TITLE
android: Fix config ini validation

### DIFF
--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -337,10 +337,10 @@ void Config::Reload() {
     for (auto key = Settings::Keys::keys_array.begin(); key != Settings::Keys::keys_array.end();
          ++key) {
         const auto key_declaration_string = std::string(*key) + " =";
-        if ((std::ranges::find(DefaultINI::android_config_omitted_keys, *key) ==
+        if ((std::ranges::find(DefaultINI::android_config_omitted_keys, std::string_view(*key)) ==
              std::end(DefaultINI::android_config_omitted_keys)) &&
-            (std::string(DefaultINI::android_config_default_file_content)
-                 .find(key_declaration_string) == std::string::npos)) {
+            (std::string_view(DefaultINI::android_config_default_file_content)
+                 .find(key_declaration_string) == std::string_view::npos)) {
             ASSERT_MSG(false,
                        "Validation of default config content (jni/default_ini.h) failed: Missing "
                        "declaration for key '{}'",


### PR DESCRIPTION
Before this change, the following line: `std::ranges::find(DefaultINI::android_config_omitted_keys, *key) == std::end(DefaultINI::android_config_omitted_keys)` would result in `const char*` comparation because both `*key` and `DefaultINI::android_config_omitted_keys` are `const char*`.

`const char*` comparation uses pointer comparation, not string content comparation, which is incorrect. This worked on release builds because it just so happened that the compiler placed the strings in the same memory location, but that is not the case for debug builds. This PR fixes that by using `std::string_view`.