### PR TITLE
android: Fix crash due to nullptr dereference

### DIFF
--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -790,7 +790,9 @@ void Java_org_citra_citra_1emu_NativeLibrary_stopEmulation([[maybe_unused]] JNIE
         return;
     }
     pause_emulation = false;
-    window->StopPresenting();
+    if (window) {
+        window->StopPresenting();
+    }
     if (secondary_window) {
         secondary_window->StopPresenting();
     }


### PR DESCRIPTION
On android, whenever emulation exited early on its own from the `run` function (due to a signal or core error), it would call `TryShutdown()` which eventually calls `window.reset()`. Then if the frontend called `stopEmulation` the emulator would crash due to a nullptr dereference due to it unconditionally calling `window->StopPresenting()`.

Fixes crahses whenever a fatal error occurred and the user selected `Abort` in the pop-up window, or when homebrew applications exited on their own.