### PR TITLE
core: nwm: Move packet handling to emulation thread

### DIFF
--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -349,6 +349,8 @@ static Core::System::ResultStatus RunCitra(const std::string& filepath) {
 
     SCOPE_EXIT({ TryShutdown(); });
 
+    system.RegisterCoreLoopThreadId();
+
     // Start running emulation
     while (!stop_run) {
         if (!pause_emulation) {

--- a/src/citra_libretro/citra_libretro.cpp
+++ b/src/citra_libretro/citra_libretro.cpp
@@ -61,6 +61,7 @@ public:
     Common::Log::Filter log_filter;
     std::unique_ptr<EmuWindow_LibRetro> emu_window;
     bool game_loaded = false;
+    bool first_run_loop = true;
     struct retro_hw_render_callback hw_render{};
 };
 
@@ -277,6 +278,12 @@ void retro_run() {
     }
 #endif
 
+    // Run only-once operations
+    if (emu_instance->first_run_loop) {
+        emu_instance->first_run_loop = false;
+        Core::System::GetInstance().RegisterCoreLoopThreadId();
+    }
+
     while (!emu_instance->emu_window->HasSubmittedFrame()) {
         auto result = Core::System::GetInstance().RunLoop();
 
@@ -487,6 +494,7 @@ void retro_reset() {
     LOG_DEBUG(Frontend, "retro_reset");
     Core::System::GetInstance().Shutdown();
     emu_instance->game_loaded = do_load_game();
+    emu_instance->first_run_loop = true;
 }
 
 /**
@@ -550,6 +558,7 @@ bool retro_load_game(const struct retro_game_info* info) {
     }
 
     emu_instance->emu_window->UpdateLayout();
+    emu_instance->first_run_loop = true;
 
     switch (Settings::values.graphics_api.GetValue()) {
     case Settings::GraphicsAPI::OpenGL: {

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -100,6 +100,8 @@ void EmuThread::run() {
         system.frame_limiter.WaitOnce();
     }
 
+    system.RegisterCoreLoopThreadId();
+
     // Holds whether the cpu was running during the last iteration,
     // so that the DebugModeLeft signal can be emitted before the
     // next execution step.

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -83,6 +83,7 @@ System::~System() = default;
 
 System::ResultStatus System::RunLoop(bool tight_loop) {
     status = ResultStatus::Success;
+
     if (!IsPoweredOn()) {
         return ResultStatus::ErrorNotInitialized;
     }
@@ -98,6 +99,8 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
         GDBStub::HandlePacket(*this);
     }
 #endif
+
+    core_loop_thread_id = std::this_thread::get_id();
 
     Signal signal{Signal::None};
     u32 param{};

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -100,8 +100,6 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
     }
 #endif
 
-    core_loop_thread_id = std::this_thread::get_id();
-
     Signal signal{Signal::None};
     u32 param{};
     {

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -431,6 +431,10 @@ public:
         override_gdb_port = port;
     }
 
+    void RegisterCoreLoopThreadId() {
+        core_loop_thread_id = std::this_thread::get_id();
+    }
+
     std::thread::id GetCoreLoopThreadId() {
         return core_loop_thread_id;
     }
@@ -549,7 +553,7 @@ private:
     bool debug_next_process;
     int override_gdb_port = -1;
 
-    std::thread::id core_loop_thread_id;
+    std::thread::id core_loop_thread_id{};
 
     friend class boost::serialization::access;
     template <typename Archive>

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -431,6 +431,10 @@ public:
         override_gdb_port = port;
     }
 
+    std::thread::id GetCoreLoopThreadId() {
+        return core_loop_thread_id;
+    }
+
 private:
     /**
      * Initialize the emulated system.
@@ -544,6 +548,8 @@ private:
 
     bool debug_next_process;
     int override_gdb_port = -1;
+
+    std::thread::id core_loop_thread_id;
 
     friend class boost::serialization::access;
     template <typename Archive>

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -600,7 +600,7 @@ void NWM_UDS::ShutdownHLE() {
     initialized = false;
 
     for (auto& bind_node : channel_data) {
-        bind_node.second.event->Signal();
+        SignalEventAsync(bind_node.second.event);
     }
     channel_data.clear();
     node_map.clear();
@@ -909,7 +909,7 @@ void NWM_UDS::UnbindHLE(u32 bind_node_id) {
 
     if (itr != channel_data.end()) {
         // TODO(B3N30): Check out what Unbind does if the bind_node_id wasn't in the map
-        itr->second.event->Signal();
+        SignalEventAsync(itr->second.event);
         channel_data.erase(itr);
     }
 }
@@ -989,7 +989,7 @@ Result NWM_UDS::BeginHostingNetwork(std::span<const u8> network_info_buffer,
             network_info.channel = DefaultNetworkChannel;
     }
 
-    connection_status_event->Signal();
+    SignalEventAsync(connection_status_event);
 
     // Start broadcasting the network, send a beacon frame every 102.4ms.
     system.CoreTiming().ScheduleEvent(msToCycles(DefaultBeaconInterval * MillisecondsPerTU),
@@ -1128,10 +1128,10 @@ Result NWM_UDS::DestroyNetworkHLE() {
     connection_status.status = NetworkStatus::NotConnected;
     connection_status.network_node_id = tmp_node_id;
     node_map.clear();
-    connection_status_event->Signal();
+    SignalEventAsync(connection_status_event);
 
     for (auto& bind_node : channel_data) {
-        bind_node.second.event->Signal();
+        SignalEventAsync(bind_node.second.event);
     }
     channel_data.clear();
 
@@ -1464,7 +1464,7 @@ ResultStatus NWM_UDS::DisconnectNetworkHLE() {
         connection_status.status = NetworkStatus::NotConnected;
         connection_status.network_node_id = tmp_node_id;
         node_map.clear();
-        connection_status_event->Signal();
+        SignalEventAsync(connection_status_event);
 
         deauth.channel = network_channel;
         // TODO(B3N30): Add disconnect reason
@@ -1476,7 +1476,7 @@ ResultStatus NWM_UDS::DisconnectNetworkHLE() {
     SendPacket(deauth);
 
     for (auto& bind_node : channel_data) {
-        bind_node.second.event->Signal();
+        SignalEventAsync(bind_node.second.event);
     }
     channel_data.clear();
 
@@ -1661,6 +1661,8 @@ Network::MacAddress NWM_UDS::GetMacAddress() {
 }
 
 void NWM_UDS::SignalEventAsync(std::shared_ptr<Kernel::Event> event) {
+    // TODO: check if this is being called on the core loop thread
+    // and signal the event directly
     pending_async_event_signals.Push(event);
     system.CoreTiming().ScheduleEvent(0, handle_async_event_signals_event, -1, true);
 }

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -200,7 +200,7 @@ void NWM_UDS::HandleAssociationResponseFrame(const Network::WifiPacket& packet) 
 }
 
 void NWM_UDS::HandleEAPoLPacket(const Network::WifiPacket& packet) {
-    std::scoped_lock lock{connection_status_mutex, system.Kernel().GetHLELock()};
+    std::scoped_lock lock{connection_status_mutex};
 
     if (GetEAPoLFrameType(packet.data) == EAPoLStartMagic) {
         if (connection_status.status != NetworkStatus::ConnectedAsHost) {
@@ -351,7 +351,7 @@ void NWM_UDS::HandleEAPoLPacket(const Network::WifiPacket& packet) {
 
 void NWM_UDS::HandleSecureDataPacket(const Network::WifiPacket& packet) {
     const auto secure_data = ParseSecureDataHeader(packet.data);
-    std::scoped_lock lock{connection_status_mutex, system.Kernel().GetHLELock()};
+    std::scoped_lock lock{connection_status_mutex};
 
     if (connection_status.status != NetworkStatus::ConnectedAsHost &&
         connection_status.status != NetworkStatus::ConnectedAsClient &&
@@ -498,7 +498,6 @@ void NWM_UDS::HandleAuthenticationFrame(const Network::WifiPacket& packet) {
 
 void NWM_UDS::HandleDeauthenticationFrame(const Network::WifiPacket& packet) {
     LOG_DEBUG(Service_NWM, "called");
-    std::scoped_lock lock{connection_status_mutex, system.Kernel().GetHLELock()};
 
     if (connection_status.status != NetworkStatus::ConnectedAsHost) {
         LOG_ERROR(Service_NWM, "Got deauthentication frame but we are not the host");
@@ -1707,8 +1706,11 @@ NWM_UDS::NWM_UDS(Core::System& system) : ServiceFramework("nwm::UDS"), system(sy
     system.Kernel().GetSharedPageHandler().SetMacAddress(GetMacAddress());
 
     if (auto room_member = Network::GetRoomMember().lock()) {
-        wifi_packet_received = room_member->BindOnWifiPacketReceived(
-            [this](const Network::WifiPacket& packet) { OnWifiPacketReceived(packet); });
+        wifi_packet_received =
+            room_member->BindOnWifiPacketReceived([this](const Network::WifiPacket& packet) {
+                std::scoped_lock lock{this->system.Kernel().GetHLELock()};
+                OnWifiPacketReceived(packet);
+            });
     } else {
         LOG_ERROR(Service_NWM, "Network isn't initalized");
     }

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -40,6 +40,8 @@ void NWM_UDS::serialize(Archive& ar, const unsigned int) {
     ar & connection_event;
     ar & received_beacons;
     // wifi_packet_received set in constructor
+    // pending packet queue is lost, but that's fine as it doesn't make sense to save state during
+    // an active multiplayer session as it will mess up everything anyways.
 }
 
 namespace ErrCodes {
@@ -1703,13 +1705,22 @@ NWM_UDS::NWM_UDS(Core::System& system) : ServiceFramework("nwm::UDS"), system(sy
             BeaconBroadcastCallback(user_data, cycles_late);
         });
 
+    handle_wifi_packet_event = system.CoreTiming().RegisterEvent(
+        "UDS::OnWifiPacketReceived",
+        [this]([[maybe_unused]] std::uintptr_t user_data, s64 cycles_late) {
+            Network::WifiPacket packet;
+            if (pending_packets.Pop(packet)) {
+                OnWifiPacketReceived(packet);
+            }
+        });
+
     system.Kernel().GetSharedPageHandler().SetMacAddress(GetMacAddress());
 
     if (auto room_member = Network::GetRoomMember().lock()) {
         wifi_packet_received =
             room_member->BindOnWifiPacketReceived([this](const Network::WifiPacket& packet) {
-                std::scoped_lock lock{this->system.Kernel().GetHLELock()};
-                OnWifiPacketReceived(packet);
+                pending_packets.Push(packet);
+                this->system.CoreTiming().ScheduleEvent(0, handle_wifi_packet_event, 0, 1, true);
             });
     } else {
         LOG_ERROR(Service_NWM, "Network isn't initalized");

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -40,8 +40,6 @@ void NWM_UDS::serialize(Archive& ar, const unsigned int) {
     ar & connection_event;
     ar & received_beacons;
     // wifi_packet_received set in constructor
-    // pending packet queue is lost, but that's fine as it doesn't make sense to save state during
-    // an active multiplayer session as it will mess up everything anyways.
 }
 
 namespace ErrCodes {
@@ -275,7 +273,7 @@ void NWM_UDS::HandleEAPoLPacket(const Network::WifiPacket& packet) {
 
         SendPacket(eapol_logoff);
 
-        connection_status_event->Signal();
+        SignalEventAsync(connection_status_event);
     } else if (connection_status.status == NetworkStatus::Connecting) {
         auto logoff = ParseEAPoLLogoffFrame(packet.data);
 
@@ -315,8 +313,8 @@ void NWM_UDS::HandleEAPoLPacket(const Network::WifiPacket& packet) {
         // Some games require ConnectToNetwork to block, for now it doesn't
         // If blocking is implemented this lock needs to be changed,
         // otherwise it might cause deadlocks
-        connection_status_event->Signal();
-        connection_event->Signal();
+        SignalEventAsync(connection_status_event);
+        SignalEventAsync(connection_event);
     } else if (connection_status.status == NetworkStatus::ConnectedAsClient ||
                connection_status.status == NetworkStatus::ConnectedAsSpectator) {
         // TODO(B3N30): Remove that section and send/receive a proper connection_status packet
@@ -347,7 +345,7 @@ void NWM_UDS::HandleEAPoLPacket(const Network::WifiPacket& packet) {
         }
         connection_status.changed_nodes = old_bitmask ^ connection_status.node_bitmask;
 
-        connection_status_event->Signal();
+        SignalEventAsync(connection_status_event);
     }
 }
 
@@ -410,8 +408,8 @@ void NWM_UDS::HandleSecureDataPacket(const Network::WifiPacket& packet) {
     // Add the received packet to the data queue.
     channel_info->second.received_packets.emplace_back(packet.data);
 
-    // Signal the data event. We can do this directly because we locked hle_lock
-    channel_info->second.event->Signal();
+    // Signal the data event. We can do this directly because we use SignalEventAsync
+    SignalEventAsync(channel_info->second.event);
 }
 
 void NWM_UDS::StartConnectionSequence(const MacAddress& server) {
@@ -500,6 +498,7 @@ void NWM_UDS::HandleAuthenticationFrame(const Network::WifiPacket& packet) {
 
 void NWM_UDS::HandleDeauthenticationFrame(const Network::WifiPacket& packet) {
     LOG_DEBUG(Service_NWM, "called");
+    std::scoped_lock lock{connection_status_mutex};
 
     if (connection_status.status != NetworkStatus::ConnectedAsHost) {
         LOG_ERROR(Service_NWM, "Got deauthentication frame but we are not the host");
@@ -536,7 +535,7 @@ void NWM_UDS::HandleDeauthenticationFrame(const Network::WifiPacket& packet) {
         // TODO(B3N30): broadcast new connection_status to clients
     }
     node_it->Reset();
-    connection_status_event->Signal();
+    SignalEventAsync(connection_status_event);
 }
 
 void NWM_UDS::HandleDataFrame(const Network::WifiPacket& packet) {
@@ -1661,6 +1660,21 @@ Network::MacAddress NWM_UDS::GetMacAddress() {
     return mac;
 }
 
+void NWM_UDS::SignalEventAsync(std::shared_ptr<Kernel::Event> event) {
+    pending_async_event_signals.Push(event);
+    system.CoreTiming().ScheduleEvent(0, handle_async_event_signals_event, -1, true);
+}
+
+void NWM_UDS::DispatchQueuedAsyncEventSignals() {
+    std::shared_ptr<Kernel::Event> event;
+    pending_async_event_signals.Pop(event);
+    if (!event) {
+        LOG_WARNING(Service_NWM, "Tried to signal async event, but event was null");
+        return;
+    }
+    event->Signal();
+}
+
 NWM_UDS::NWM_UDS(Core::System& system) : ServiceFramework("nwm::UDS"), system(system) {
     static const FunctionInfo functions[] = {
         // clang-format off
@@ -1705,23 +1719,17 @@ NWM_UDS::NWM_UDS(Core::System& system) : ServiceFramework("nwm::UDS"), system(sy
             BeaconBroadcastCallback(user_data, cycles_late);
         });
 
-    handle_wifi_packet_event = system.CoreTiming().RegisterEvent(
-        "UDS::OnWifiPacketReceived",
-        [this]([[maybe_unused]] std::uintptr_t user_data, s64 cycles_late) {
-            Network::WifiPacket packet;
-            if (pending_packets.Pop(packet)) {
-                OnWifiPacketReceived(packet);
-            }
+    handle_async_event_signals_event = system.CoreTiming().RegisterEvent(
+        "UDS::handle_async_event_signals_event",
+        [this]([[maybe_unused]] std::uintptr_t user_data, [[maybe_unused]] s64 cycles_late) {
+            DispatchQueuedAsyncEventSignals();
         });
 
     system.Kernel().GetSharedPageHandler().SetMacAddress(GetMacAddress());
 
     if (auto room_member = Network::GetRoomMember().lock()) {
-        wifi_packet_received =
-            room_member->BindOnWifiPacketReceived([this](const Network::WifiPacket& packet) {
-                pending_packets.Push(packet);
-                this->system.CoreTiming().ScheduleEvent(0, handle_wifi_packet_event, 0, 1, true);
-            });
+        wifi_packet_received = room_member->BindOnWifiPacketReceived(
+            [this](const Network::WifiPacket& packet) { OnWifiPacketReceived(packet); });
     } else {
         LOG_ERROR(Service_NWM, "Network isn't initalized");
     }

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -1661,8 +1661,10 @@ Network::MacAddress NWM_UDS::GetMacAddress() {
 }
 
 void NWM_UDS::SignalEventAsync(std::shared_ptr<Kernel::Event> event) {
-    // TODO: check if this is being called on the core loop thread
-    // and signal the event directly
+    if (system.GetCoreLoopThreadId() == std::this_thread::get_id()) {
+        event->Signal();
+        return;
+    }
     pending_async_event_signals.Push(event);
     system.CoreTiming().ScheduleEvent(0, handle_async_event_signals_event, -1, true);
 }

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -1666,7 +1666,7 @@ void NWM_UDS::SignalEventAsync(std::shared_ptr<Kernel::Event> event) {
         return;
     }
     pending_async_event_signals.Push(event);
-    system.CoreTiming().ScheduleEvent(0, handle_async_event_signals_event, -1, true);
+    system.CoreTiming().ScheduleEvent(0, handle_async_event_signals_event, 0, 1, true);
 }
 
 void NWM_UDS::DispatchQueuedAsyncEventSignals() {

--- a/src/core/hle/service/nwm/nwm_uds.h
+++ b/src/core/hle/service/nwm/nwm_uds.h
@@ -18,6 +18,7 @@
 #include <boost/serialization/export.hpp>
 #include "common/common_types.h"
 #include "common/swap.h"
+#include "common/threadsafe_queue.h"
 #include "core/hle/service/nwm/uds_common.h"
 #include "core/hle/service/service.h"
 #include "network/network.h"
@@ -626,6 +627,12 @@ private:
 
     // Event that will generate and send the 802.11 beacon frames.
     Core::TimingEventType* beacon_broadcast_event;
+
+    // Event for handling wifi packets
+    Core::TimingEventType* handle_wifi_packet_event;
+
+    // Queue holding the pending packets
+    Common::SPSCQueue<Network::WifiPacket> pending_packets;
 
     // Callback identifier for the OnWifiPacketReceived event.
     Network::RoomMember::CallbackHandle<Network::WifiPacket> wifi_packet_received;

--- a/src/core/hle/service/nwm/nwm_uds.h
+++ b/src/core/hle/service/nwm/nwm_uds.h
@@ -482,6 +482,9 @@ private:
 
     void CheckSpoofFriendCodeSeed(Kernel::HLERequestContext& ctx, NodeInfo& node);
 
+    void SignalEventAsync(std::shared_ptr<Kernel::Event> event);
+    void DispatchQueuedAsyncEventSignals();
+
     ResultVal<std::shared_ptr<Kernel::Event>> Initialize(
         u32 sharedmem_size, const NodeInfo& node, u16 version,
         std::shared_ptr<Kernel::SharedMemory> sharedmem);
@@ -628,11 +631,11 @@ private:
     // Event that will generate and send the 802.11 beacon frames.
     Core::TimingEventType* beacon_broadcast_event;
 
-    // Event for handling wifi packets
-    Core::TimingEventType* handle_wifi_packet_event;
+    // Event for handling async event signals
+    Core::TimingEventType* handle_async_event_signals_event;
 
-    // Queue holding the pending packets
-    Common::SPSCQueue<Network::WifiPacket> pending_packets;
+    // Queue holding the async event shared pointers
+    Common::SPSCQueue<std::shared_ptr<Kernel::Event>> pending_async_event_signals;
 
     // Callback identifier for the OnWifiPacketReceived event.
     Network::RoomMember::CallbackHandle<Network::WifiPacket> wifi_packet_received;

--- a/src/core/hle/service/nwm/nwm_uds.h
+++ b/src/core/hle/service/nwm/nwm_uds.h
@@ -635,7 +635,7 @@ private:
     Core::TimingEventType* handle_async_event_signals_event;
 
     // Queue holding the async event shared pointers
-    Common::SPSCQueue<std::shared_ptr<Kernel::Event>> pending_async_event_signals;
+    Common::MPSCQueue<std::shared_ptr<Kernel::Event>> pending_async_event_signals;
 
     // Callback identifier for the OnWifiPacketReceived event.
     Network::RoomMember::CallbackHandle<Network::WifiPacket> wifi_packet_received;


### PR DESCRIPTION
Moves nwm uds packet handling to the emulation thread, this allows the HLE NWM to properly access the kernel structures as they are not thread safe.

Closes #2353, #2366