### PR TITLE
renderer_vk: Fix disabled cubemap texture units

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -639,10 +639,23 @@ void RasterizerVulkan::SyncTextureUnits(const Framebuffer* framebuffer) {
 
         // If the texture unit is disabled bind a null surface to it
         if (!texture.enabled) {
-            Surface& null_surface = res_cache.GetSurface(VideoCore::NULL_SURFACE_ID);
-            const Sampler& null_sampler = res_cache.GetSampler(VideoCore::NULL_SAMPLER_ID);
-            update_queue.AddImageSampler(texture_set, texture_index, 0, null_surface.ImageView(),
-                                         null_sampler.Handle());
+            switch (texture.config.type.Value()) {
+            case TextureType::TextureCube:
+            case TextureType::ShadowCube: {
+                Surface& null_surface = res_cache.GetSurface(VideoCore::NULL_SURFACE_CUBE_ID);
+                const Sampler& null_sampler = res_cache.GetSampler(VideoCore::NULL_SURFACE_CUBE_ID);
+                update_queue.AddImageSampler(texture_set, texture_index, 0,
+                                             null_surface.ImageView(), null_sampler.Handle());
+                break;
+            }
+            default: {
+                Surface& null_surface = res_cache.GetSurface(VideoCore::NULL_SURFACE_ID);
+                const Sampler& null_sampler = res_cache.GetSampler(VideoCore::NULL_SURFACE_ID);
+                update_queue.AddImageSampler(texture_set, texture_index, 0,
+                                             null_surface.ImageView(), null_sampler.Handle());
+                break;
+            }
+            }
             continue;
         }
 


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

This is a vulkan version of the OpenGL fix done here: https://github.com/azahar-emu/azahar/pull/2159

This ensures that disabled texture units get the appropriate null-texture type(either a null cubemap or a null texture-2d).

Discovered the same issue was happening on Vulkan while looking into https://github.com/azahar-emu/azahar/issues/1852

This resolves crashes and validation messages relating to generated shaders expecting one texture-type but being provided another:
```
Render.Vulkan <Error> video_core\renderer_vulkan\vk_platform.cpp:Vulkan::`anonymous-namespace'::DebugUtilsCallback:61: VUID-vkCmdDrawIndexed-viewType-07752: vkCmdDrawIndexed(): the combined image sampler descriptor [VkDescriptorSet 0xe8e0000000e8e, Set 1, Binding 0, Index 0] VkImageViewType is VK_IMAGE_VIEW_TYPE_2D but the OpTypeImage has (Dim = Cube) and (Arrayed = 0).
```