### PR TITLE
video_core: Fix texture runtime garbage collection

### DIFF
--- a/src/video_core/rasterizer_cache/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache/rasterizer_cache.h
@@ -128,10 +128,13 @@ void RasterizerCache<T>::TickFrame() {
 
 template <class T>
 void RasterizerCache<T>::RunGarbageCollector() {
-    frame_tick++;
+    const u64 remove_tick = runtime.GetResourceTick();
     for (auto it = sentenced.begin(); it != sentenced.end();) {
-        const auto [surface_id, tick] = *it;
-        if (frame_tick - tick <= runtime.RemoveThreshold()) {
+        const auto [surface_id, resource_tick] = *it;
+        // Anything older(lower tick-value) than the resource-free tick-value is done being used
+        // and is ready to be deleted
+        if (remove_tick >= resource_tick) {
+            // Resource is still possibly in-use, skip
             it++;
             continue;
         }
@@ -169,7 +172,7 @@ void RasterizerCache<T>::RemoveTextureCubeFace(SurfaceId surface_id) {
         }
         if (std::none_of(cube.face_ids.begin(), cube.face_ids.end(),
                          [](SurfaceId id) { return id; })) {
-            sentenced.emplace_back(cube.surface_id, frame_tick);
+            sentenced.emplace_back(cube.surface_id, runtime.GetResourceTick());
             it = texture_cube_cache.erase(it);
         } else {
             it++;
@@ -599,7 +602,7 @@ SurfaceId RasterizerCache<T>::GetTextureSurface(const Pica::Texture::TextureInfo
         params.res_scale = src_surface.res_scale;
         SurfaceId tmp_surface_id = CreateSurface(params, initial_flags);
         Surface& tmp_surface = slot_surfaces[tmp_surface_id];
-        sentenced.emplace_back(tmp_surface_id, frame_tick);
+        sentenced.emplace_back(tmp_surface_id, runtime.GetResourceTick());
 
         const TextureBlit blit = {
             .src_level = src_surface.LevelOf(params.addr),
@@ -1119,7 +1122,7 @@ bool RasterizerCache<T>::UploadCustomSurface(SurfaceId surface_id, SurfaceInterv
             const SurfaceId old_id =
                 slot_surfaces.swap_and_insert(surface_id, runtime, old_surface, material);
             slot_surfaces[old_id].flags &= ~SurfaceFlagBits::Registered;
-            sentenced.emplace_back(old_id, frame_tick);
+            sentenced.emplace_back(old_id, runtime.GetResourceTick());
         }
         Surface& surface = slot_surfaces[surface_id];
         surface.UploadCustom(material, level);
@@ -1418,7 +1421,7 @@ void RasterizerCache<T>::UnregisterSurface(SurfaceId surface_id) {
 
     if (surface.type != SurfaceType::Fill) {
         RemoveTextureCubeFace(surface_id);
-        sentenced.emplace_back(surface_id, frame_tick);
+        sentenced.emplace_back(surface_id, runtime.GetResourceTick());
         return;
     }
 
@@ -1434,7 +1437,6 @@ void RasterizerCache<T>::UnregisterAll() {
         }
     }
     runtime.Finish();
-    frame_tick += runtime.RemoveThreshold();
     RunGarbageCollector();
 }
 

--- a/src/video_core/rasterizer_cache/rasterizer_cache_base.h
+++ b/src/video_core/rasterizer_cache/rasterizer_cache_base.h
@@ -227,7 +227,6 @@ private:
     SurfaceMap dirty_regions;
     PageMap cached_pages;
     u32 resolution_scale_factor;
-    u64 frame_tick{};
     FramebufferParams fb_params;
     Settings::TextureFilter filter;
     bool dump_textures;

--- a/src/video_core/renderer_opengl/gl_texture_runtime.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_runtime.cpp
@@ -114,7 +114,7 @@ static constexpr std::array<FormatTuple, 8> CUSTOM_TUPLES = {{
 } // Anonymous namespace
 
 TextureRuntime::TextureRuntime(const Driver& driver_, VideoCore::RendererBase& renderer)
-    : driver{driver_}, blit_helper{driver} {
+    : driver{driver_}, current_resource_tick{0}, blit_helper{driver} {
     for (std::size_t i = 0; i < draw_fbos.size(); ++i) {
         draw_fbos[i].Create();
         read_fbos[i].Create();
@@ -123,8 +123,12 @@ TextureRuntime::TextureRuntime(const Driver& driver_, VideoCore::RendererBase& r
 
 TextureRuntime::~TextureRuntime() = default;
 
-u32 TextureRuntime::RemoveThreshold() {
-    return SWAP_CHAIN_SIZE;
+u64 TextureRuntime::GetResourceTick() {
+    return current_resource_tick;
+}
+
+void TextureRuntime::Finish() {
+    current_resource_tick++;
 }
 
 bool TextureRuntime::NeedsConversion(const Surface& surface) const {

--- a/src/video_core/renderer_opengl/gl_texture_runtime.h
+++ b/src/video_core/renderer_opengl/gl_texture_runtime.h
@@ -42,11 +42,12 @@ public:
     explicit TextureRuntime(const Driver& driver, VideoCore::RendererBase& renderer);
     ~TextureRuntime();
 
-    /// Returns the removal threshold ticks for the garbage collector
-    u32 RemoveThreshold();
+    /// Gets an opaque tick-value used to indicate to the garbage collector when a surface was made.
+    /// Incrementing this variable indicates that all previous resource ticks can be safely deleted
+    u64 GetResourceTick();
 
     /// Submits and waits for current GPU work.
-    void Finish() {}
+    void Finish();
 
     /// Returns true if the provided pixel format cannot be used natively by the runtime.
     bool NeedsConversion(const Surface& surface) const;
@@ -89,6 +90,7 @@ private:
 
 private:
     const Driver& driver;
+    u64 current_resource_tick;
     BlitHelper blit_helper;
     std::vector<u8> staging_buffer;
     std::array<OGLFramebuffer, 3> draw_fbos;

--- a/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
@@ -303,8 +303,8 @@ VideoCore::StagingData TextureRuntime::FindStaging(u32 size, bool upload) {
     };
 }
 
-u32 TextureRuntime::RemoveThreshold() {
-    return num_swapchain_images;
+u64 TextureRuntime::GetResourceTick() {
+    return scheduler.GetMasterSemaphore()->KnownGpuTick();
 }
 
 void TextureRuntime::Finish() {

--- a/src/video_core/renderer_vulkan/vk_texture_runtime.h
+++ b/src/video_core/renderer_vulkan/vk_texture_runtime.h
@@ -125,8 +125,9 @@ public:
         return renderpass_cache;
     }
 
-    /// Returns the removal threshold ticks for the garbage collector
-    u32 RemoveThreshold();
+    /// Gets an opaque tick-value used to indicate to the garbage collector when a surface was made.
+    /// Incrementing this variable indicates that all previous resource ticks can be safely deleted.
+    u64 GetResourceTick();
 
     /// Submits and waits for current GPU work.
     void Finish();


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Addresses https://github.com/azahar-emu/azahar/issues/1852

The RasterizerCache was ticking its own frame-index number to determine when it was safe to delete surfaces, but it allows the possibility to delete surfaces while the frame is in flight. This becomes especially possible when frames take longer than expected to complete, such as when using larger upscaling values.

Instead of ticking its own frame-index variable, the RasterizerCache will ask the texture-runtime for opaque "resource-tick" values to determine when it is safe to destroy surfaces. This allows the vulkan implementation to provide its own timestamp values from the master semaphore to indicate when the GPU is actually done with a surface and it is safe to delete.