### PR TITLE
core: Fix yet another MSVC compiler bug

### DIFF
--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -178,7 +178,7 @@ void ServiceFrameworkBase::ReportUnimplementedFunction(u32* cmd_buf, const Funct
 void ServiceFrameworkBase::HandleSyncRequest(Kernel::HLERequestContext& context) {
     auto itr = handlers.find(context.CommandHeader().command_id.Value());
     const FunctionInfoBase* info = itr == handlers.end() ? nullptr : &itr->second;
-    if (info == nullptr || !info->implemented) {
+    if (info == nullptr || info->handler_callback == nullptr) {
         context.ReportUnimplemented();
         return ReportUnimplementedFunction(context.CommandBuffer(), info);
     }

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -82,7 +82,6 @@ private:
 
     struct FunctionInfoBase {
         u32 command_id;
-        bool implemented;
         HandlerFnP<ServiceFrameworkBase> handler_callback;
         const char* name;
     };
@@ -96,8 +95,6 @@ private:
 
     void RegisterHandlersBase(const FunctionInfoBase* functions, std::size_t n);
     void ReportUnimplementedFunction(u32* cmd_buf, const FunctionInfoBase* info);
-
-    void Empty(Kernel::HLERequestContext& ctx) {}
 
     /// Identifier string used to connect to the service.
     std::string service_name;
@@ -137,11 +134,9 @@ protected:
          */
         constexpr FunctionInfo(u32 command_id, HandlerFnP<Self> handler_callback, const char* name)
             : FunctionInfoBase{
-                  command_id, handler_callback != nullptr,
+                  command_id,
                   // Type-erase member function pointer by casting it down to the base class.
-                  handler_callback ? static_cast<HandlerFnP<ServiceFrameworkBase>>(handler_callback)
-                                   : &ServiceFrameworkBase::Empty,
-                  name} {}
+                  static_cast<HandlerFnP<ServiceFrameworkBase>>(handler_callback), name} {}
     };
 
     /**

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -132,7 +132,20 @@ protected:
          *     the request
          * @param name human-friendly name for the request. Used mostly for logging purposes.
          */
-        constexpr FunctionInfo(u32 command_id, HandlerFnP<Self> handler_callback, const char* name)
+#ifdef _MSC_VER
+        // This is the ifdef of shame.
+        // Microslop is apparenly unable to have a properly working compiler, so we need to disable
+        // constexpr evaulation of the FunctionInfo constructor.
+        //
+        // When pointer-to-member callbacks are passed through a constexpr, it can cause the
+        // resulting array to have elements of different size:
+        // https://developercommunity.visualstudio.com/t/Incorrect-struct-array-memory-layout/11011322
+        // or to have invalid `this` delta information:
+        // https://developercommunity.visualstudio.com/t/MSVC-vmg-sets-invalid-pointer-to-member/11136987
+#else
+        constexpr
+#endif
+        FunctionInfo(u32 command_id, HandlerFnP<Self> handler_callback, const char* name)
             : FunctionInfoBase{
                   command_id,
                   // Type-erase member function pointer by casting it down to the base class.


### PR DESCRIPTION
This PR reverts the commit that worked around a MSVC compiler bug (see #1505) and introduces a better more reliable workaround. This addresses yet another compiler bug that started showing up in the recent MSVC versions.

The initial bug report can be found here (which hasn't been resolved yet):
https://developercommunity.visualstudio.com/t/Incorrect-struct-array-memory-layout/11011322

The new bug report can be found here:
https://developercommunity.visualstudio.com/t/MSVC-vmg-sets-invalid-pointer-to-member/11136987

Please read the bug report descriptions for more information.