### PR TITLE
video_core: Fix some pica command handling issues

### DIFF
--- a/src/video_core/pica/pica_core.cpp
+++ b/src/video_core/pica/pica_core.cpp
@@ -498,12 +498,14 @@ void PicaCore::HandleSpecialRegBatch(u32 id, const u32* values, u32 count) {
     case PICA_REG_INDEX(lighting.lut_data[6]):
     case PICA_REG_INDEX(lighting.lut_data[7]): {
         auto& lut_config = regs.internal.lighting.lut_config;
-        ASSERT_MSG(lut_config.index + count <= 256,
-                   "lut_config.index exceeded maximum value of 255!");
 
         for (u32 i = 0; i < count; i++) {
             const u32 prev =
-                std::exchange(lighting.luts[lut_config.type][lut_config.index + i].raw, values[i]);
+                std::exchange(lighting
+                                  .luts[lut_config.type][(lut_config.index + i) %
+                                                         lighting.luts[lut_config.type].size()]
+                                  .raw,
+                              values[i]);
             lighting.lut_dirty |= (prev != values[i]) << lut_config.type;
         }
         lut_config.index.Assign(lut_config.index + count);
@@ -786,7 +788,6 @@ void PicaCore::HandleSpecialReg(u32 id, u32 value, bool& stop_requested) {
     case PICA_REG_INDEX(lighting.lut_data[6]):
     case PICA_REG_INDEX(lighting.lut_data[7]): {
         auto& lut_config = regs.internal.lighting.lut_config;
-        ASSERT_MSG(lut_config.index < 256, "lut_config.index exceeded maximum value of 255!");
 
         const u32 prev = std::exchange(lighting.luts[lut_config.type][lut_config.index].raw, value);
         lighting.lut_dirty |= (prev != value) << lut_config.type;
@@ -854,7 +855,8 @@ void PicaCore::HandleSpecialReg(u32 id, u32 value, bool& stop_requested) {
 void PicaCore::WriteInternalRegBatch(u32 id, const u32* values, u32 count, u32 mask,
                                      bool& stop_requested) {
     if (id >= RegsInternal::NUM_REGS) [[unlikely]] {
-        LOG_ERROR(HW_GPU,
+        // Writes to OOB registers are no-op.
+        LOG_DEBUG(HW_GPU,
                   "Commandlist tried to write to invalid register 0x{:03X} repeated 0x{:04X} times"
                   "(mask: {:X})",
                   id, count, mask);
@@ -885,11 +887,16 @@ void PicaCore::WriteInternalRegBatch(u32 id, const u32* values, u32 count, u32 m
 void PicaCore::WriteInternalRegSequential(u32 id, const u32* __restrict values, u32 count, u32 mask,
                                           bool& stop_requested) {
     if (id + count > RegsInternal::NUM_REGS) [[unlikely]] {
-        LOG_ERROR(
+        // Writes to OOB registers are no-op.
+        LOG_DEBUG(
             HW_GPU,
             "Commandlist tried to write to invalid register range 0x{:03X}-0x{:03X} (mask: {:X})",
             id, id + count, mask);
-        return;
+        if (id >= RegsInternal::NUM_REGS) {
+            return;
+        } else {
+            count = RegsInternal::NUM_REGS - id;
+        }
     }
     const u32 write_mask = ExpandBitsToBytes[mask];
     u32* __restrict dst = &regs.internal.reg_array[id];
@@ -933,7 +940,8 @@ void PicaCore::WriteInternalRegSequential(u32 id, const u32* __restrict values, 
 // Handle individual command write.
 void PicaCore::WriteInternalReg(u32 id, u32 value, u32 mask, bool& stop_requested) {
     if (id >= RegsInternal::NUM_REGS) [[unlikely]] {
-        LOG_ERROR(
+        // Writes to OOB registers are no-op.
+        LOG_DEBUG(
             HW_GPU,
             "Commandlist tried to write to invalid register 0x{:03X} (value: {:08X}, mask: {:X})",
             id, value, mask);

--- a/src/video_core/pica/shader_setup.cpp
+++ b/src/video_core/pica/shader_setup.cpp
@@ -59,7 +59,8 @@ std::optional<u32> ShaderSetup::WriteUniformFloatReg(ShaderRegs& config, u32 val
 
     const auto uniform = uniform_queue.Get(is_float32);
     if (uniform_setup.index >= uniforms.f.size()) {
-        LOG_ERROR(HW_GPU, "Invalid float uniform index {}", uniform_setup.index.Value());
+        // Some games may submit OOB indexes (mainly 0x7F), which is
+        // ignored on real HW.
         return std::nullopt;
     }
 
@@ -90,7 +91,8 @@ std::optional<ShaderSetup::UniformWriteRange> ShaderSetup::WriteUniformFloatRegR
 
         const auto uniform = uniform_queue.Get(is_float32);
         if (uniform_setup.index >= uniforms.f.size()) [[unlikely]] {
-            LOG_ERROR(HW_GPU, "Invalid float uniform index {}", uniform_setup.index.Value());
+            // Some games may submit OOB indexes (mainly 0x7F), which is
+            // ignored on real HW.
             break;
         }
 


### PR DESCRIPTION
Fixes some Pica command handling issues, some which are long standing and others that were introduced recently.
- Fixed float uniform invalid indices spamming errors and causing lag. This behaviour is actually not a bug and done by commercial games for an unknown reason. OOB writes have no effect on real HW
    - Fixes lag in Super Smash Bros in the character selection screen and other places.
- Fixed pica register writes to invalid indices spamming errors and causing lag. Same as before, done by some commercial games and has no effect on real HW.
    - Fixes lag in Mini Mario & Friends: Amiibo Challenge when walking on diagonal surfaces.
- Fixed two issues introduced in #2318:
    - Fix handling of LUT writes, which would cause crashes (for example when opening the friend list from the home menu).
    - Fix invalid register index calculation on batch writes.    