### PR TITLE
Implement more detailed exception handler

### DIFF
--- a/CMakeModules/GenerateSettingKeys.cmake
+++ b/CMakeModules/GenerateSettingKeys.cmake
@@ -120,7 +120,7 @@ foreach(KEY IN ITEMS
     "log_filter"
     "log_regex_filter"
     "toggle_unique_data_console_type"
-    "break_on_unmapped_memory_access"
+    "enable_exception_handler"
     "use_integer_scaling"
     "layouts_to_cycle"
     "camera_inner_flip"

--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
@@ -965,10 +965,9 @@ object NativeLibrary {
         ErrorArticDisconnected(12, R.string.core_error_artic_disconnected),
         ErrorN3DSApplication(13, R.string.core_error_n3ds_application),
         ErrorCoreExceptionRaised(14, R.string.core_error_core_exception_raised),
-        ErrorMemoryExceptionRaised(15, R.string.core_error_memory_exception_raised),
-        ErrorSavestateBuildMismatch(16, R.string.core_error_savestate_build_mismatch),
-        ShutdownRequested(17, R.string.core_error_shutdown_requested),
-        ErrorUnknown(18, R.string.core_error_unknown);
+        ErrorSavestateBuildMismatch(15, R.string.core_error_savestate_build_mismatch),
+        ShutdownRequested(16, R.string.core_error_shutdown_requested),
+        ErrorUnknown(17, R.string.core_error_unknown);
 
         companion object {
             fun fromInt(value: Int): CoreError = entries.find { it.value == value } ?: ErrorUnknown

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -320,7 +320,7 @@ void Config::ReadValues() {
     ReadSetting("Debugging", Settings::values.instant_debug_log);
     ReadSetting("Debugging", Settings::values.enable_rpc_server);
     ReadSetting("Debugging", Settings::values.toggle_unique_data_console_type);
-    ReadSetting("Debugging", Settings::values.break_on_unmapped_memory_access);
+    ReadSetting("Debugging", Settings::values.enable_exception_handler);
 
     for (const auto& service_module : Service::service_module_map) {
         bool use_lle =

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -33,9 +33,9 @@ constexpr std::array android_config_omitted_keys = {
     Settings::Keys::audio_encoder,
     Settings::Keys::audio_encoder_options,
     Settings::Keys::audio_bitrate,
-    Settings::Keys::last_artic_base_addr, // On Android, this value is stored as a "preference"
+    Settings::Keys::last_artic_base_addr,     // On Android, this value is stored as a "preference"
     Settings::Keys::enable_exception_handler, // Does nothing as the error is ignored
-    Settings::Keys::use_gdbstub, // GDB functionality disabled by deafult on Android
+    Settings::Keys::use_gdbstub,              // GDB functionality disabled by deafult on Android
     Settings::Keys::gdbstub_port,
 };
 

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -34,7 +34,7 @@ constexpr std::array android_config_omitted_keys = {
     Settings::Keys::audio_encoder_options,
     Settings::Keys::audio_bitrate,
     Settings::Keys::last_artic_base_addr, // On Android, this value is stored as a "preference"
-    Settings::Keys::break_on_unmapped_memory_access, // Does nothing as the error is ignored
+    Settings::Keys::enable_exception_handler, // Does nothing as the error is ignored
     Settings::Keys::use_gdbstub, // GDB functionality disabled by deafult on Android
     Settings::Keys::gdbstub_port,
 };

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -134,7 +134,6 @@ static jobject ToJavaCoreError(Core::System::ResultStatus result) {
         {Core::System::ResultStatus::ErrorArticDisconnected, "ErrorArticDisconnected"},
         {Core::System::ResultStatus::ErrorN3DSApplication, "ErrorN3DSApplication"},
         {Core::System::ResultStatus::ErrorCoreExceptionRaised, "ErrorCoreExceptionRaised"},
-        {Core::System::ResultStatus::ErrorMemoryExceptionRaised, "ErrorMemoryExceptionRaised"},
         {Core::System::ResultStatus::ErrorSavestateBuildMismatch, "ErrorSavestateBuildMismatch"},
         {Core::System::ResultStatus::ErrorUnknown, "ErrorUnknown"},
     };

--- a/src/android/app/src/main/res/values-b+ca+ES+valencia/strings.xml
+++ b/src/android/app/src/main/res/values-b+ca+ES+valencia/strings.xml
@@ -464,7 +464,6 @@ S\'esperen errors gràfics temporals quan estigue activat.</string>
     <string name="core_error_artic_disconnected">Artic Base s\'ha desconnectat</string>
     <string name="core_error_n3ds_application">El fitxer es una aplicació de New 3DS</string>
     <string name="core_error_core_exception_raised">Es va produir una exepció en el nucli</string>
-    <string name="core_error_memory_exception_raised">Es va produir una excepció de memòria</string>
     <string name="core_error_shutdown_requested">Es va sol·licitar el tancament</string>
     <string name="core_error_unknown">Error desconegut</string>
 

--- a/src/android/app/src/main/res/values-b+pt+BR/strings.xml
+++ b/src/android/app/src/main/res/values-b+pt+BR/strings.xml
@@ -471,7 +471,6 @@
     <string name="core_error_artic_disconnected">Artic Base desconectado</string>
     <string name="core_error_n3ds_application">O arquivo é um aplicativo do New 3DS</string>
     <string name="core_error_core_exception_raised">Exceção de núcleo disparada</string>
-    <string name="core_error_memory_exception_raised">Exceção de memória disparada</string>
     <string name="core_error_savestate_build_mismatch">Versão do savestate incompatível</string>
     <string name="core_error_shutdown_requested">Desligamento solicitado</string>
     <string name="core_error_unknown">Erro desconhecido</string>

--- a/src/android/app/src/main/res/values-da/strings.xml
+++ b/src/android/app/src/main/res/values-da/strings.xml
@@ -441,7 +441,6 @@
     <string name="core_error_artic_disconnected">Arktisk base afkoblet</string>
     <string name="core_error_n3ds_application">Filen er en ny 3DS-applikation</string>
     <string name="core_error_core_exception_raised">Kerneundtagelse hævet</string>
-    <string name="core_error_memory_exception_raised">Hukommelsesundtagelse opstået</string>
     <string name="core_error_shutdown_requested">Nedlukning anmodet</string>
     <string name="core_error_unknown">Ukendt fejl</string>
 

--- a/src/android/app/src/main/res/values-es/strings.xml
+++ b/src/android/app/src/main/res/values-es/strings.xml
@@ -464,7 +464,6 @@ Se esperan fallos gráficos temporales cuando ésta esté activado.</string>
     <string name="core_error_artic_disconnected">Artic Base se desconectó</string>
     <string name="core_error_n3ds_application">El archivo es una aplicación de New 3DS</string>
     <string name="core_error_core_exception_raised">Se produjo una excepción en el núcleo</string>
-    <string name="core_error_memory_exception_raised">Se produjo una excepción de memoria</string>
     <string name="core_error_shutdown_requested">Se solicitó el cierre</string>
     <string name="core_error_unknown">Error desconocido</string>
 

--- a/src/android/app/src/main/res/values-fr/strings.xml
+++ b/src/android/app/src/main/res/values-fr/strings.xml
@@ -463,7 +463,6 @@
     <string name="core_error_artic_disconnected">Artic Base déconnecté</string>
     <string name="core_error_n3ds_application">Le fichier est une application New 3DS</string>
     <string name="core_error_core_exception_raised">Une erreur du cœur s\'est produite</string>
-    <string name="core_error_memory_exception_raised">Une erreur de mémoire s\'est produite</string>
     <string name="core_error_shutdown_requested">Arrêt demandé</string>
     <string name="core_error_unknown">Erreur inconnue</string>
 

--- a/src/android/app/src/main/res/values-it/strings.xml
+++ b/src/android/app/src/main/res/values-it/strings.xml
@@ -471,7 +471,6 @@
     <string name="core_error_artic_disconnected">Artic Base disconnesso</string>
     <string name="core_error_n3ds_application">Il file è un\'applicazione New 3DS</string>
     <string name="core_error_core_exception_raised">Rilevata eccezione del core</string>
-    <string name="core_error_memory_exception_raised">Rilevata eccezione della memoria</string>
     <string name="core_error_savestate_build_mismatch">Versione savestate incompatibile</string>
     <string name="core_error_shutdown_requested">Spegnimento richiesto</string>
     <string name="core_error_unknown">Errore sconosciuto</string>

--- a/src/android/app/src/main/res/values-pl/strings.xml
+++ b/src/android/app/src/main/res/values-pl/strings.xml
@@ -439,7 +439,6 @@
     <string name="core_error_artic_disconnected">Odłączono Artic Base</string>
     <string name="core_error_n3ds_application">Aplikacja jest dostępna wyłącznie na konsolę New 3DS</string>
     <string name="core_error_core_exception_raised">Wystąpił błąd rdzenia</string>
-    <string name="core_error_memory_exception_raised">Wystąpił błąd pamięci</string>
     <string name="core_error_shutdown_requested">Prośba o zamknięcie</string>
     <string name="core_error_unknown">Nieznany błąd</string>
 

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -492,7 +492,6 @@
     <string name="core_error_artic_disconnected">Artic Base disconnected</string>
     <string name="core_error_n3ds_application">File is New 3DS application</string>
     <string name="core_error_core_exception_raised">Core exception raised</string>
-    <string name="core_error_memory_exception_raised">Memory exception raised</string>
     <string name="core_error_savestate_build_mismatch">Savestate version mismatch</string>
     <string name="core_error_shutdown_requested">Shutdown requested</string>
     <string name="core_error_unknown">Unknown error</string>

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -99,6 +99,7 @@
 #include "common/settings.h"
 #include "common/string_util.h"
 #include "common/zstd_compression.h"
+#include "core/arm/exception_handler.h"
 #include "core/core.h"
 #include "core/dumping/backend.h"
 #include "core/file_sys/archive_extsavedata.h"
@@ -3854,8 +3855,79 @@ void GMainWindow::showEvent([[maybe_unused]] QShowEvent* event) {
     game_list->PopulateAsync(UISettings::values.game_dirs);
 }
 
+bool GMainWindow::ShowExceptionDialog(Core::System::ResultStatus result, const std::string& details) {
+    QDialog dialog(this);
+    dialog.setWindowTitle(result == Core::System::ResultStatus::ErrorCoreExceptionRaised
+            ? tr("An exception occurred")
+            : tr("An invalid memory access occurred")
+    );
+
+    dialog.setMinimumSize(600, 500);
+
+    auto* layout = new QVBoxLayout(&dialog);
+
+    auto* label = new QLabel(
+        result == Core::System::ResultStatus::ErrorCoreExceptionRaised
+            ? tr("An exception occurred while executing the emulated application.")
+            : tr("An invalid memory access occurred while executing the emulated application.")
+    );
+
+    layout->addWidget(label);
+
+    auto* textEdit = new QPlainTextEdit();
+    textEdit->setPlainText(QString::fromStdString(details));
+    textEdit->setReadOnly(true);
+    QFont monoFont(QStringLiteral("Monospace"));
+    monoFont.setStyleHint(QFont::TypeWriter);
+    monoFont.setPointSize(10);
+    textEdit->setFont(monoFont);
+    textEdit->setLineWrapMode(QPlainTextEdit::NoWrap);
+    layout->addWidget(textEdit);
+
+    auto* buttonLayout = new QHBoxLayout();
+
+    auto* ignoreButton = new QPushButton(tr("Ignore for this Session"));
+
+    QObject::connect(ignoreButton, &QPushButton::clicked, []() {
+        Core::SetIgnoreExceptionsForSession(true);
+    });
+
+    buttonLayout->addWidget(ignoreButton);
+    buttonLayout->addStretch();
+
+    auto* continueButton = new QPushButton(tr("Continue"));
+    QObject::connect(continueButton, &QPushButton::clicked, &dialog, &QDialog::reject);
+    buttonLayout->addWidget(continueButton);
+
+    auto* stopButton = new QPushButton(tr("Stop Emulation"));
+    QObject::connect(stopButton, &QPushButton::clicked, &dialog, &QDialog::accept);
+    buttonLayout->addWidget(stopButton);
+
+    layout->addLayout(buttonLayout);
+
+    return dialog.exec() == QDialog::Accepted;
+}
+
 void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string details) {
     QString status_message;
+
+    // Handle exception dialogs separately
+    if (result == Core::System::ResultStatus::ErrorCoreExceptionRaised ||
+        result == Core::System::ResultStatus::ErrorMemoryExceptionRaised) {
+        if (ShowExceptionDialog(result, details)) {
+            if (emu_thread) {
+                ShutdownGame();
+                return;
+            }
+        }
+
+        if (emu_thread) {
+            emu_thread->SetRunning(true);
+            message_label->setText(status_message);
+            message_label_used_for_movie = false;
+        }
+        return;
+    }
 
     QString title, message;
     QMessageBox::Icon error_severity_icon;
@@ -3886,18 +3958,6 @@ void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string det
                    .c_str());
         error_severity_icon = QMessageBox::Icon::Critical;
         can_continue = false;
-    } else if (result == Core::System::ResultStatus::ErrorCoreExceptionRaised) {
-        title = tr("An exception occurred");
-        message = tr("An exception occurred while executing the emulated application.\n\n");
-        message += QString::fromStdString(details);
-        error_severity_icon = QMessageBox::Icon::Critical;
-        can_continue = false;
-    } else if (result == Core::System::ResultStatus::ErrorMemoryExceptionRaised) {
-        title = tr("An invalid memory access occurred");
-        message =
-            tr("An invalid memory access occurred while executing the emulated application.\n\n");
-        message += QString::fromStdString(details);
-        error_severity_icon = QMessageBox::Icon::Critical;
     } else if (result == Core::System::ResultStatus::ErrorSavestateBuildMismatch) {
         title = tr("Savestate version mismatch");
         message = tr("Could not load savestate because it was created on a different Azahar "

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -3855,12 +3855,12 @@ void GMainWindow::showEvent([[maybe_unused]] QShowEvent* event) {
     game_list->PopulateAsync(UISettings::values.game_dirs);
 }
 
-bool GMainWindow::ShowExceptionDialog(Core::System::ResultStatus result, const std::string& details) {
+bool GMainWindow::ShowExceptionDialog(Core::System::ResultStatus result,
+                                      const std::string& details) {
     QDialog dialog(this);
     dialog.setWindowTitle(result == Core::System::ResultStatus::ErrorCoreExceptionRaised
-            ? tr("An exception occurred")
-            : tr("An invalid memory access occurred")
-    );
+                              ? tr("An exception occurred")
+                              : tr("An invalid memory access occurred"));
 
     dialog.setMinimumSize(600, 500);
 
@@ -3869,8 +3869,7 @@ bool GMainWindow::ShowExceptionDialog(Core::System::ResultStatus result, const s
     auto* label = new QLabel(
         result == Core::System::ResultStatus::ErrorCoreExceptionRaised
             ? tr("An exception occurred while executing the emulated application.")
-            : tr("An invalid memory access occurred while executing the emulated application.")
-    );
+            : tr("An invalid memory access occurred while executing the emulated application."));
 
     layout->addWidget(label);
 
@@ -3888,9 +3887,8 @@ bool GMainWindow::ShowExceptionDialog(Core::System::ResultStatus result, const s
 
     auto* ignoreButton = new QPushButton(tr("Ignore for this Session"));
 
-    QObject::connect(ignoreButton, &QPushButton::clicked, []() {
-        Core::SetIgnoreExceptionsForSession(true);
-    });
+    QObject::connect(ignoreButton, &QPushButton::clicked,
+                     []() { Core::SetIgnoreExceptionsForSession(true); });
 
     buttonLayout->addWidget(ignoreButton);
     buttonLayout->addStretch();
@@ -3912,8 +3910,7 @@ void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string det
     QString status_message;
 
     // Handle exception dialogs separately
-    if (result == Core::System::ResultStatus::ErrorCoreExceptionRaised ||
-        result == Core::System::ResultStatus::ErrorMemoryExceptionRaised) {
+    if (result == Core::System::ResultStatus::ErrorCoreExceptionRaised) {
         if (ShowExceptionDialog(result, details)) {
             if (emu_thread) {
                 ShutdownGame();

--- a/src/citra_qt/citra_qt.h
+++ b/src/citra_qt/citra_qt.h
@@ -303,6 +303,7 @@ private slots:
     void StartVideoDumping(const QString& path);
     void OnStopVideoDumping();
     void OnCoreError(Core::System::ResultStatus, std::string);
+    bool ShowExceptionDialog(Core::System::ResultStatus result, const std::string& details);
     /// Called whenever a user selects Help->About Azahar
     void OnMenuAboutCitra();
 

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -524,7 +524,7 @@ void QtConfig::ReadDebuggingValues() {
     ReadBasicSetting(Settings::values.instant_debug_log);
     ReadBasicSetting(Settings::values.enable_rpc_server);
     ReadBasicSetting(Settings::values.toggle_unique_data_console_type);
-    ReadBasicSetting(Settings::values.break_on_unmapped_memory_access);
+    ReadBasicSetting(Settings::values.enable_exception_handler);
 
     qt_config->beginGroup(QStringLiteral("LLE"));
     for (const auto& service_module : Service::service_module_map) {
@@ -1115,7 +1115,7 @@ void QtConfig::SaveDebuggingValues() {
     WriteBasicSetting(Settings::values.instant_debug_log);
     WriteBasicSetting(Settings::values.enable_rpc_server);
     WriteBasicSetting(Settings::values.toggle_unique_data_console_type);
-    WriteBasicSetting(Settings::values.break_on_unmapped_memory_access);
+    WriteBasicSetting(Settings::values.enable_exception_handler);
 
     qt_config->beginGroup(QStringLiteral("LLE"));
     for (const auto& service_module : Settings::values.lle_modules) {

--- a/src/citra_qt/configuration/configure_debug.cpp
+++ b/src/citra_qt/configuration/configure_debug.cpp
@@ -137,8 +137,7 @@ void ConfigureDebug::SetConfiguration() {
 #endif // !ENABLE_SCRIPTING
     ui->toggle_unique_data_console_type->setChecked(
         Settings::values.toggle_unique_data_console_type.GetValue());
-    ui->enable_exception_handler->setChecked(
-        Settings::values.enable_exception_handler.GetValue());
+    ui->enable_exception_handler->setChecked(Settings::values.enable_exception_handler.GetValue());
 
     ui->toggle_renderer_debug->setChecked(Settings::values.renderer_debug.GetValue());
     ui->toggle_pica_debugging->setChecked(Settings::values.pica_debugging.GetValue());
@@ -185,8 +184,7 @@ void ConfigureDebug::ApplyConfiguration() {
     Settings::values.enable_rpc_server = ui->enable_rpc_server->isChecked();
     Settings::values.toggle_unique_data_console_type =
         ui->toggle_unique_data_console_type->isChecked();
-    Settings::values.enable_exception_handler =
-        ui->enable_exception_handler->isChecked();
+    Settings::values.enable_exception_handler = ui->enable_exception_handler->isChecked();
     Settings::values.renderer_debug = ui->toggle_renderer_debug->isChecked();
     Settings::values.pica_debugging = ui->toggle_pica_debugging->isChecked();
     Settings::values.dump_command_buffers = ui->toggle_dump_command_buffers->isChecked();

--- a/src/citra_qt/configuration/configure_debug.cpp
+++ b/src/citra_qt/configuration/configure_debug.cpp
@@ -137,8 +137,8 @@ void ConfigureDebug::SetConfiguration() {
 #endif // !ENABLE_SCRIPTING
     ui->toggle_unique_data_console_type->setChecked(
         Settings::values.toggle_unique_data_console_type.GetValue());
-    ui->break_on_unmapped_memory_access->setChecked(
-        Settings::values.break_on_unmapped_memory_access.GetValue());
+    ui->enable_exception_handler->setChecked(
+        Settings::values.enable_exception_handler.GetValue());
 
     ui->toggle_renderer_debug->setChecked(Settings::values.renderer_debug.GetValue());
     ui->toggle_pica_debugging->setChecked(Settings::values.pica_debugging.GetValue());
@@ -185,8 +185,8 @@ void ConfigureDebug::ApplyConfiguration() {
     Settings::values.enable_rpc_server = ui->enable_rpc_server->isChecked();
     Settings::values.toggle_unique_data_console_type =
         ui->toggle_unique_data_console_type->isChecked();
-    Settings::values.break_on_unmapped_memory_access =
-        ui->break_on_unmapped_memory_access->isChecked();
+    Settings::values.enable_exception_handler =
+        ui->enable_exception_handler->isChecked();
     Settings::values.renderer_debug = ui->toggle_renderer_debug->isChecked();
     Settings::values.pica_debugging = ui->toggle_pica_debugging->isChecked();
     Settings::values.dump_command_buffers = ui->toggle_dump_command_buffers->isChecked();
@@ -213,7 +213,6 @@ void ConfigureDebug::SetupPerGameUI() {
     ui->groupBox_2->setVisible(false);
     ui->enable_rpc_server->setVisible(false);
     ui->toggle_unique_data_console_type->setVisible(false);
-    ui->break_on_unmapped_memory_access->setVisible(false);
     ui->toggle_cpu_jit->setVisible(false);
 }
 

--- a/src/citra_qt/configuration/configure_debug.ui
+++ b/src/citra_qt/configuration/configure_debug.ui
@@ -313,7 +313,7 @@
       <item row="5" column="0">
        <widget class="QCheckBox" name="enable_exception_handler">
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enables the exception handler. When an exception occurs a detailed crash report will be shown.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enables the exception handler. When an exception occurs a detailed crash report will be shown.&lt;/p&gt;&lt;p&gt;Note: When using CPU JIT, register values in the crash report may not be fully accurate because the JIT may have advanced past the fault. For more accurate reports, consider disabling CPU JIT.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
          <string>Enable exception handler</string>

--- a/src/citra_qt/configuration/configure_debug.ui
+++ b/src/citra_qt/configuration/configure_debug.ui
@@ -311,12 +311,12 @@
         </widget>
       </item>
       <item row="5" column="0">
-       <widget class="QCheckBox" name="break_on_unmapped_memory_access">
+       <widget class="QCheckBox" name="enable_exception_handler">
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pauses emulation and shows an error message if an unmapped memory access is detected.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enables the exception handler. When an exception occurs a detailed crash report will be shown.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
-         <string>Break on unmapped memory access</string>
+         <string>Enable exception handler</string>
         </property>
        </widget>
       </item>

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -171,8 +171,8 @@ void LogSettings() {
     log_setting("Debugging_InstantDebugLog", values.instant_debug_log.GetValue());
     log_setting("Debugging_ToggleUniqueDataConsoleType",
                 values.toggle_unique_data_console_type.GetValue());
-    log_setting("Debugging_BreakOnUnmappedMemoryAccess",
-                values.break_on_unmapped_memory_access.GetValue());
+    log_setting("Debugging_EnableExceptionHandler",
+                values.enable_exception_handler.GetValue());
 }
 
 bool IsConfiguringGlobal() {

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -171,8 +171,7 @@ void LogSettings() {
     log_setting("Debugging_InstantDebugLog", values.instant_debug_log.GetValue());
     log_setting("Debugging_ToggleUniqueDataConsoleType",
                 values.toggle_unique_data_console_type.GetValue());
-    log_setting("Debugging_EnableExceptionHandler",
-                values.enable_exception_handler.GetValue());
+    log_setting("Debugging_EnableExceptionHandler", values.enable_exception_handler.GetValue());
 }
 
 bool IsConfiguringGlobal() {

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -659,7 +659,7 @@ struct Values {
     Setting<bool> instant_debug_log{false, Keys::instant_debug_log};
     Setting<bool> enable_rpc_server{false, Keys::enable_rpc_server};
     Setting<bool> toggle_unique_data_console_type{false, Keys::toggle_unique_data_console_type};
-    Setting<bool> break_on_unmapped_memory_access{false, Keys::break_on_unmapped_memory_access};
+    Setting<bool> enable_exception_handler{true, Keys::enable_exception_handler};
 
     // WebService
     Setting<std::string> web_api_url{"", Keys::web_api_url};

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_library(citra_core STATIC EXCLUDE_FROM_ALL
     3ds.h
     arm/arm_interface.h
+    arm/exception_handler.cpp
+    arm/exception_handler.h
     arm/dyncom/arm_dyncom.cpp
     arm/dyncom/arm_dyncom.h
     arm/dyncom/arm_dyncom_dec.cpp

--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -12,6 +12,7 @@
 #include "core/arm/dynarmic/arm_dynarmic_cp15.h"
 #include "core/arm/dynarmic/arm_exclusive_monitor.h"
 #include "core/arm/dynarmic/arm_tick_counts.h"
+#include "core/arm/exception_handler.h"
 #include "core/core.h"
 #include "core/core_timing.h"
 #ifdef ENABLE_GDBSTUB
@@ -140,14 +141,22 @@ public:
         } else
 #endif
         {
-            std::string error;
-            for (int i = 0; i < 16; i++) {
-                error += fmt::format("r{:02d} = {:08X}\n", i, parent.GetReg(i));
+            Core::ExceptionType exc_type;
+            switch (exception) {
+            case Dynarmic::A32::Exception::UndefinedInstruction:
+            case Dynarmic::A32::Exception::UnpredictableInstruction:
+            case Dynarmic::A32::Exception::DecodeError:
+            case Dynarmic::A32::Exception::NoExecuteFault:
+                exc_type = Core::ExceptionType::UndefinedInstruction;
+                break;
+            case Dynarmic::A32::Exception::Breakpoint:
+                exc_type = Core::ExceptionType::Break;
+                break;
+            default:
+                exc_type = Core::ExceptionType::UndefinedInstruction;
+                break;
             }
-            error += fmt::format("ExceptionRaised(exception = {}, pc = {:08X})",
-                                 ExceptionToString(exception), pc);
-            parent.system.SetStatus(Core::System::ResultStatus::ErrorCoreExceptionRaised,
-                                    error.c_str());
+            Core::LogException(parent.system, exc_type, pc, ExceptionToString(exception));
         }
     }
 

--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -156,7 +156,7 @@ public:
                 exc_type = Core::ExceptionType::UndefinedInstruction;
                 break;
             }
-            Core::LogException(parent.system, exc_type, pc, ExceptionToString(exception));
+            Core::LogException(parent.system, exc_type);
         }
     }
 

--- a/src/core/arm/exception_handler.cpp
+++ b/src/core/arm/exception_handler.cpp
@@ -38,11 +38,11 @@ static std::string DumpRegisters(const ARM_Interface& core) {
 
     // SP, LR, PC
     out += fmt::format("    SP    0x{:08X}     LR    0x{:08X}     PC    0x{:08X}\n",
-        core.GetReg(13), core.GetReg(14), core.GetReg(15));
+                       core.GetReg(13), core.GetReg(14), core.GetReg(15));
 
     // CPSR, FPEXC, FPSCR
-    out += fmt::format("    CPSR  0x{:08X}     FPEXC 0x{:08X}     FPSCR 0x{:08X}\n",
-        core.GetCPSR(), core.GetVFPSystemReg(VFP_FPEXC), core.GetVFPSystemReg(VFP_FPSCR));
+    out += fmt::format("    CPSR  0x{:08X}     FPEXC 0x{:08X}     FPSCR 0x{:08X}\n", core.GetCPSR(),
+                       core.GetVFPSystemReg(VFP_FPEXC), core.GetVFPSystemReg(VFP_FPSCR));
 
     // VFP single-precision registers S0-S31
     out += '\n';
@@ -70,9 +70,8 @@ static std::string DumpStack(const ARM_Interface& core, Memory::MemorySystem& me
         for (u32 byte_offset = 0; byte_offset < 16; byte_offset += 4) {
             auto word = memory.Read32OrNullopt(addr + byte_offset);
             if (word) {
-                out += fmt::format("{:02X} {:02X} {:02X} {:02X}  ",
-                    (*word >> 0) & 0xFF, (*word >> 8) & 0xFF,
-                    (*word >> 16) & 0xFF, (*word >> 24) & 0xFF);
+                out += fmt::format("{:02X} {:02X} {:02X} {:02X}  ", (*word >> 0) & 0xFF,
+                                   (*word >> 8) & 0xFF, (*word >> 16) & 0xFF, (*word >> 24) & 0xFF);
             } else {
                 out += "?? ?? ?? ??  ";
             }
@@ -102,7 +101,11 @@ static const char* ExceptionTypeToString(ExceptionType type) {
     }
 }
 
-void LogException(System& system, ExceptionType type, u32 fault_address, const std::string& description) {
+void LogException(System& system, ExceptionType type) {
+    if (g_ignore_exceptions_for_session) {
+        return;
+    }
+
     auto& core = system.GetRunningCore();
     auto& memory = system.Memory();
 
@@ -112,7 +115,8 @@ void LogException(System& system, ExceptionType type, u32 fault_address, const s
         auto& kernel = system.Kernel();
         auto thread = kernel.GetCurrentThreadManager().GetCurrentThread();
         if (thread) {
-            report += fmt::format("Thread: {} (ID: {})\n", thread->GetName(), thread->GetThreadId());
+            report +=
+                fmt::format("Thread: {} (ID: {})\n", thread->GetName(), thread->GetThreadId());
             auto process = thread->owner_process.lock();
             if (process) {
                 report += fmt::format("Process: {}\n", process->GetName());
@@ -130,10 +134,6 @@ void LogException(System& system, ExceptionType type, u32 fault_address, const s
     report += DumpStack(core, memory);
 
     LOG_CRITICAL(Core, "\n{}", report);
-
-    if (g_ignore_exceptions_for_session) {
-        return;
-    }
 
     system.SetStatus(System::ResultStatus::ErrorCoreExceptionRaised, report.c_str());
 }

--- a/src/core/arm/exception_handler.cpp
+++ b/src/core/arm/exception_handler.cpp
@@ -1,3 +1,7 @@
+// Copyright 2026 Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
 #include "core/arm/exception_handler.h"
 
 #include <fmt/format.h>

--- a/src/core/arm/exception_handler.cpp
+++ b/src/core/arm/exception_handler.cpp
@@ -58,9 +58,7 @@ static std::string DumpRegisters(const ARM_Interface& core) {
     return out;
 }
 
-static std::string DumpStack(const ARM_Interface& core) {
-    auto& memory = system.Memory();
-
+static std::string DumpStack(const ARM_Interface& core, Memory::MemorySystem& memory) {
     std::string out;
     constexpr u32 stack_dump_size = 256;
     const u32 sp = core.GetReg(13);
@@ -106,6 +104,7 @@ static const char* ExceptionTypeToString(ExceptionType type) {
 
 void LogException(System& system, ExceptionType type, u32 fault_address, const std::string& description) {
     auto& core = system.GetRunningCore();
+    auto& memory = system.Memory();
 
     std::string report;
 

--- a/src/core/arm/exception_handler.cpp
+++ b/src/core/arm/exception_handler.cpp
@@ -1,0 +1,142 @@
+#include "core/arm/exception_handler.h"
+
+#include <fmt/format.h>
+#include "common/logging/log.h"
+#include "core/arm/arm_interface.h"
+#include "core/core.h"
+#include "core/hle/kernel/kernel.h"
+#include "core/hle/kernel/process.h"
+#include "core/hle/kernel/thread.h"
+#include "core/memory.h"
+
+namespace Core {
+
+static bool g_ignore_exceptions_for_session = false;
+
+void SetIgnoreExceptionsForSession(bool ignore) {
+    g_ignore_exceptions_for_session = ignore;
+}
+
+bool AreExceptionsIgnoredForSession() {
+    return g_ignore_exceptions_for_session;
+}
+
+static std::string DumpRegisters(const ARM_Interface& core) {
+    std::string out;
+
+    // General purpose registers: R0-R12
+    for (int i = 0; i < 13; i += 3) {
+        out += "    ";
+        for (int j = 0; j < 3 && i + j < 13; j++) {
+            const int reg = i + j;
+            out += fmt::format("R{:<3}  0x{:08X}     ", reg, core.GetReg(reg));
+        }
+        out += '\n';
+    }
+
+    out += '\n';
+
+    // SP, LR, PC
+    out += fmt::format("    SP    0x{:08X}     LR    0x{:08X}     PC    0x{:08X}\n",
+        core.GetReg(13), core.GetReg(14), core.GetReg(15));
+
+    // CPSR, FPEXC, FPSCR
+    out += fmt::format("    CPSR  0x{:08X}     FPEXC 0x{:08X}     FPSCR 0x{:08X}\n",
+        core.GetCPSR(), core.GetVFPSystemReg(VFP_FPEXC), core.GetVFPSystemReg(VFP_FPSCR));
+
+    // VFP single-precision registers S0-S31
+    out += '\n';
+    for (int i = 0; i < 32; i += 3) {
+        out += "    ";
+        for (int j = 0; j < 3 && i + j < 32; j++) {
+            const int reg = i + j;
+            out += fmt::format("S{:<3}  0x{:08X}     ", reg, core.GetVFPReg(reg));
+        }
+        out += '\n';
+    }
+
+    return out;
+}
+
+static std::string DumpStack(const ARM_Interface& core) {
+    auto& memory = system.Memory();
+
+    std::string out;
+    constexpr u32 stack_dump_size = 256;
+    const u32 sp = core.GetReg(13);
+
+    for (u32 offset = 0; offset < stack_dump_size; offset += 16) {
+        const u32 addr = sp + offset;
+        out += fmt::format("    0x{:08X}:  ", addr);
+
+        for (u32 byte_offset = 0; byte_offset < 16; byte_offset += 4) {
+            auto word = memory.Read32OrNullopt(addr + byte_offset);
+            if (word) {
+                out += fmt::format("{:02X} {:02X} {:02X} {:02X}  ",
+                    (*word >> 0) & 0xFF, (*word >> 8) & 0xFF,
+                    (*word >> 16) & 0xFF, (*word >> 24) & 0xFF);
+            } else {
+                out += "?? ?? ?? ??  ";
+            }
+        }
+        out += '\n';
+    }
+
+    return out;
+}
+
+static const char* ExceptionTypeToString(ExceptionType type) {
+    switch (type) {
+    case ExceptionType::UnmappedRead:
+        return "Unmapped Read";
+    case ExceptionType::UnmappedWrite:
+        return "Unmapped Write";
+    case ExceptionType::DataAbort:
+        return "Data Abort";
+    case ExceptionType::PrefetchAbort:
+        return "Prefetch Abort";
+    case ExceptionType::UndefinedInstruction:
+        return "Undefined Instruction";
+    case ExceptionType::Break:
+        return "Break";
+    default:
+        return "Unknown";
+    }
+}
+
+void LogException(System& system, ExceptionType type, u32 fault_address, const std::string& description) {
+    auto& core = system.GetRunningCore();
+
+    std::string report;
+
+    if (system.KernelRunning()) {
+        auto& kernel = system.Kernel();
+        auto thread = kernel.GetCurrentThreadManager().GetCurrentThread();
+        if (thread) {
+            report += fmt::format("Thread: {} (ID: {})\n", thread->GetName(), thread->GetThreadId());
+            auto process = thread->owner_process.lock();
+            if (process) {
+                report += fmt::format("Process: {}\n", process->GetName());
+            }
+        }
+    }
+
+    report += fmt::format("Exception Type: {}\n\n", ExceptionTypeToString(type));
+
+    report += "Registers:\n\n";
+    report += DumpRegisters(core);
+    report += '\n';
+
+    report += "Stack Dump:\n\n";
+    report += DumpStack(core, memory);
+
+    LOG_CRITICAL(Core, "\n{}", report);
+
+    if (g_ignore_exceptions_for_session) {
+        return;
+    }
+
+    system.SetStatus(System::ResultStatus::ErrorCoreExceptionRaised, report.c_str());
+}
+
+} // namespace Core

--- a/src/core/arm/exception_handler.h
+++ b/src/core/arm/exception_handler.h
@@ -24,10 +24,8 @@ enum class ExceptionType : u32 {
  *
  * @param system          The emulator system instance.
  * @param type            The type of exception that occurred.
- * @param fault_address   The address that caused the fault.
- * @param description     Optional human-readable description of the exception.
  */
-void LogException(System& system, ExceptionType type, u32 fault_address = 0, const std::string& description = "");
+void LogException(System& system, ExceptionType type);
 
 /**
  * Configures whether exceptions should be ignored for the current session.

--- a/src/core/arm/exception_handler.h
+++ b/src/core/arm/exception_handler.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <string>
+#include "common/common_types.h"
+
+namespace Core {
+
+class System;
+
+enum class ExceptionType : u32 {
+    UnmappedRead,
+    UnmappedWrite,
+    DataAbort,
+    PrefetchAbort,
+    UndefinedInstruction,
+    Break,
+};
+
+/**
+ * Logs a detailed crash report and halts emulation.
+ *
+ * Produces a structured report containing the exception type, register state and stack dump.
+ * The report is logged at LOG_CRITICAL level and passed to System::SetStatus to halt the run loop.
+ *
+ * @param system          The emulator system instance.
+ * @param type            The type of exception that occurred.
+ * @param fault_address   The address that caused the fault.
+ * @param description     Optional human-readable description of the exception.
+ */
+void LogException(System& system, ExceptionType type, u32 fault_address = 0, const std::string& description = "");
+
+/**
+ * Configures whether exceptions should be ignored for the current session.
+ *
+ * When enabled, LogException() will log the exception report without halting emulation.
+ *
+ * @param ignore    Whether to ignore exceptions and continue emulation.
+ */
+void SetIgnoreExceptionsForSession(bool ignore);
+bool AreExceptionsIgnoredForSession();
+
+} // namespace Core

--- a/src/core/arm/exception_handler.h
+++ b/src/core/arm/exception_handler.h
@@ -1,3 +1,7 @@
+// Copyright 2026 Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
 #pragma once
 
 #include <string>

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -106,7 +106,6 @@ public:
         ErrorArticDisconnected,               ///< Error when artic base disconnects
         ErrorN3DSApplication,        ///< Error launching New 3DS application in Old 3DS mode
         ErrorCoreExceptionRaised,    ///< The CPU emulation raised an exception
-        ErrorMemoryExceptionRaised,  ///< Unmmaped memory was accessed
         ErrorSavestateBuildMismatch, ///< Tried to load savestate from a different Azahar version
         ShutdownRequested,           ///< Emulated program requested a system shutdown
         ErrorUnknown                 ///< Any other error

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -12,6 +12,7 @@
 #include "common/scm_rev.h"
 #include "common/settings.h"
 #include "core/arm/arm_interface.h"
+#include "core/arm/exception_handler.h"
 #include "core/core.h"
 #include "core/core_timing.h"
 #ifdef ENABLE_GDBSTUB
@@ -1144,7 +1145,6 @@ Result SVC::ArbitrateAddress(Handle handle, u32 address, u32 type, u32 value, s6
 }
 
 void SVC::Break(u8 break_reason) {
-    LOG_CRITICAL(Debug_Emulated, "Emulated program broke execution!");
     std::string reason_str;
     switch (break_reason) {
     case 0:
@@ -1160,8 +1160,9 @@ void SVC::Break(u8 break_reason) {
         reason_str = "UNKNOWN";
         break;
     }
-    LOG_CRITICAL(Debug_Emulated, "Break reason: {}", reason_str);
-    system.SetStatus(Core::System::ResultStatus::ErrorUnknown);
+    LOG_CRITICAL(Debug_Emulated, "Emulated program broke execution! Reason: {}", reason_str);
+    Core::LogException(system, Core::ExceptionType::Break, 0,
+                       fmt::format("SVC Break - Reason: {}", reason_str));
 }
 
 /// Used to output a message on a debug hardware unit, or for the GDB file I/O

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1161,8 +1161,7 @@ void SVC::Break(u8 break_reason) {
         break;
     }
     LOG_CRITICAL(Debug_Emulated, "Emulated program broke execution! Reason: {}", reason_str);
-    Core::LogException(system, Core::ExceptionType::Break, 0,
-                       fmt::format("SVC Break - Reason: {}", reason_str));
+    Core::LogException(system, Core::ExceptionType::Break);
 }
 
 /// Used to output a message on a debug hardware unit, or for the GDB file I/O

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -578,11 +578,8 @@ void MemorySystem::UnmappedAccess(const VAddr vaddr, const T value, bool read) {
 #endif
     LOG_ERROR(HW_Memory, "{}", message);
     if (Settings::values.enable_exception_handler) {
-        Core::LogException(impl->system, read ?
-            Core::ExceptionType::UnmappedRead :
-            Core::ExceptionType::UnmappedWrite,
-            vaddr, message
-        );
+        Core::LogException(impl->system, read ? Core::ExceptionType::UnmappedRead
+                                              : Core::ExceptionType::UnmappedWrite);
     }
 }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -17,6 +17,7 @@
 #include "common/settings.h"
 #include "common/swap.h"
 #include "core/arm/arm_interface.h"
+#include "core/arm/exception_handler.h"
 #include "core/core.h"
 #ifdef ENABLE_GDBSTUB
 #include "core/gdbstub/gdbstub.h"
@@ -573,14 +574,16 @@ void MemorySystem::UnmappedAccess(const VAddr vaddr, const T value, bool read) {
 #ifdef ENABLE_GDBSTUB
     if (GDBStub::IsConnected()) {
         GDBStub::Break(SIGSEGV);
-    } else
-#endif
-        if (Settings::values.break_on_unmapped_memory_access) {
-        impl->system.SetStatus(Core::System::ResultStatus::ErrorMemoryExceptionRaised,
-                               message.c_str());
     }
-
+#endif
     LOG_ERROR(HW_Memory, "{}", message);
+    if (Settings::values.enable_exception_handler) {
+        Core::LogException(impl->system, read ?
+            Core::ExceptionType::UnmappedRead :
+            Core::ExceptionType::UnmappedWrite,
+            vaddr, message
+        );
+    }
 }
 
 template <typename T>


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

## Summary

This PR introduces a more detailed exception handler replacing the existing exception dialog that is shown when "**Break on unmapped memory access**" is enabled in the debug settings. The setting has also been renamed to "**Enable exception handler**".

When enabled, an exception now shows a dialog containing the full CPU register state as well as a stack trace, similar to the information provided by Luma3DS's exception handler.

The dialog provides three options to the user. The two pre-existing options "**Continue**" and "**Quit Application**" (now renamed to "**Stop Emulation**") are functionally unchanged. One additional option "**Ignore for current session**" has been added, allowing for the dialog to be dismissed and disabled for the remainder for the current session.
 
 ## Motivation
 
I primarily implemented this feature for myself as I find the current dialog to be quite limiting.

The existing exception dialog only displays the value of the program counter, which is often insufficient when investigating an exception. Additional context from other registers as well as stack information can be very valuable when debugging an exception.

Additionally, while open, a dialog prevents interaction with the rest of the UI. This means a user cannot open the Registers view to inspect the state. The only available options are to continue or stop emulation, both of which can cause the state that needs to be inspected to be lost or overwritten.

Providing the relevant state directly in the dialog addresses both of these limitations, while also allowing users to temporarily suppress the dialog when they encounter exceptions they do care about.