### PR TITLE
Look Mode For Motion Emulation

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -546,6 +546,8 @@ void GRenderWindow::mousePressEvent(QMouseEvent* event) {
         this->TouchPressed(x, y);
     } else if (event->button() == Qt::RightButton) {
         InputCommon::GetMotionEmu()->BeginTilt(pos.x(), pos.y());
+    } else if (event->button() == Qt::MiddleButton) {
+        InputCommon::GetMotionEmu()->BeginLook(pos.x(), pos.y());
     }
     emit MouseActivity();
 }
@@ -559,6 +561,7 @@ void GRenderWindow::mouseMoveEvent(QMouseEvent* event) {
     const auto [x, y] = ScaleTouch(pos);
     this->TouchMoved(x, y);
     InputCommon::GetMotionEmu()->Tilt(pos.x(), pos.y());
+    InputCommon::GetMotionEmu()->Look(pos.x(), pos.y());
     emit MouseActivity();
 }
 
@@ -571,6 +574,8 @@ void GRenderWindow::mouseReleaseEvent(QMouseEvent* event) {
         this->TouchReleased();
     else if (event->button() == Qt::RightButton)
         InputCommon::GetMotionEmu()->EndTilt();
+    else if (event->button() == Qt::MiddleButton)
+        InputCommon::GetMotionEmu()->EndLook();
     emit MouseActivity();
 }
 

--- a/src/citra_qt/configuration/configure_motion_touch.cpp
+++ b/src/citra_qt/configuration/configure_motion_touch.cpp
@@ -76,7 +76,7 @@ void CalibrationConfigurationDialog::UpdateButtonText(const QString& text) {
 }
 
 constexpr std::array<std::pair<const char*, const char*>, 3> MotionProviders = {{
-    {"motion_emu", QT_TRANSLATE_NOOP("ConfigureMotionTouch", "Mouse (Right Click)")},
+    {"motion_emu", QT_TRANSLATE_NOOP("ConfigureMotionTouch", "Mouse (Right Click for Tilt, Middle Click for Look)")},
     {"cemuhookudp", QT_TRANSLATE_NOOP("ConfigureMotionTouch", "CemuhookUDP")},
     {"sdl", QT_TRANSLATE_NOOP("ConfigureMotionTouch", "SDL")},
 }};

--- a/src/input_common/motion_emu.cpp
+++ b/src/input_common/motion_emu.cpp
@@ -87,7 +87,7 @@ private:
 
     void MotionEmuThread() {
         auto update_time = std::chrono::steady_clock::now();
-        Common::Quaternion<float> q = Common::MakeQuaternion(Common::Vec3<float>(), 0);
+        Common::Quaternion<float> q = Common::MakeQuaternion(Common::MakeVec(90, 0, 0), 90);
         Common::Quaternion<float> old_q;
 
         while (!shutdown_event.WaitUntil(update_time)) {
@@ -99,6 +99,8 @@ private:
 
                 // Find the quaternion describing current 3DS tilting
                 q = Common::MakeQuaternion(
+                    Common::MakeVec(90, 0, 0), 90);
+                q += Common::MakeQuaternion(
                     Common::MakeVec(-tilt_direction.y, 0.0f, tilt_direction.x), tilt_angle);
             }
 

--- a/src/input_common/motion_emu.cpp
+++ b/src/input_common/motion_emu.cpp
@@ -7,11 +7,13 @@
 #include <mutex>
 #include <thread>
 #include <tuple>
+#include <cmath>
 #include "common/math_util.h"
 #include "common/quaternion.h"
 #include "common/thread.h"
 #include "common/vector_math.h"
 #include "input_common/motion_emu.h"
+
 
 namespace InputCommon {
 
@@ -34,7 +36,15 @@ public:
 
     void BeginTilt(int x, int y) {
         mouse_origin = Common::MakeVec(x, y);
+        look_direction = Common::MakeVec(0.0f, 0.0f);
         is_tilting = true;
+        is_looking = false;
+    }
+
+    void BeginLook(int x, int y) {
+        mouse_origin = Common::MakeVec(x, y);
+        previous_look_direction = look_direction;
+        is_looking = true;
     }
 
     void Tilt(int x, int y) {
@@ -51,10 +61,24 @@ public:
         }
     }
 
+    void Look(int x, int y) {
+        auto mouse_move = Common::MakeVec(x, y) - mouse_origin + previous_look_direction.Cast<int>();
+        if (is_looking) {
+            std::lock_guard guard{tilt_mutex};
+            if (!(mouse_move.x == 0 && mouse_move.y == 0)) {
+                look_direction = mouse_move.Cast<float>();
+            }
+        }
+    }
+
     void EndTilt() {
         std::lock_guard guard{tilt_mutex};
         tilt_angle = 0;
         is_tilting = false;
+    }
+
+    void EndLook() {
+        is_looking = false;
     }
 
     std::tuple<Common::Vec3<float>, Common::Vec3<float>> GetStatus() {
@@ -71,10 +95,13 @@ private:
 
     std::mutex tilt_mutex;
     Common::Vec2<float> tilt_direction;
+    Common::Vec2<float> look_direction;
+    Common::Vec2<float> previous_look_direction = Common::MakeVec(0.0f,0.0f);
     float tilt_angle = 0;
     float tilt_clamp = 90;
 
     bool is_tilting = false;
+    bool is_looking = false;
 
     Common::Event shutdown_event;
 
@@ -87,7 +114,7 @@ private:
 
     void MotionEmuThread() {
         auto update_time = std::chrono::steady_clock::now();
-        Common::Quaternion<float> q = Common::MakeQuaternion(Common::MakeVec(-1.0f, 0.0f, 0.0f), 90.0f);
+        Common::Quaternion<float> q = {{0.0f, 0.0f, 0.0f}, 1.0f};
         Common::Quaternion<float> old_q;
 
         while (!shutdown_event.WaitUntil(update_time)) {
@@ -97,8 +124,20 @@ private:
             {
                 std::lock_guard guard{tilt_mutex};
 
-                // Find the quaternion describing current 3DS tilting
-                q = Common::MakeQuaternion(Common::MakeVec(-1.0f, 0.0f, 0.0f), 90.0f) + Common::MakeQuaternion(Common::MakeVec(-tilt_direction.y, 0.0f, tilt_direction.x), tilt_angle);
+                if (is_tilting) {
+                    // Find the quaternion describing current 3DS tilting
+                    q = Common::MakeQuaternion(Common::MakeVec(-tilt_direction.y, 0.0f, tilt_direction.x), tilt_angle);
+                }else {
+                    // Find the quaternion describing current 3DS looking
+                    float p = -1.0f * ((Common::PI * 0.25f) + Common::PI * (-look_direction.y * sensitivity * 100.0f) / 360.0f);
+                    float y = Common::PI * (-look_direction.x * sensitivity * 100.0f) / 360.0f;
+                    float qw = std::cos(p) * std::cos(y);
+                    float qx = std::sin(p) * std::cos(y);
+                    float qy = std::cos(p) * std::sin(y);
+                    float qz = -1.0f * std::sin(p) * std::sin(y);
+
+                    q = {Common::MakeVec(qx, qy, qz), qw};
+                }
             }
 
             auto inv_q = q.Inverse();
@@ -157,15 +196,33 @@ void MotionEmu::BeginTilt(int x, int y) {
     }
 }
 
+void MotionEmu::BeginLook(int x, int y) {
+    if (auto ptr = current_device.lock()) {
+        ptr->BeginLook(x, y);
+    }
+}
+
 void MotionEmu::Tilt(int x, int y) {
     if (auto ptr = current_device.lock()) {
         ptr->Tilt(x, y);
     }
 }
 
+void MotionEmu::Look(int x, int y) {
+    if (auto ptr = current_device.lock()) {
+        ptr->Look(x, y);
+    }
+}
+
 void MotionEmu::EndTilt() {
     if (auto ptr = current_device.lock()) {
         ptr->EndTilt();
+    }
+}
+
+void MotionEmu::EndLook() {
+    if (auto ptr = current_device.lock()) {
+        ptr->EndLook();
     }
 }
 

--- a/src/input_common/motion_emu.cpp
+++ b/src/input_common/motion_emu.cpp
@@ -87,7 +87,7 @@ private:
 
     void MotionEmuThread() {
         auto update_time = std::chrono::steady_clock::now();
-        Common::Quaternion<float> q = Common::MakeQuaternion(Common::MakeVec(90, 0, 0), 90);
+        Common::Quaternion<float> q = Common::MakeQuaternion(Common::MakeVec(-1.0f, 0.0f, 0.0f), 90.0f);
         Common::Quaternion<float> old_q;
 
         while (!shutdown_event.WaitUntil(update_time)) {
@@ -98,10 +98,7 @@ private:
                 std::lock_guard guard{tilt_mutex};
 
                 // Find the quaternion describing current 3DS tilting
-                q = Common::MakeQuaternion(
-                    Common::MakeVec(90, 0, 0), 90);
-                q += Common::MakeQuaternion(
-                    Common::MakeVec(-tilt_direction.y, 0.0f, tilt_direction.x), tilt_angle);
+                q = Common::MakeQuaternion(Common::MakeVec(-1.0f, 0.0f, 0.0f), 90.0f) + Common::MakeQuaternion(Common::MakeVec(-tilt_direction.y, 0.0f, tilt_direction.x), tilt_angle);
             }
 
             auto inv_q = q.Inverse();

--- a/src/input_common/motion_emu.h
+++ b/src/input_common/motion_emu.h
@@ -21,23 +21,26 @@ public:
     std::unique_ptr<Input::MotionDevice> Create(const Common::ParamPackage& params) override;
 
     /**
-     * Signals that a motion sensor tilt has begun.
+     * Signals that a motion sensor tilt and look has begun.
      * @param x the x-coordinate of the cursor
      * @param y the y-coordinate of the cursor
      */
     void BeginTilt(int x, int y);
+    void BeginLook(int x, int y);
 
     /**
-     * Signals that a motion sensor tilt is occurring.
+     * Signals that a motion sensor tilt and look is occurring.
      * @param x the x-coordinate of the cursor
      * @param y the y-coordinate of the cursor
      */
     void Tilt(int x, int y);
+    void Look(int x, int y);
 
     /**
-     * Signals that a motion sensor tilt has ended.
+     * Signals that a motion sensor tilt and look has ended.
      */
     void EndTilt();
+    void EndLook();
 
 private:
     std::weak_ptr<MotionEmuDevice> current_device;


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------
By using middle click and moving the mouse, you can change the pitch and yaw of the gyro. Gyro rotation doesn't resent until you used the tilt function to allow for large rotations. This function aims to allow users without a gyro controller to use the gyro function in games that require more than tilting, something that is kinda overdue.
<!--
If you are contributing to Azahar for the first time please
keep the block of text between `---` and write your 
PR description below it. Do not write anything inside 
or change this block of text!

If you are a recurrent contributor, remove this entire
block of text and proceed as normal.
-->

---
