### PR TITLE
android: Add locks around surface creation and destruction

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/EmulationFragment.kt
@@ -1707,8 +1707,6 @@ class EmulationFragment :
                 state = State.PAUSED
                 Log.debug("[EmulationFragment] Pausing emulation.")
 
-                // Release the surface before pausing, since emulation has to be running for that.
-                NativeLibrary.surfaceDestroyed()
                 NativeLibrary.pauseEmulation()
                 NativeLibrary.playTimeManagerStop()
             } else {
@@ -1768,6 +1766,7 @@ class EmulationFragment :
                     }
 
                     State.PAUSED -> {
+                        NativeLibrary.surfaceDestroyed()
                         Log.warning("[EmulationFragment] Surface cleared while emulation paused.")
                     }
 

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -103,6 +103,22 @@ std::mutex paused_mutex;
 std::mutex running_mutex;
 std::condition_variable running_cv;
 
+// Guards the lifetime of s_surface/s_secondary_surface and the (re)creation of the
+// EmuWindow_Android and renderer objects that consume them. Android may destroy or replace the
+// Surface passed to us (on rotation, or if the fragment hosting the SurfaceView is torn
+// down and recreated) from the UI thread at any time, including while the renderer is still
+// being constructed on the emulation thread in RunCitra(). Without this lock, the UI thread can
+// release/replace the ANativeWindow while it is concurrently being used to create the
+// initial Vulkan/EGL surface, resulting in a use-after-free. A recursive mutex is needed
+// due to the locking pattern used in RunCitra().
+std::recursive_mutex surface_mutex;
+
+// Signalled by surfaceChanged() whenever s_surface goes from null to non-null. Used by the
+// System::Init() callback to block the renderer (re)creation (initial boot or a
+// savestate load) until a surface actually exists, instead of giving
+// VideoCore a null ANativeWindow.
+std::condition_variable_any surface_cv;
+
 std::string inserted_cartridge;
 
 // Android Multiplayer which can be initialized with parameters
@@ -151,6 +167,8 @@ static void LoadDiskCacheProgress(VideoCore::LoadCallbackStage stage, int progre
 static Camera::NDK::Factory* g_ndk_factory{};
 
 static void TryShutdown() {
+    std::scoped_lock surface_lock(surface_mutex);
+
     if (!window) {
         return;
     }
@@ -197,6 +215,37 @@ static Core::System::ResultStatus RunCitra(const std::string& filepath) {
     if (!inserted_cartridge.empty()) {
         system.InsertCartridge(inserted_cartridge);
     }
+
+    // Acquired for the whole window/renderer construction below (and released again once
+    // system.Load() has finished setting up the renderer), so that a concurrent
+    // surfaceChanged/surfaceDestroyed callback from the UI thread cannot release or replace
+    // s_surface/s_secondary_surface while they're still being used.
+    std::unique_lock<std::recursive_mutex> surface_lock(surface_mutex);
+
+    // We also need to lock the surface mutex when System::Init() is called.
+    // This is because save state saving and loading may call System::Init
+    // on its own which does GPU reinitialization.
+    // This is why a recursive mutex is needed, as System::Load() also calls
+    // System::Init() which in this RunCitra() function would result in a deadlock.
+    system.RegisterOnInitCallback([](bool init_start) {
+        if (init_start) {
+            surface_mutex.lock();
+            // A savestate load re-enters here later, well after surface_lock in RunCitra() has
+            // already been released. If a rotation destroyed s_surface just before this callback
+            // acquired the lock, wait here for surfaceChanged() to hand us a new one rather than
+            // proceeding into CreateSurface() with a null window. During the very first call
+            // (initial boot) this never actually blocks, since surfaceChanged/surfaceDestroyed
+            // cannot run concurrently here, this same thread still holds surface_lock above
+            // for the whole boot sequence.
+            if (!s_surface) {
+                std::unique_lock<std::recursive_mutex> wait_lock(surface_mutex, std::adopt_lock);
+                surface_cv.wait(wait_lock, [] { return s_surface != nullptr; });
+                wait_lock.release();
+            }
+        } else {
+            surface_mutex.unlock();
+        }
+    });
 
     const auto graphics_api = Settings::GetWorkingGraphicsAPI();
     EGLContext* shared_context;
@@ -274,8 +323,13 @@ static Core::System::ResultStatus RunCitra(const std::string& filepath) {
     InputManager::Init();
 
     window->MakeCurrent();
+
     const Core::System::ResultStatus load_result{
         system.Load(*window, filepath, secondary_window.get())};
+
+    // At this point, the surface has already been used, so the mutex can be unlocked.
+    surface_lock.unlock();
+
     if (load_result != Core::System::ResultStatus::Success) {
         return load_result;
     }
@@ -369,7 +423,20 @@ extern "C" {
 void Java_org_citra_citra_1emu_NativeLibrary_surfaceChanged(JNIEnv* env,
                                                             [[maybe_unused]] jobject obj,
                                                             jobject surf) {
+    std::scoped_lock lock(surface_mutex);
+
+    if (s_surface) {
+        ANativeWindow_release(s_surface);
+        s_surface = nullptr;
+    }
     s_surface = ANativeWindow_fromSurface(env, surf);
+    if (!s_surface) {
+        LOG_WARNING(Frontend, "Surface changed, but failed to acquire the native window");
+        return;
+    }
+    // Wake up any System::Init() currently blocked waiting for a live surface
+    // (can happen when loading savestates and the screen rotates).
+    surface_cv.notify_all();
 
     bool notify = false;
     if (window) {
@@ -387,6 +454,8 @@ void Java_org_citra_citra_1emu_NativeLibrary_surfaceChanged(JNIEnv* env,
 void Java_org_citra_citra_1emu_NativeLibrary_secondarySurfaceChanged(JNIEnv* env,
                                                                      [[maybe_unused]] jobject obj,
                                                                      jobject surf) {
+    std::scoped_lock lock(surface_mutex);
+
     auto& system = Core::System::GetInstance();
 
     if (s_secondary_surface) {
@@ -421,6 +490,8 @@ void Java_org_citra_citra_1emu_NativeLibrary_secondarySurfaceChanged(JNIEnv* env
 
 void Java_org_citra_citra_1emu_NativeLibrary_secondarySurfaceDestroyed(
     JNIEnv* env, [[maybe_unused]] jobject obj) {
+    std::scoped_lock lock(surface_mutex);
+
     if (s_secondary_surface != nullptr) {
         ANativeWindow_release(s_secondary_surface);
         s_secondary_surface = nullptr;
@@ -431,6 +502,8 @@ void Java_org_citra_citra_1emu_NativeLibrary_secondarySurfaceDestroyed(
 
 void Java_org_citra_citra_1emu_NativeLibrary_surfaceDestroyed([[maybe_unused]] JNIEnv* env,
                                                               [[maybe_unused]] jobject obj) {
+    std::scoped_lock lock(surface_mutex);
+
     if (s_surface != nullptr) {
         ANativeWindow_release(s_surface);
         s_surface = nullptr;

--- a/src/android/app/src/main/jni/ndk_motion.cpp
+++ b/src/android/app/src/main/jni/ndk_motion.cpp
@@ -1,3 +1,7 @@
+// Copyright 2020-2026 Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
 #include <chrono>
 #include <thread>
 
@@ -16,10 +20,19 @@ using Common::Vec3;
 
 class NDKMotion final : public Input::MotionDevice {
     std::chrono::microseconds update_period;
+    NDKMotionFactory* owner_factory;
 
     ASensorManager* sensor_manager = nullptr;
     ALooper* looper = nullptr;
     ASensorEventQueue* event_queue;
+
+    // EnableSensors()/DisableSensors() can be invoked from the UI thread
+    // (pauseEmulation/unPauseEmulation) or from the emulation thread (the
+    // RunLoop error handling path), while Update() is invoked from inside the core.
+    // The underlying ASensorEventQueue is not safe for concurrent
+    // use from multiple threads, so without this lock, concurrent access can
+    // cause queue corruption and crashes.
+    mutable std::mutex sensor_mutex;
 
     mutable std::atomic<Vec3<float>> acceleration{};
     mutable std::atomic<Vec3<float>> rotation{};
@@ -82,6 +95,7 @@ class NDKMotion final : public Input::MotionDevice {
     }
 
     void Update() const {
+        std::lock_guard lock{sensor_mutex};
         ALooper_pollOnce(0, nullptr, nullptr, nullptr);
         ASensorEvent event{};
         std::optional<Vec3<float>> new_accel{}, new_rot{};
@@ -105,8 +119,9 @@ class NDKMotion final : public Input::MotionDevice {
     }
 
 public:
-    NDKMotion(std::chrono::microseconds update_period_, bool asynchronous = false)
-        : update_period(update_period_) {
+    NDKMotion(std::chrono::microseconds update_period_, NDKMotionFactory* owner_factory_,
+              bool asynchronous = false)
+        : update_period(update_period_), owner_factory(owner_factory_) {
         if (asynchronous) {
             poll_thread = std::thread([this] {
                 Construct();
@@ -123,6 +138,14 @@ public:
     }
 
     ~NDKMotion() {
+        // Unregister first so the factory can never dereference this object
+        // again once we start tearing it down. This blocks until any
+        // EnableSensors()/DisableSensors() call already running through the
+        // factory has finished, so it's safe to destroy event_queue after.
+        if (owner_factory) {
+            owner_factory->Unregister(this);
+        }
+
         if (std::thread::id{} == poll_thread.get_id()) {
             Destruct();
         } else {
@@ -139,6 +162,7 @@ public:
     }
 
     void EnableSensors() {
+        std::lock_guard lock{sensor_mutex};
         const auto init_sensor = [this](int sensor_type) {
             ASensorRef sensor = ASensorManager_getDefaultSensor(sensor_manager, sensor_type);
             if (!sensor) {
@@ -158,6 +182,7 @@ public:
     }
 
     void DisableSensors() {
+        std::lock_guard lock{sensor_mutex};
         const auto disable_sensor = [this](int sensor_type) {
             ASensorRef sensor = ASensorManager_getDefaultSensor(sensor_manager, sensor_type);
             if (!sensor) {
@@ -177,19 +202,33 @@ public:
 
 std::unique_ptr<Input::MotionDevice> NDKMotionFactory::Create(const Common::ParamPackage& params) {
     std::chrono::milliseconds update_period{params.Get("update_period", 4)};
-    std::unique_ptr<NDKMotion> ndk_motion = std::make_unique<NDKMotion>(update_period);
-    ndk_motion_device = ndk_motion.get();
+    std::unique_ptr<NDKMotion> ndk_motion = std::make_unique<NDKMotion>(update_period, this);
+    {
+        std::lock_guard lock{device_mutex};
+        ndk_motion_device = ndk_motion.get();
+    }
     return std::move(ndk_motion);
 }
 
 void NDKMotionFactory::EnableSensors() {
-    if (ndk_motion_device)
+    std::lock_guard lock{device_mutex};
+    if (ndk_motion_device) {
         ndk_motion_device->EnableSensors();
+    }
 }
 
 void NDKMotionFactory::DisableSensors() {
-    if (ndk_motion_device)
+    std::lock_guard lock{device_mutex};
+    if (ndk_motion_device) {
         ndk_motion_device->DisableSensors();
+    }
+}
+
+void NDKMotionFactory::Unregister(NDKMotion* device) {
+    std::lock_guard lock{device_mutex};
+    if (ndk_motion_device == device) {
+        ndk_motion_device = nullptr;
+    }
 }
 
 } // namespace InputManager

--- a/src/android/app/src/main/jni/ndk_motion.h
+++ b/src/android/app/src/main/jni/ndk_motion.h
@@ -1,8 +1,10 @@
-// Copyright 2020 Citra Emulator Project
-// Licensed under GPLv2+
+// Copyright 2020-2026 Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
 #pragma once
+
+#include <mutex>
 
 #include "core/frontend/input.h"
 
@@ -23,6 +25,13 @@ public:
     void DisableSensors();
 
 private:
-    NDKMotion* ndk_motion_device;
+    friend class NDKMotion;
+
+    /// Called from ~NDKMotion() so the factory can never call into a device
+    /// that has already been destroyed.
+    void Unregister(NDKMotion* device);
+
+    std::mutex device_mutex;
+    NDKMotion* ndk_motion_device = nullptr;
 };
 } // namespace InputManager

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -10,6 +10,7 @@
 #include "audio_core/lle/lle.h"
 #include "common/arch.h"
 #include "common/logging/log.h"
+#include "common/scope_exit.h"
 #include "common/settings.h"
 #include "core/arm/arm_interface.h"
 #include "core/arm/exclusive_monitor.h"
@@ -519,6 +520,16 @@ void System::Reschedule() {
 System::ResultStatus System::Init(Frontend::EmuWindow& emu_window,
                                   Frontend::EmuWindow* secondary_window,
                                   Kernel::MemoryMode memory_mode, u32 num_cores) {
+    // Notification for system initialization (either boot or savestate).
+    if (on_init_callback) {
+        on_init_callback(true);
+    }
+    SCOPE_EXIT({
+        if (on_init_callback) {
+            on_init_callback(false);
+        }
+    });
+
     LOG_DEBUG(HW_Memory, "initialized OK");
 
     memory = std::make_unique<Memory::MemorySystem>(*this);

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -344,9 +344,14 @@ public:
     }
 
     /// Function for checking OS microphone permissions.
-
     void RegisterMicPermissionCheck(const std::function<bool()>& permission_func) {
         mic_permission_func = permission_func;
+    }
+
+    /// Fires the callback when System::Init() is called. Called with
+    /// true when initialization starts, and with false once its done.
+    void RegisterOnInitCallback(const std::function<void(bool)>& init_callback) {
+        on_init_callback = init_callback;
     }
 
     [[nodiscard]] bool HasMicPermission() {
@@ -523,6 +528,8 @@ private:
 
     std::function<bool()> mic_permission_func;
     bool mic_permission_granted = false;
+
+    std::function<void(bool)> on_init_callback;
 
     boost::optional<Service::APT::DeliverArg> restore_deliver_arg;
     boost::optional<Service::APT::SysMenuArg> restore_sys_menu_arg;

--- a/src/video_core/renderer_vulkan/vk_present_window.cpp
+++ b/src/video_core/renderer_vulkan/vk_present_window.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Citra Emulator Project / Azahar Emulator Project
+// Copyright 2023-2026 Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -155,6 +155,13 @@ PresentWindow::PresentWindow(Frontend::EmuWindow& emu_window_, const Instance& i
 PresentWindow::~PresentWindow() {
     scheduler.Finish();
     const vk::Device device = instance.GetDevice();
+    // If the window is destroyed before the next_surface is
+    // consumed, make sure to destroy it here to prevent a
+    // resource leak.
+    if (next_surface && next_surface != surface) {
+        instance.GetInstance().destroySurfaceKHR(next_surface);
+        next_surface = vk::SurfaceKHR{};
+    }
     device.destroyCommandPool(command_pool);
     device.destroyRenderPass(present_renderpass);
     for (auto& frame : swap_chain) {
@@ -340,6 +347,24 @@ void PresentWindow::PresentThread(std::stop_token token) {
 void PresentWindow::NotifySurfaceChanged() {
 #ifdef ANDROID
     std::scoped_lock lock{recreate_surface_mutex};
+
+    // surfaceChanged() may notify us that a surface has changed
+    // for the same surface multiple times. If that is the case
+    // skip creating the surface again as that would cause a
+    // vulkan ErrorNativeWindowInUseKHR.
+    void* const render_surface = emu_window.GetWindowInfo().render_surface;
+    if (render_surface == last_render_surface) {
+        return;
+    }
+    last_render_surface = render_surface;
+
+    // If an earlier notification produced a surface that CopyToSwapchain() has not consumed yet,
+    // release it rather than just overwritting its handle and causing a leak.
+    if (next_surface && next_surface != surface) {
+        instance.GetInstance().destroySurfaceKHR(next_surface);
+        next_surface = vk::SurfaceKHR{};
+    }
+
     next_surface = CreateSurface(instance.GetInstance(), emu_window);
     recreate_surface_cv.notify_one();
 #endif


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.

Crashes caused by surface handling have been pending for resolution in our backlog for a very long time, due to how difficult it is to reproduce them (3 different Android devices with different specs and manufacturers weren't able to trigger them). So I finally decided to feed the surface handling code to an AI, in hopes that it would find issues. The AI did find issues, and suggested how to fix them (mostly using mutexes). After this, the timings changed enough to finally be able to reproduce the remaining crashes, which helped fix all of them. A final pass was done with AI to find any additional issues.

Therefore, AI was used to diagnose the problem, find all edge cases and suggest fixes that were implemented manually.

---------

This PR includes fixes to crashes commonly found in Azahar regarding surface handling. Those crashes can appear at boot, screen rotation, app suspension and savestate loading.

- Fixed surface handling issues, mostly caused by race conditions between the UI thread and the emulation thread and by duplicate surface changed notifications. All of the edge cases have been documented in the code itself to help avoid the same situation in the future. Please check the changed files for more information.
- Fixes issues related to `NDKMotion` handling, again caused by races between the UI thread and the emulation thread.  Please check the changed files for more information, as everything has been documented there.