### PR TITLE
Support LG G8X dual screen

### DIFF
--- a/src/android/app/src/main/AndroidManifest.xml
+++ b/src/android/app/src/main/AndroidManifest.xml
@@ -86,6 +86,17 @@
             android:exported="false"
             android:theme="@style/Theme.Citra.Main"
             android:label="@string/cheats"/>
+
+        <!-- Hosts the secondary 3DS screen on displays that cannot use Presentation
+             (e.g. LG G8X Dual Screen); launched onto the target display at runtime. -->
+        <activity
+            android:name="org.citra.citra_emu.display.SecondaryDisplayActivity"
+            android:exported="false"
+            android:theme="@style/Theme.Citra.Main"
+            android:resizeableActivity="true"
+            android:launchMode="singleInstance"
+            android:excludeFromRecents="true"
+            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|keyboardHidden|uiMode" />
     </application>
 
 </manifest>

--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.kt
@@ -184,6 +184,12 @@ object NativeLibrary {
     external fun secondarySurfaceDestroyed()
 
     /**
+     * Tells the native layer whether a secondary display host is expected to provide a surface,
+     * so game start waits briefly for a late-arriving second screen instead of starting without it.
+     */
+    external fun setSecondaryHostExpected(expected: Boolean)
+
+    /**
      * Unpauses emulation from a paused state.
      */
     external fun unPauseEmulation()

--- a/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.kt
@@ -6,6 +6,7 @@ package org.citra.citra_emu.activities
 
 import android.Manifest.permission
 import android.annotation.SuppressLint
+import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.ActivityInfo
@@ -37,6 +38,7 @@ import org.citra.citra_emu.databinding.ActivityEmulationBinding
 import org.citra.citra_emu.dialogs.NetPlayDialog
 import org.citra.citra_emu.display.ScreenAdjustmentUtil
 import org.citra.citra_emu.display.SecondaryDisplay
+import org.citra.citra_emu.display.SecondaryDisplayActivity
 import org.citra.citra_emu.features.hotkeys.HotkeyUtility
 import org.citra.citra_emu.features.settings.model.BooleanSetting
 import org.citra.citra_emu.features.settings.model.IntSetting
@@ -86,6 +88,7 @@ class EmulationActivity : AppCompatActivity() {
     private var isRotationBlocked: Boolean = true
     private var isEmulationRunning: Boolean = false
     private var isEmulationReady: Boolean = false
+    private var isForeground: Boolean = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         requestWindowFeature(Window.FEATURE_NO_TITLE)
@@ -150,7 +153,9 @@ class EmulationActivity : AppCompatActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
-
+        if (intent.getBooleanExtra("bring_to_front_only", false)) {
+            return
+        }
         NativeLibrary.stopEmulation()
         NativeLibrary.playTimeManagerStop()
 
@@ -186,11 +191,21 @@ class EmulationActivity : AppCompatActivity() {
                 applyOrientationSettings()
             }
         }
+        isForeground = true
+        // Bring the cover host forward, and re-host it if a background round-trip dropped it.
+        SecondaryDisplayActivity.bringToFront(this)
+        secondaryDisplayManager.updateDisplay()
         super.onResume()
     }
 
+    override fun onPause() {
+        isForeground = false
+        SecondaryDisplayActivity.sendToBack()
+        super.onPause()
+    }
+
     override fun onStop() {
-        secondaryDisplayManager.releasePresentation()
+        secondaryDisplayManager.releaseSecondaryOutput()
         super.onStop()
     }
 
@@ -224,7 +239,7 @@ class EmulationActivity : AppCompatActivity() {
         NativeLibrary.playTimeManagerStop()
         isEmulationRunning = false
         instance = null
-        secondaryDisplayManager.releasePresentation()
+        secondaryDisplayManager.releaseSecondaryOutput()
         secondaryDisplayManager.releaseVD()
 
         super.onDestroy()
@@ -616,5 +631,9 @@ class EmulationActivity : AppCompatActivity() {
         private var instance: EmulationActivity? = null
 
         fun isRunning(): Boolean = instance?.isEmulationRunning ?: false
+
+        fun runningInstance(): EmulationActivity? = instance
+
+        fun isForeground(): Boolean = instance?.isForeground == true
     }
 }

--- a/src/android/app/src/main/java/org/citra/citra_emu/display/SecondaryDisplay.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/display/SecondaryDisplay.kt
@@ -12,16 +12,20 @@ import android.os.Build
 import android.os.Bundle
 import android.view.Display
 import android.view.MotionEvent
+import android.view.Surface
 import android.view.SurfaceHolder
 import android.view.SurfaceView
 import android.view.WindowManager
 import org.citra.citra_emu.NativeLibrary
+import org.citra.citra_emu.activities.EmulationActivity
 import org.citra.citra_emu.features.settings.model.BooleanSetting
 import org.citra.citra_emu.features.settings.model.IntSetting
 import org.citra.citra_emu.utils.Log
 
-class SecondaryDisplay(val context: Context) : DisplayManager.DisplayListener {
+class SecondaryDisplay(val context: Context) : DisplayManager.DisplayListener,
+    SecondaryDisplayCallback {
     private var pres: SecondaryDisplayPresentation? = null
+    private var usingActivityFallback = false
     private val displayManager = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
     private val vd: VirtualDisplay
     var preferredDisplayId = -1
@@ -55,8 +59,20 @@ class SecondaryDisplay(val context: Context) : DisplayManager.DisplayListener {
         NativeLibrary.secondarySurfaceDestroyed()
     }
 
+    // Invoked by SecondaryDisplayActivity when the secondary output is hosted by an Activity.
+    override fun onSurfaceChanged(surface: Surface) {
+        if (surface.isValid) {
+            NativeLibrary.secondarySurfaceChanged(surface)
+        } else {
+            Log.warning("SecondaryDisplay Attempted to update null or invalid surface")
+        }
+    }
+
+    override fun onSurfaceDestroyed() {
+        NativeLibrary.secondarySurfaceDestroyed()
+    }
+
     private fun getSecondaryDisplays(): List<Display> {
-        val dm = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
         val currentDisplayId = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             context.display.displayId
         } else {
@@ -64,19 +80,26 @@ class SecondaryDisplay(val context: Context) : DisplayManager.DisplayListener {
             (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager)
                 .defaultDisplay.displayId
         }
-        val displays = dm.displays
-        val presDisplays = dm.getDisplays(DisplayManager.DISPLAY_CATEGORY_PRESENTATION)
-        return displays.filter {
-            val isPresentable = presDisplays.any { pd -> pd.displayId == it.displayId }
-            val isNotDefaultOrPresentable =
-                (it != null && it.displayId != Display.DEFAULT_DISPLAY) || isPresentable
-
-            isNotDefaultOrPresentable &&
+        val result = displayManager.displays.filter {
+            // Do not require DISPLAY_CATEGORY_PRESENTATION: some panels (e.g. LG G8X) are not
+            // presentation-capable. updateDisplay() picks Presentation vs Activity per display.
+            val kept =
                 it.displayId != currentDisplayId &&
                 it.name != "HiddenDisplay" &&
                 it.state != Display.STATE_OFF &&
                 it.isValid
+            if (!kept) {
+                // Debug-level: this list can change on every display event, so per-display
+                // noise does not belong in the regular log.
+                Log.debug(
+                    "SecondaryDisplay getSecondaryDisplays: excluded ${it.displayId}:${it.name} " +
+                        "current=$currentDisplayId state=${it.state} valid=${it.isValid}"
+                )
+            }
+            kept
         }
+        Log.debug("SecondaryDisplay getSecondaryDisplays: available=[${result.joinToString { "${it.displayId}:${it.name}" }}]")
+        return result
     }
 
     fun updateDisplay() {
@@ -85,57 +108,112 @@ class SecondaryDisplay(val context: Context) : DisplayManager.DisplayListener {
             return
         }
 
-        val displayToUse = if (availableDisplays.isEmpty() ||
+        // Snapshot once: avoid re-querying DisplayManager multiple times below, which
+        // previously allowed a transient empty result (e.g. mid display-state change) to
+        // throw an uncaught IndexOutOfBoundsException on availableDisplays[0].
+        val displays = availableDisplays
+        Log.info(
+            "SecondaryDisplay updateDisplay: available=[${displays.joinToString { "${it.displayId}:${it.name}" }}] " +
+                "layout=${IntSetting.SECONDARY_DISPLAY_LAYOUT.int} enabled=${BooleanSetting.ENABLE_SECONDARY_DISPLAY.boolean} " +
+                "preferred=$preferredDisplayId"
+        )
+
+        val displayToUse: Display? = if (displays.isEmpty() ||
             // Theoretically, the NONE option is no longer selectable, but
             // I am leaving this in for backwards compatibility
             IntSetting.SECONDARY_DISPLAY_LAYOUT.int == SecondaryDisplayLayout.NONE.int ||
             !BooleanSetting.ENABLE_SECONDARY_DISPLAY.boolean
         ) {
+            Log.info("SecondaryDisplay updateDisplay: falling back to HiddenDisplay (vd.display id=${vd.display?.displayId})")
             currentDisplayId = -1
             vd.display
         } else if (preferredDisplayId >= 0 &&
-            availableDisplays.any { it.displayId == preferredDisplayId }
+            displays.any { it.displayId == preferredDisplayId }
         ) {
             currentDisplayId = preferredDisplayId
-            availableDisplays.first { it.displayId == preferredDisplayId }
+            displays.first { it.displayId == preferredDisplayId }
         } else {
             val dm = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
             val default = dm.displays.first { it.displayId == Display.DEFAULT_DISPLAY }
             // prioritize displays that have a different name from the default display, as
             // some devices such as the Odin 2 create a permanent virtual display with the same
             // name as the default display that should be skipped in most cases
-            currentDisplayId = availableDisplays.firstOrNull {
+            currentDisplayId = displays.firstOrNull {
                 it.name != default.name && !it.name.contains("Built", true)
             }?.displayId
-                ?: availableDisplays[0].displayId
-            availableDisplays.first { it.displayId == currentDisplayId }
+                ?: displays.firstOrNull()?.displayId
+                ?: -1
+            if (currentDisplayId == -1) null else displays.first { it.displayId == currentDisplayId }
         }
 
-        // if our presentation is already on the right display, ignore
-        if (pres?.display == displayToUse) return
-
-        // otherwise, make a new presentation
-        releasePresentation()
-
-        try {
-            pres = SecondaryDisplayPresentation(context, displayToUse!!, this)
-            pres?.show()
+        if (displayToUse == null) {
+            Log.info("SecondaryDisplay updateDisplay: no display selected, releasing secondary output")
+            releaseSecondaryOutput()
+            return
         }
-        // catch BadTokenException and InvalidDisplayException,
-        // the display became invalid asynchronously, so we can assign to null
-        // until onDisplayAdded/Removed/Changed is called and logic retriggered
-        catch (_: WindowManager.BadTokenException) {
-            pres = null
-        } catch (_: WindowManager.InvalidDisplayException) {
-            pres = null
+
+        val isPresentationCapable = displayManager
+            .getDisplays(DisplayManager.DISPLAY_CATEGORY_PRESENTATION)
+            .any { it.displayId == displayToUse.displayId }
+
+        // if our current output is already on the right display via the right
+        // mechanism, ignore
+        if (isPresentationCapable && pres?.display == displayToUse) {
+            Log.info("SecondaryDisplay updateDisplay: presentation already on display ${displayToUse.displayId}")
+            return
+        }
+        if (!isPresentationCapable && SecondaryDisplayActivity.isHosting(displayToUse.displayId)) {
+            Log.info("SecondaryDisplay updateDisplay: activity already hosting display ${displayToUse.displayId}")
+            return
+        }
+
+        Log.info(
+            "SecondaryDisplay updateDisplay: switching secondary output to display " +
+                "${displayToUse.displayId} (${displayToUse.name}) " +
+                "via ${if (isPresentationCapable) "Presentation" else "SecondaryDisplayActivity (fallback)"}"
+        )
+        // otherwise, create a new presentation (or activity fallback)
+        releaseSecondaryOutput()
+
+        // A real (visible) host will provide a surface, so let the emulator wait for it; the
+        // hidden virtual display is not a real host and must not delay game start.
+        val hostExpected = displayToUse.displayId != vd.display?.displayId
+        NativeLibrary.setSecondaryHostExpected(hostExpected)
+        Log.info("SecondaryDisplay updateDisplay: native host expected=$hostExpected")
+
+        if (isPresentationCapable) {
+            try {
+                pres = SecondaryDisplayPresentation(context, displayToUse, this)
+                pres?.show()
+                Log.info("SecondaryDisplay updateDisplay: presentation shown on display ${displayToUse.displayId}")
+            }
+            // catch BadTokenException and InvalidDisplayException,
+            // the display became invalid asynchronously, so we can assign to null
+            // until onDisplayAdded/Removed/Changed is called and logic retriggered
+            catch (_: WindowManager.BadTokenException) {
+                pres = null
+            } catch (_: WindowManager.InvalidDisplayException) {
+                pres = null
+            }
+        } else {
+            usingActivityFallback = true
+            SecondaryDisplayActivity.launch(context, displayToUse.displayId, this)
         }
     }
 
-    fun releasePresentation() {
+    fun releaseSecondaryOutput() {
         try {
             pres?.dismiss()
         } catch (_: Exception) { }
         pres = null
+
+        if (usingActivityFallback) {
+            usingActivityFallback = false
+            SecondaryDisplayActivity.finishActive()
+        }
+
+        // No secondary host going forward: never make the emulator wait for a surface.
+        NativeLibrary.setSecondaryHostExpected(false)
     }
 
     fun releaseVD() {
@@ -144,14 +222,26 @@ class SecondaryDisplay(val context: Context) : DisplayManager.DisplayListener {
     }
 
     override fun onDisplayAdded(displayId: Int) {
-        updateDisplay()
+        onDisplayEvent()
     }
 
     override fun onDisplayRemoved(displayId: Int) {
-        updateDisplay()
+        onDisplayEvent()
     }
+
     override fun onDisplayChanged(displayId: Int) {
-        updateDisplay()
+        onDisplayEvent()
+    }
+
+    // Display events fire while the app is backgrounded too (e.g. the cover screen's own launcher
+    // takes over during Recents); reconciling then would relaunch the host onto the cover only for
+    // the system to tear it down again, thrashing lifecycle state. Reconcile from display events
+    // only while the emulation activity is in the foreground -- its onResume re-hosts on the way
+    // back.
+    private fun onDisplayEvent() {
+        if (EmulationActivity.isForeground()) {
+            updateDisplay()
+        }
     }
 }
 class SecondaryDisplayPresentation(
@@ -175,7 +265,7 @@ class SecondaryDisplayPresentation(
         surfaceView = SurfaceView(context)
         surfaceView.holder.addCallback(object : SurfaceHolder.Callback {
             override fun surfaceCreated(holder: SurfaceHolder) {
-                Log.debug("SecondaryDisplay Surface created")
+                Log.debug("SecondaryDisplay Surface created on display ${display.displayId}")
             }
 
             override fun surfaceChanged(
@@ -184,7 +274,7 @@ class SecondaryDisplayPresentation(
                 width: Int,
                 height: Int
             ) {
-                Log.debug("SecondaryDisplay Surface changed: ${width}x$height")
+                Log.debug("SecondaryDisplay Surface changed: ${width}x$height on display ${display.displayId}")
                 parent.updateSurface()
             }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/display/SecondaryDisplayActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/display/SecondaryDisplayActivity.kt
@@ -1,0 +1,204 @@
+// Copyright 2025-2026 Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+package org.citra.citra_emu.display
+
+import android.app.ActivityOptions
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.InputDevice
+import android.view.KeyEvent
+import android.view.MotionEvent
+import android.view.Surface
+import android.view.SurfaceHolder
+import android.view.SurfaceView
+import android.view.WindowManager
+import androidx.activity.OnBackPressedCallback
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+import org.citra.citra_emu.activities.EmulationActivity
+import org.citra.citra_emu.utils.Log
+
+/** Reports secondary surface events back to SecondaryDisplay regardless of the host used. */
+interface SecondaryDisplayCallback {
+    fun onSurfaceChanged(surface: Surface)
+    fun onSurfaceDestroyed()
+}
+
+/**
+ * Hosts the secondary 3DS screen on displays that do not support Presentation (e.g. the LG G8X
+ * Dual Screen). A real Activity is launched onto the target display via
+ * ActivityOptions.setLaunchDisplayId(), which needs android:resizeableActivity="true".
+ * SecondaryDisplay owns the lifecycle and calls finishActive() before each new launch.
+ */
+class SecondaryDisplayActivity : AppCompatActivity() {
+    companion object {
+        private const val EXTRA_DISPLAY_ID = "display_id"
+
+        private var activeInstance: SecondaryDisplayActivity? = null
+        private var callback: SecondaryDisplayCallback? = null
+
+        var currentDisplayId: Int = -1
+            private set
+
+        // Set between launch() and the host's onCreate so a display event racing the launch treats
+        // it as already hosting instead of relaunching a duplicate.
+        @Volatile
+        private var launchPending: Boolean = false
+
+        /**
+         * True while a live host activity owns [displayId] (or one is being launched onto it). It
+         * survives a surface cycle such as rotation (the activity is kept via configChanges) and
+         * turns false only once the host is finishing or gone, so the manager can tell a working
+         * host from one the system tore down on another display (e.g. after a Recents round-trip).
+         */
+        fun isHosting(displayId: Int): Boolean {
+            if (currentDisplayId != displayId) return false
+            if (launchPending) return true
+            val instance = activeInstance ?: return false
+            return !instance.isFinishing
+        }
+
+        fun launch(context: Context, displayId: Int, cb: SecondaryDisplayCallback) {
+            // Set before starting so overlapping updateDisplay() calls dedupe on currentDisplayId
+            // instead of launching duplicate activities.
+            currentDisplayId = displayId
+            callback = cb
+            launchPending = true
+            val options = ActivityOptions.makeBasic().apply { launchDisplayId = displayId }
+            val intent = Intent(context, SecondaryDisplayActivity::class.java).apply {
+                putExtra(EXTRA_DISPLAY_ID, displayId)
+                addFlags(
+                    Intent.FLAG_ACTIVITY_NEW_TASK or
+                        Intent.FLAG_ACTIVITY_MULTIPLE_TASK or
+                        Intent.FLAG_ACTIVITY_NO_ANIMATION
+                )
+            }
+            try {
+                context.startActivity(intent, options.toBundle())
+                Log.info("SecondaryDisplayActivity launched on display $displayId")
+            } catch (e: SecurityException) {
+                // Some OEMs restrict which UID may launch onto a given display.
+                Log.error("SecondaryDisplayActivity failed to launch on display $displayId: ${e.message}")
+                callback = null
+                currentDisplayId = -1
+                launchPending = false
+            }
+        }
+
+        fun finishActive() {
+            activeInstance?.finish()
+            activeInstance = null
+            callback = null
+            currentDisplayId = -1
+            launchPending = false
+        }
+
+        fun sendToBack() {
+            activeInstance?.moveTaskToBack(true)
+        }
+
+        fun bringToFront(context: Context) {
+            val instance = activeInstance ?: return
+            val displayId = currentDisplayId
+            if (displayId < 0 || instance.isForeground) return
+            val intent = Intent(context, SecondaryDisplayActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_NO_ANIMATION)
+            }
+            val options = ActivityOptions.makeBasic().apply { launchDisplayId = displayId }
+            context.startActivity(intent, options.toBundle())
+        }
+    }
+
+    private lateinit var surfaceView: SurfaceView
+    private var isForeground = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        activeInstance?.finish()
+        activeInstance = this
+        launchPending = false
+        currentDisplayId = intent.getIntExtra(EXTRA_DISPLAY_ID, -1)
+        Log.info("SecondaryDisplayActivity created for display $currentDisplayId")
+
+        // This window may hold input focus on multi-display devices (its display can become the
+        // focused one after a background/foreground switch). Keep it focusable and forward any
+        // key/gamepad events it receives to EmulationActivity in dispatchKeyEvent()/
+        // dispatchGenericMotionEvent() so the game keeps working without a tap on the main screen.
+        window.setFlags(
+            WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL,
+            WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL
+        )
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        WindowInsetsControllerCompat(window, window.decorView).let { controller ->
+            controller.hide(WindowInsetsCompat.Type.systemBars())
+            controller.systemBarsBehavior =
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        }
+
+        surfaceView = SurfaceView(this)
+        surfaceView.holder.addCallback(object : SurfaceHolder.Callback {
+            override fun surfaceCreated(holder: SurfaceHolder) {}
+
+            override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
+                val surface = holder.surface
+                if (surface != null && surface.isValid) {
+                    callback?.onSurfaceChanged(surface)
+                }
+            }
+
+            override fun surfaceDestroyed(holder: SurfaceHolder) {
+                callback?.onSurfaceDestroyed()
+            }
+        })
+
+        // Top screen is not a touchscreen; consume without action.
+        surfaceView.setOnTouchListener { _, _ -> true }
+
+        // Only EmulationActivity's teardown finishes this activity; ignore back here.
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() = Unit
+        })
+
+        setContentView(surfaceView)
+    }
+
+    override fun onPause() {
+        isForeground = false
+        super.onPause()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        isForeground = true
+    }
+
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean =
+        EmulationActivity.runningInstance()?.dispatchKeyEvent(event)
+            ?: super.dispatchKeyEvent(event)
+
+    // Forward joystick axes only; pointer/mouse events are not forwarded.
+    override fun dispatchGenericMotionEvent(event: MotionEvent): Boolean {
+        if (event.source and InputDevice.SOURCE_CLASS_JOYSTICK == 0) {
+            return super.dispatchGenericMotionEvent(event)
+        }
+        return EmulationActivity.runningInstance()?.dispatchGenericMotionEvent(event)
+            ?: super.dispatchGenericMotionEvent(event)
+    }
+
+    override fun onDestroy() {
+        Log.info("SecondaryDisplayActivity destroyed (display $currentDisplayId)")
+        if (activeInstance == this) {
+            activeInstance = null
+            callback = null
+            currentDisplayId = -1
+            launchPending = false
+        }
+        super.onDestroy()
+    }
+}

--- a/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.kt
@@ -43,6 +43,7 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeSource
 import kotlinx.coroutines.launch
 import org.citra.citra_emu.BuildConfig
+import org.citra.citra_emu.activities.EmulationActivity
 import org.citra.citra_emu.NativeLibrary
 import org.citra.citra_emu.R
 import org.citra.citra_emu.contracts.OpenFileResultContract
@@ -62,6 +63,7 @@ import org.citra.citra_emu.utils.CitraDirectoryUtils
 import org.citra.citra_emu.utils.DirectoryInitialization
 import org.citra.citra_emu.utils.FileBrowserHelper
 import org.citra.citra_emu.utils.InsetsHelper
+import org.citra.citra_emu.utils.Log
 import org.citra.citra_emu.utils.PermissionsHandler
 import org.citra.citra_emu.utils.RefreshRateUtil
 import org.citra.citra_emu.utils.ThemeUtil
@@ -84,6 +86,18 @@ class MainActivity :
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // When a game is already running, reveal it instead of building a new game list on top.
+        // super.onCreate() must run before finish(); the normal path below calls it late (after
+        // the splash screen), so it cannot be hoisted to the top.
+        if (savedInstanceState == null && tryResumeRunningGame()) {
+            super.onCreate(savedInstanceState)
+            // EmulationActivity sits below this activity in the same task, so finishing reveals
+            // and resumes it via onRestart/onResume. Starting it instead would trigger its
+            // onNewIntent handler, which stops the running emulation.
+            finish()
+            return
+        }
+
         RefreshRateUtil.enforceRefreshRate(this)
 
         val splashScreen = installSplashScreen()
@@ -211,6 +225,20 @@ class MainActivity :
 
         ThemeUtil.setCorrectTheme(this)
         super.onResume()
+    }
+
+    /** True when a game is running and this launch should finish to reveal it. */
+    private fun tryResumeRunningGame(): Boolean {
+        if (!EmulationActivity.isRunning()) {
+            return false
+        }
+        // Only react to a real relaunch (launcher icon or an external view intent).
+        val action = intent?.action
+        if (action != Intent.ACTION_MAIN && action != Intent.ACTION_VIEW) {
+            return false
+        }
+        Log.info("Revealing the running game instead of showing the game list")
+        return true
     }
 
     override fun onDestroy() {

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -113,11 +113,15 @@ std::condition_variable running_cv;
 // due to the locking pattern used in RunCitra().
 std::recursive_mutex surface_mutex;
 
-// Signalled by surfaceChanged() whenever s_surface goes from null to non-null. Used by the
-// System::Init() callback to block the renderer (re)creation (initial boot or a
-// savestate load) until a surface actually exists, instead of giving
-// VideoCore a null ANativeWindow.
+// Signalled by surfaceChanged() whenever s_surface goes from null to non-null, and by the
+// secondary surface callbacks when s_secondary_surface changes. Used by the System::Init()
+// callback to block the renderer (re)creation (initial boot or a savestate load) until a
+// surface actually exists, instead of giving VideoCore a null ANativeWindow.
 std::condition_variable_any surface_cv;
+
+// True while a secondary display host is expected to provide a surface, so game start waits
+// briefly for a late-arriving second screen (e.g. the LG G8X cover activity) before starting.
+std::atomic<bool> s_secondary_host_expected{false};
 
 std::string inserted_cartridge;
 
@@ -249,20 +253,37 @@ static Core::System::ResultStatus RunCitra(const std::string& filepath) {
 
     const auto graphics_api = Settings::GetWorkingGraphicsAPI();
     EGLContext* shared_context;
+
+    // Wait briefly for the secondary surface when a host is expected but its asynchronous
+    // surface has not arrived yet, so an activity-hosted second screen is not missed.
+    if (!s_secondary_surface && s_secondary_host_expected.load()) {
+        LOG_INFO(Frontend, "Waiting for secondary surface before starting...");
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(8);
+        surface_cv.wait_until(surface_lock, deadline, [] {
+            return s_secondary_surface != nullptr || !s_secondary_host_expected.load();
+        });
+    }
+    ANativeWindow* const secondary_surface_ptr = s_secondary_surface;
+    const bool has_secondary_surface = secondary_surface_ptr != nullptr;
     switch (graphics_api) {
 #ifdef ENABLE_OPENGL
     case Settings::GraphicsAPI::OpenGL:
         window = std::make_unique<EmuWindow_Android_OpenGL>(system, s_surface, false);
         shared_context = window->GetEGLContext();
-        secondary_window = std::make_unique<EmuWindow_Android_OpenGL>(system, s_secondary_surface,
-                                                                      true, shared_context);
+        if (has_secondary_surface) {
+            secondary_window = std::make_unique<EmuWindow_Android_OpenGL>(system,
+                                                                          secondary_surface_ptr, true,
+                                                                          shared_context);
+        }
         break;
 #endif
 #ifdef ENABLE_VULKAN
     case Settings::GraphicsAPI::Vulkan:
         window = std::make_unique<EmuWindow_Android_Vulkan>(s_surface, vulkan_library, false);
-        secondary_window =
-            std::make_unique<EmuWindow_Android_Vulkan>(s_secondary_surface, vulkan_library, true);
+        if (has_secondary_surface) {
+            secondary_window =
+                std::make_unique<EmuWindow_Android_Vulkan>(secondary_surface_ptr, vulkan_library, true);
+        }
         break;
 #endif
     default:
@@ -272,13 +293,18 @@ static Core::System::ResultStatus RunCitra(const std::string& filepath) {
 #ifdef ENABLE_OPENGL
         window = std::make_unique<EmuWindow_Android_OpenGL>(system, s_surface, false);
         shared_context = window->GetEGLContext();
-        secondary_window = std::make_unique<EmuWindow_Android_OpenGL>(system, s_secondary_surface,
-                                                                      true, shared_context);
+        if (has_secondary_surface) {
+            secondary_window = std::make_unique<EmuWindow_Android_OpenGL>(system,
+                                                                          secondary_surface_ptr, true,
+                                                                          shared_context);
+        }
 
 #elif ENABLE_VULKAN
         window = std::make_unique<EmuWindow_Android_Vulkan>(s_surface, vulkan_library, false);
-        secondary_window =
-            std::make_unique<EmuWindow_Android_Vulkan>(s_secondary_surface, vulkan_library, true);
+        if (has_secondary_surface) {
+            secondary_window =
+                std::make_unique<EmuWindow_Android_Vulkan>(secondary_surface_ptr, vulkan_library, true);
+        }
 #else
         // TODO: Add a null renderer backend for this, perhaps.
 #error "At least one renderer must be enabled."
@@ -451,53 +477,54 @@ void Java_org_citra_citra_1emu_NativeLibrary_surfaceChanged(JNIEnv* env,
     LOG_INFO(Frontend, "Surface changed");
 }
 
+void Java_org_citra_citra_1emu_NativeLibrary_setSecondaryHostExpected(JNIEnv* env,
+                                                                      [[maybe_unused]] jobject obj,
+                                                                      jboolean expected) {
+    {
+        std::scoped_lock lock(surface_mutex);
+        s_secondary_host_expected.store(expected != 0);
+    }
+    surface_cv.notify_all();
+    LOG_INFO(Frontend, "Secondary host expected: {}", expected != 0);
+}
+
 void Java_org_citra_citra_1emu_NativeLibrary_secondarySurfaceChanged(JNIEnv* env,
                                                                      [[maybe_unused]] jobject obj,
                                                                      jobject surf) {
     std::scoped_lock lock(surface_mutex);
 
-    auto& system = Core::System::GetInstance();
-
     if (s_secondary_surface) {
         ANativeWindow_release(s_secondary_surface);
         s_secondary_surface = nullptr;
     }
-    s_secondary_surface = ANativeWindow_fromSurface(env, surf);
-    if (!s_secondary_surface) {
+    if (surf) {
+        s_secondary_surface = ANativeWindow_fromSurface(env, surf);
+    }
+    surface_cv.notify_all();
+
+    if (!s_secondary_surface || !secondary_window) {
+        // With no window yet, RunCitra's wait gate or the next game launch picks up the surface.
         return;
     }
 
-    bool notify = false;
-    if (secondary_window) {
-        // Second window already created, so update it
-        notify = secondary_window->OnSurfaceChanged(s_secondary_surface);
-
-        // Log the dimensions for debugging
-        int32_t width = ANativeWindow_getWidth(s_secondary_surface);
-        int32_t height = ANativeWindow_getHeight(s_secondary_surface);
-        LOG_INFO(Frontend, "Secondary Surface changed to {}x{}", width, height);
-    } else {
-        LOG_WARNING(Frontend,
-                    "Second Window does not exist in native.cpp but surface changed. Ignoring.");
+    if (secondary_window->OnSurfaceChanged(s_secondary_surface)) {
+        auto& system = Core::System::GetInstance();
+        if (system.IsPoweredOn()) {
+            system.GPU().Renderer().NotifySurfaceChanged(true);
+        }
     }
-
-    if (notify && system.IsPoweredOn()) {
-        system.GPU().Renderer().NotifySurfaceChanged(true);
-    }
-
-    LOG_INFO(Frontend, "Secondary Surface changed");
+    LOG_INFO(Frontend, "Secondary surface changed");
 }
 
 void Java_org_citra_citra_1emu_NativeLibrary_secondarySurfaceDestroyed(
     JNIEnv* env, [[maybe_unused]] jobject obj) {
     std::scoped_lock lock(surface_mutex);
-
     if (s_secondary_surface != nullptr) {
         ANativeWindow_release(s_secondary_surface);
         s_secondary_surface = nullptr;
     }
-
-    LOG_INFO(Frontend, "Secondary Surface Destroyed");
+    surface_cv.notify_all();
+    LOG_INFO(Frontend, "Secondary surface destroyed");
 }
 
 void Java_org_citra_citra_1emu_NativeLibrary_surfaceDestroyed([[maybe_unused]] JNIEnv* env,

--- a/src/video_core/renderer_vulkan/vk_platform.cpp
+++ b/src/video_core/renderer_vulkan/vk_platform.cpp
@@ -184,6 +184,10 @@ vk::SurfaceKHR CreateSurface(vk::Instance instance, const Frontend::EmuWindow& e
     }
 #elif defined(VK_USE_PLATFORM_ANDROID_KHR)
     if (window_info.type == Frontend::WindowSystemType::Android) {
+        if (!window_info.render_surface) {
+            LOG_CRITICAL(Render_Vulkan, "Android surface requested without a native window");
+            UNREACHABLE();
+        }
         vk::AndroidSurfaceCreateInfoKHR android_ci = {
             .window = reinterpret_cast<ANativeWindow*>(window_info.render_surface),
         };

--- a/src/video_core/renderer_vulkan/vk_present_window.cpp
+++ b/src/video_core/renderer_vulkan/vk_present_window.cpp
@@ -158,9 +158,9 @@ PresentWindow::~PresentWindow() {
     // If the window is destroyed before the next_surface is
     // consumed, make sure to destroy it here to prevent a
     // resource leak.
-    if (next_surface && next_surface != surface) {
-        instance.GetInstance().destroySurfaceKHR(next_surface);
-        next_surface = vk::SurfaceKHR{};
+    if (next_surface.load() && next_surface.load() != surface) {
+        instance.GetInstance().destroySurfaceKHR(next_surface.load());
+        next_surface.store(vk::SurfaceKHR{});
     }
     device.destroyCommandPool(command_pool);
     device.destroyRenderPass(present_renderpass);
@@ -347,41 +347,53 @@ void PresentWindow::PresentThread(std::stop_token token) {
 void PresentWindow::NotifySurfaceChanged() {
 #ifdef ANDROID
     std::scoped_lock lock{recreate_surface_mutex};
+    const void* current_surface = emu_window.GetWindowInfo().render_surface;
+    if (current_surface != last_render_surface) {
+        // Window replaced: build the new VkSurface but keep the old one until the present
+        // thread has recreated its swapchain (a native window binds to one VkSurface at a time).
+        // If an earlier notification produced a surface that CopyToSwapchain() has not consumed yet,
+        // release it rather than just overwritting its handle and causing a leak.
+        if (next_surface.load() && next_surface.load() != surface) {
+            instance.GetInstance().destroySurfaceKHR(next_surface.load());
+            next_surface.store(vk::SurfaceKHR{});
+        }
 
-    // surfaceChanged() may notify us that a surface has changed
-    // for the same surface multiple times. If that is the case
-    // skip creating the surface again as that would cause a
-    // vulkan ErrorNativeWindowInUseKHR.
-    void* const render_surface = emu_window.GetWindowInfo().render_surface;
-    if (render_surface == last_render_surface) {
-        return;
+        last_render_surface = current_surface;
+        next_surface.store(CreateSurface(instance.GetInstance(), emu_window));
+    } else {
+        // Same window resized in place (e.g. rotation): the VkSurface stays valid, only the
+        // swapchain needs recreating at the new extent.
+        recreate_requested = true;
     }
-    last_render_surface = render_surface;
-
-    // If an earlier notification produced a surface that CopyToSwapchain() has not consumed yet,
-    // release it rather than just overwritting its handle and causing a leak.
-    if (next_surface && next_surface != surface) {
-        instance.GetInstance().destroySurfaceKHR(next_surface);
-        next_surface = vk::SurfaceKHR{};
-    }
-
-    next_surface = CreateSurface(instance.GetInstance(), emu_window);
     recreate_surface_cv.notify_one();
 #endif
 }
 
 void PresentWindow::CopyToSwapchain(Frame* frame) {
     const auto recreate_swapchain = [&] {
+        vk::SurfaceKHR old_surface{};
 #ifdef ANDROID
         {
             std::unique_lock lock{recreate_surface_mutex};
-            recreate_surface_cv.wait(lock, [this]() { return surface != next_surface; });
-            surface = next_surface;
+            recreate_surface_cv.wait(lock, [this]() {
+                return surface != next_surface.load() || recreate_requested.load();
+            });
+            if (next_surface.load() != surface) {
+                old_surface = surface;
+                surface = next_surface.load();
+            }
+            recreate_requested.store(false);
         }
 #endif
         std::scoped_lock submit_lock{scheduler.submit_mutex};
         graphics_queue.waitIdle();
         swapchain.Create(frame->width, frame->height, surface, low_refresh_rate);
+#ifdef ANDROID
+        // The old swapchain is gone, so the replaced VkSurface can now be destroyed.
+        if (old_surface != VK_NULL_HANDLE && old_surface != surface) {
+            instance.GetInstance().destroySurfaceKHR(old_surface);
+        }
+#endif
     };
 
 #ifndef ANDROID
@@ -391,6 +403,14 @@ void PresentWindow::CopyToSwapchain(Frame* frame) {
     const bool vsync_changed = vsync_enabled != use_vsync;
     if (vsync_changed || size_changed) [[unlikely]] {
         vsync_enabled = use_vsync;
+        recreate_swapchain();
+    }
+#endif
+
+#ifdef ANDROID
+    // Recreate on a window change or in-place resize; the lock-free atomic check
+    // keeps the steady-state frame free of any mutex.
+    if (recreate_requested.load() || surface != next_surface.load()) [[unlikely]] {
         recreate_swapchain();
     }
 #endif

--- a/src/video_core/renderer_vulkan/vk_present_window.h
+++ b/src/video_core/renderer_vulkan/vk_present_window.h
@@ -80,7 +80,10 @@ private:
     Scheduler& scheduler;
     bool low_refresh_rate;
     vk::SurfaceKHR surface;
-    vk::SurfaceKHR next_surface{};
+    // Written by the UI thread on a window change, read lock-free by the present thread's
+    // per-frame fast path in CopyToSwapchain. Surface data is still accessed under
+    // recreate_surface_mutex.
+    std::atomic<vk::SurfaceKHR> next_surface{};
     Swapchain swapchain;
     vk::CommandPool command_pool;
     vk::Queue graphics_queue;
@@ -99,7 +102,10 @@ private:
     bool vsync_enabled{};
     bool blit_supported;
     bool use_present_thread{true};
-    void* last_render_surface{};
+    const void* last_render_surface{};
+    // Set when the current window was resized in place (e.g. rotation) so the present thread
+    // recreates the swapchain even though the VkSurface is unchanged. Read lock-free per frame.
+    std::atomic<bool> recreate_requested{false};
 };
 
 } // namespace Vulkan


### PR DESCRIPTION
Enable second screen on devices without Presentation display. We are using a dedicated activity instead to access screen surface. Tested with Vulkan and OpenGL and screen rotation use cases. Close azahar-emu/azahar#2420.

> Limited regression test was performed to date. If the developer community is interested in merging this functionality I can do more regression tests.

AI was used to do some analysis, architecture review, coding and test automation.

- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

