### PR TITLE
macos: Fix local network connections not working correctly (Artic Base, system file setup, etc)

### DIFF
--- a/dist/apple/Info.plist.in
+++ b/dist/apple/Info.plist.in
@@ -62,6 +62,8 @@
     <string>This app requires camera access to emulate the 3DS&apos;s cameras.</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>This app requires microphone access to emulate the 3DS&apos;s microphone.</string>
+    <key>NSLocalNetworkUsageDescription</key>
+    <string>This app requires access to the local network to connect to Artic Base servers and perform system file setup using a real 3DS.</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundlePackageType</key>


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

This issue was caused by a missing Info.plist entry relating to local network access which was seemingly optional before but has now been quietly made mandatory in macOS 27.