### PR TITLE
Bump bundled Qt to 6.10.3 + Enable Liquid Glass interface on macOS 26

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,7 +378,7 @@ find_package(Threads REQUIRED)
 
 if (ENABLE_QT)
     if (NOT USE_SYSTEM_QT)
-        download_qt(6.9.3)
+        download_qt(6.10.3)
     endif()
 
     find_package(Qt6 REQUIRED COMPONENTS Widgets Multimedia Concurrent)

--- a/dist/apple/Info.plist.in
+++ b/dist/apple/Info.plist.in
@@ -76,9 +76,6 @@
     <true/>
     <key>NSHighResolutionCapable</key>
     <string>True</string>
-    <key>UIDesignRequiresCompatibility</key>
-    <true/> <!-- Remove when Qt Liquid Glass issues are fixed upstream:
-                 https://bugreports.qt.io/browse/QTBUG-138942 -->
     <key>UIFileSharingEnabled</key>
     <true/>
     <key>UILaunchStoryboardName</key>


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------
