### PR TITLE
qt: Fix various Qt string property issues

### DIFF
--- a/src/citra_qt/aboutdialog.ui
+++ b/src/citra_qt/aboutdialog.ui
@@ -27,7 +27,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/default/256x256/azahar.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/default/256x256/azahar.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </widget>
        </item>
@@ -57,7 +57,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Azahar&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Azahar&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </widget>
        </item>
@@ -70,7 +70,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3 (%4)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3 (%4)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </widget>
        </item>
@@ -83,7 +83,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+          <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
@@ -131,7 +131,7 @@ p, li { white-space: pre-wrap; }
           </sizepolicy>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; is a trademark of Nintendo. Azahar is not affiliated with Nintendo in any way.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; is a trademark of Nintendo. Azahar is not affiliated with Nintendo in any way.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </widget>
        </item>

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -1257,9 +1257,9 @@ void GMainWindow::UpdateMenuState() {
     ui->action_Advance_Frame->setEnabled(emulation_running && is_paused);
 
     if (emulation_running && is_paused) {
-        ui->action_Pause->setText(tr("&Continue"));
+        ui->action_Pause->setText(tr("Continue"));
     } else {
-        ui->action_Pause->setText(tr("&Pause"));
+        ui->action_Pause->setText(tr("Pause"));
     }
 }
 
@@ -1804,7 +1804,7 @@ void GMainWindow::UpdateSaveStates() {
         }
         actions_load_state[savestate.slot]->setEnabled(true);
         if (savestate.slot == 0) {
-            const auto text = tr("%2")
+            const auto text = QStringLiteral("%2")
                                   .arg(QDateTime::fromSecsSinceEpoch(savestate.time)
                                            .toString(QStringLiteral("yyyy-MM-dd hh:mm:ss")))
                                   .trimmed();
@@ -2219,7 +2219,7 @@ void GMainWindow::OnGameListDumpRomFS(QString game_path, u64 program_id) {
                 const auto& [base, update] = future_watcher->result();
                 if (base != Loader::ResultStatus::Success) {
                     QMessageBox::critical(
-                        this, tr("Azahar"),
+                        this, QStringLiteral("Azahar"),
                         tr("Could not dump base RomFS.\nRefer to the log for details."));
                     return;
                 }
@@ -2293,9 +2293,10 @@ void GMainWindow::OnGameListOpenPerGameProperties(const QString& file) {
 void GMainWindow::OnMenuLoadFile() {
     const QString extensions = QStringLiteral("*.").append(
         GameList::supported_file_extensions.join(QStringLiteral(" *.")));
-    const QString file_filter = tr("3DS Executable (%1);;All Files (*.*)",
-                                   "%1 is an identifier for the 3DS executable file extensions.")
-                                    .arg(extensions);
+    const QString file_filter = tr("3DS Executable (%1)"
+                                   "%1 is an identifier for the 3DS executable file extensions.") +
+                                QStringLiteral(";;") + tr("All Files") +
+                                QStringLiteral(" (*.*)").arg(extensions);
     const QString filename = QFileDialog::getOpenFileName(
         this, tr("Load File"), UISettings::values.roms_path, file_filter);
 
@@ -2340,7 +2341,7 @@ void GMainWindow::OnMenuSetUpSystemFiles() {
     QLineEdit textInput(UISettings::values.last_artic_base_addr, &dialog);
     layout_h.addWidget(&textInput);
 
-    QLabel label_select(tr("<br>Choose setup mode:"), &dialog);
+    QLabel label_select(QStringLiteral("<br>") + tr("Choose setup mode:"), &dialog);
     layout.addWidget(&label_select);
 
     std::pair<bool, bool> install_state = Core::AreSystemTitlesInstalled();
@@ -2571,9 +2572,10 @@ void GMainWindow::UninstallTitles(
     future_watcher.waitForFinished();
 
     if (failed) {
-        QMessageBox::critical(this, tr("Azahar"), tr("Failed to uninstall '%1'.").arg(failed_name));
+        QMessageBox::critical(this, QStringLiteral("Azahar"),
+                              tr("Failed to uninstall '%1'.").arg(failed_name));
     } else if (!future_watcher.isCanceled()) {
-        QMessageBox::information(this, tr("Azahar"),
+        QMessageBox::information(this, QStringLiteral("Azahar"),
                                  tr("Successfully uninstalled '%1'.").arg(first_name));
         emit InstalledTitlesChanged();
     }
@@ -3315,9 +3317,9 @@ void GMainWindow::OnCompressFile() {
             QStringLiteral(".") +
             QString::fromStdString(compress_info.value().first.recommended_compressed_extension);
 
-        QString out_filter = tr("3DS Compressed ROM File (*.%1)")
-                                 .arg(QString::fromStdString(
-                                     compress_info.value().first.recommended_compressed_extension));
+        QString out_filter = tr("3DS Compressed ROM File") +
+                             QStringLiteral(" (*.%1)").arg(QString::fromStdString(
+                                 compress_info.value().first.recommended_compressed_extension));
         out_path = QFileDialog::getSaveFileName(this, tr("Save 3DS Compressed ROM File"),
                                                 final_path, out_filter);
         if (out_path.isEmpty()) {
@@ -3384,8 +3386,8 @@ void GMainWindow::OnDecompressFile() {
 
     QStringList filepaths = QFileDialog::getOpenFileNames(
         this, tr("Load 3DS Compressed ROM Files"), UISettings::values.roms_path,
-        tr("3DS Compressed ROM Files (*.zcia *zcci *z3dsx *zcxi)") + QStringLiteral(";;") +
-            tr("All Files (*.*)"));
+        tr("3DS Compressed ROM Files") + QStringLiteral(" (*.zcia *zcci *z3dsx *zcxi)") +
+            QStringLiteral(";;") + tr("All Files") + QStringLiteral(" (*.*)"));
 
     QString out_path;
 
@@ -3408,10 +3410,9 @@ void GMainWindow::OnDecompressFile() {
             QStringLiteral(".") +
             QString::fromStdString(compress_info.value().first.recommended_uncompressed_extension);
 
-        QString out_filter =
-            tr("3DS ROM File (*.%1)")
-                .arg(QString::fromStdString(
-                    compress_info.value().first.recommended_uncompressed_extension));
+        QString out_filter = tr("3DS ROM File") +
+                             QStringLiteral(" (*.%1)").arg(QString::fromStdString(
+                                 compress_info.value().first.recommended_uncompressed_extension));
         out_path =
             QFileDialog::getSaveFileName(this, tr("Save 3DS ROM File"), final_path, out_filter);
         if (out_path.isEmpty()) {
@@ -3497,7 +3498,7 @@ void GMainWindow::OnOpenFFmpeg() {
 
     for (auto& library_name : library_names) {
         if (!FileUtil::Exists(bin_dir + DIR_SEP + library_name)) {
-            QMessageBox::critical(this, tr("Azahar"),
+            QMessageBox::critical(this, QStringLiteral("Azahar"),
                                   tr("The provided FFmpeg directory is missing %1. Please make "
                                      "sure the correct directory was selected.")
                                       .arg(QString::fromStdString(library_name)));
@@ -3521,9 +3522,10 @@ void GMainWindow::OnOpenFFmpeg() {
     FileUtil::ForeachDirectoryEntry(nullptr, bin_dir, process_file);
 
     if (success.load()) {
-        QMessageBox::information(this, tr("Azahar"), tr("FFmpeg has been sucessfully installed."));
+        QMessageBox::information(this, QStringLiteral("Azahar"),
+                                 tr("FFmpeg has been sucessfully installed."));
     } else {
-        QMessageBox::critical(this, tr("Azahar"),
+        QMessageBox::critical(this, QStringLiteral("Azahar"),
                               tr("Installation of FFmpeg failed. Check the log file for details."));
     }
 }
@@ -3553,7 +3555,7 @@ void GMainWindow::StartVideoDumping(const QString& path) {
         system.RegisterVideoDumper(dumper);
     } else {
         QMessageBox::critical(
-            this, tr("Azahar"),
+            this, QStringLiteral("Azahar"),
             tr("Could not start video dumping.<br>Please ensure that the video encoder is "
                "configured correctly.<br>Refer to the log for details."));
         ui->action_Dump_Video->setChecked(false);
@@ -3638,7 +3640,7 @@ void GMainWindow::UpdateStatusBar() {
                                tr("(Accessing SaveData)")),
             };
 
-        const QString unit = do_mb ? tr("MB/s") : tr("KB/s");
+        const QString unit = do_mb ? QStringLiteral("MB/s") : QStringLiteral("KB/s");
         QString event{};
         for (auto p : perf_events) {
             if (results.artic_events.Get(p.first)) {
@@ -3962,7 +3964,7 @@ bool GMainWindow::ConfirmClose() {
     }
 
     QMessageBox::StandardButton answer =
-        QMessageBox::question(this, tr("Azahar"), tr("Would you like to exit now?"),
+        QMessageBox::question(this, QStringLiteral("Azahar"), tr("Would you like to exit now?"),
                               QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
     return answer != QMessageBox::No;
 }
@@ -4058,7 +4060,7 @@ bool GMainWindow::ConfirmChangeGame() {
     }
 
     auto answer = QMessageBox::question(
-        this, tr("Azahar"),
+        this, QStringLiteral("Azahar"),
         tr("The application is still running. Would you like to stop emulation?"),
         QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
     return answer != QMessageBox::No;

--- a/src/citra_qt/configuration/configure_audio.cpp
+++ b/src/citra_qt/configuration/configure_audio.cpp
@@ -155,7 +155,7 @@ void ConfigureAudio::SetInputDeviceFromDeviceID() {
 }
 
 void ConfigureAudio::SetVolumeIndicatorText(int percentage) {
-    ui->volume_indicator->setText(tr("%1%", "Volume percentage (e.g. 50%)").arg(percentage));
+    ui->volume_indicator->setText(QStringLiteral("%1%").arg(percentage));
 }
 
 void ConfigureAudio::SetHleFeaturesEnabled() {

--- a/src/citra_qt/configuration/configure_audio.ui
+++ b/src/citra_qt/configuration/configure_audio.ui
@@ -162,7 +162,7 @@
             </size>
            </property>
            <property name="text">
-            <string>0 %</string>
+            <string notr="true">0%</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignCenter</set>

--- a/src/citra_qt/configuration/configure_camera.cpp
+++ b/src/citra_qt/configuration/configure_camera.cpp
@@ -194,7 +194,7 @@ void ConfigureCamera::StartPreviewing() {
     preview_width = ui->preview_box->size().width();
     preview_height = static_cast<int>(preview_width * 0.75);
     ui->preview_box->setToolTip(
-        tr("Resolution: %1*%2")
+        tr("Resolution: %1x%2")
             .arg(QString::number(preview_width), QString::number(preview_height)));
     // Load previewing camera
     previewing_camera = Camera::CreateCameraPreview(

--- a/src/citra_qt/configuration/configure_camera.ui
+++ b/src/citra_qt/configuration/configure_camera.ui
@@ -10,9 +10,6 @@
     <height>489</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QGroupBox" name="groupBox">
@@ -176,7 +173,7 @@
         <item>
          <widget class="QToolButton" name="toolButton">
           <property name="text">
-           <string>...</string>
+           <string notr="true">...</string>
           </property>
          </widget>
         </item>
@@ -310,7 +307,7 @@
          </size>
         </property>
         <property name="toolTip">
-         <string>Resolution: 512*384</string>
+         <string>Resolution: 512x384</string>
         </property>
         <property name="text">
          <string/>

--- a/src/citra_qt/configuration/configure_debug.ui
+++ b/src/citra_qt/configuration/configure_debug.ui
@@ -10,9 +10,6 @@
     <height>458</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout_1">
    <item>
     <layout class="QVBoxLayout" name="verticalLayout_2">

--- a/src/citra_qt/configuration/configure_enhancements.ui
+++ b/src/citra_qt/configuration/configure_enhancements.ui
@@ -16,9 +16,6 @@
     <height>0</height>
    </size>
   </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <widget class="QGroupBox" name="rendererBox">
@@ -226,27 +223,27 @@
            </item>
            <item>
             <property name="text">
-             <string>Anime4K</string>
+             <string notr="true">Anime4K</string>
             </property>
            </item>
            <item>
             <property name="text">
-             <string>Bicubic</string>
+             <string notr="true">Bicubic</string>
             </property>
            </item>
            <item>
             <property name="text">
-             <string>ScaleForce</string>
+             <string notr="true">ScaleForce</string>
             </property>
            </item>
            <item>
             <property name="text">
-             <string>xBRZ</string>
+             <string notr="true">xBRZ</string>
             </property>
            </item>
            <item>
             <property name="text">
-             <string>MMPX</string>
+             <string notr="true">MMPX</string>
             </property>
            </item>
           </widget>
@@ -320,7 +317,7 @@
         <item>
          <widget class="QSpinBox" name="factor_3d">
           <property name="suffix">
-           <string>%</string>
+           <string notr="true">%</string>
           </property>
           <property name="minimum">
            <number>0</number>

--- a/src/citra_qt/configuration/configure_general.cpp
+++ b/src/citra_qt/configuration/configure_general.cpp
@@ -152,7 +152,7 @@ void ConfigureGeneral::SetConfiguration() {
 void ConfigureGeneral::ResetDefaults() {
     ui->button_reset_defaults->setEnabled(false);
     QMessageBox::StandardButton answer = QMessageBox::question(
-        this, tr("Azahar"),
+        this, QStringLiteral("Azahar"),
         tr("Are you sure you want to <b>reset your settings</b> and close Azahar?"),
         QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
 

--- a/src/citra_qt/configuration/configure_general.ui
+++ b/src/citra_qt/configuration/configure_general.ui
@@ -10,9 +10,6 @@
     <height>578</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
@@ -307,7 +304,7 @@
            <item>
             <widget class="QToolButton" name="change_screenshot_dir">
              <property name="text">
-              <string>...</string>
+              <string notr="true">...</string>
              </property>
             </widget>
            </item>

--- a/src/citra_qt/configuration/configure_graphics.ui
+++ b/src/citra_qt/configuration/configure_graphics.ui
@@ -16,9 +16,6 @@
     <height>0</height>
    </size>
   </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
   <property name="accessibleName">
    <string>Graphics</string>
   </property>
@@ -60,12 +57,12 @@
            </item>
            <item>
             <property name="text">
-             <string>OpenGL</string>
+             <string notr="true">OpenGL</string>
             </property>
            </item>
            <item>
             <property name="text">
-             <string>Vulkan</string>
+             <string notr="true">Vulkan</string>
             </property>
            </item>
           </widget>
@@ -198,7 +195,7 @@
             <item>
              <widget class="QCheckBox" name="toggle_accurate_mul">
               <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Correctly handle all edge cases in multiplication operation in shaders. &lt;/p&gt;&lt;p&gt;Some applications requires this to be enabled for the hardware shader to render properly.&lt;/p&gt;&lt;p&gt;However this would reduce performance in most applications.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Correctly handle all edge cases in multiplication operation in shaders. &lt;/p&gt;&lt;p&gt;Some applications require this to be enabled for the hardware shader to render properly.&lt;/p&gt;&lt;p&gt;However this would reduce performance in most applications.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="text">
                <string>Accurate multiplication</string>

--- a/src/citra_qt/configuration/configure_hotkeys.ui
+++ b/src/citra_qt/configuration/configure_hotkeys.ui
@@ -10,9 +10,6 @@
     <height>388</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Hotkey Settings</string>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">

--- a/src/citra_qt/configuration/configure_hotkeys_controller.ui
+++ b/src/citra_qt/configuration/configure_hotkeys_controller.ui
@@ -10,9 +10,6 @@
     <height>388</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Controller Hotkey Settings</string>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">

--- a/src/citra_qt/configuration/configure_input.ui
+++ b/src/citra_qt/configuration/configure_input.ui
@@ -10,9 +10,6 @@
     <height>694</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>ConfigureInput</string>
-  </property>
   <layout class="QVBoxLayout" name="rootLayout">
    <property name="spacing">
     <number>2</number>
@@ -198,7 +195,7 @@
               <item>
                <widget class="QLabel" name="label_18">
                 <property name="text">
-                 <string>ZR:</string>
+                 <string notr="true">ZR:</string>
                 </property>
                </widget>
               </item>
@@ -216,7 +213,7 @@
               <item>
                <widget class="QLabel" name="label_17">
                 <property name="text">
-                 <string>L:</string>
+                 <string notr="true">L:</string>
                 </property>
                </widget>
               </item>
@@ -234,7 +231,7 @@
               <item>
                <widget class="QLabel" name="label_20">
                 <property name="text">
-                 <string>ZL:</string>
+                 <string notr="true">ZL:</string>
                 </property>
                </widget>
               </item>
@@ -252,7 +249,7 @@
               <item>
                <widget class="QLabel" name="label_19">
                 <property name="text">
-                 <string>R:</string>
+                 <string notr="true">R:</string>
                 </property>
                </widget>
               </item>
@@ -285,7 +282,7 @@
               <item>
                <widget class="QLabel" name="label_4">
                 <property name="text">
-                 <string>Y:</string>
+                 <string notr="true">Y:</string>
                 </property>
                </widget>
               </item>
@@ -303,7 +300,7 @@
               <item>
                <widget class="QLabel" name="label_3">
                 <property name="text">
-                 <string>X:</string>
+                 <string notr="true">X:</string>
                 </property>
                </widget>
               </item>
@@ -321,7 +318,7 @@
               <item>
                <widget class="QLabel" name="label_2">
                 <property name="text">
-                 <string>B:</string>
+                 <string notr="true">B:</string>
                 </property>
                </widget>
               </item>
@@ -339,7 +336,7 @@
               <item>
                <widget class="QLabel" name="label">
                 <property name="text">
-                 <string>A:</string>
+                 <string notr="true">A:</string>
                 </property>
                </widget>
               </item>
@@ -549,7 +546,7 @@
               <item>
                <widget class="QLabel" name="label_41">
                 <property name="text">
-                 <string>GPIO14:</string>
+                 <string notr="true">GPIO14:</string>
                 </property>
                </widget>
               </item>

--- a/src/citra_qt/configuration/configure_layout.ui
+++ b/src/citra_qt/configuration/configure_layout.ui
@@ -16,9 +16,6 @@
     <height>0</height>
    </size>
   </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <property name="spacing">
     <number>0</number>

--- a/src/citra_qt/configuration/configure_layout_cycle.ui
+++ b/src/citra_qt/configuration/configure_layout_cycle.ui
@@ -19,9 +19,6 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
-  <property name="windowTitle">
-   <string>Configure Layout Cycling</string>
-  </property>
   <widget class="QWidget" name="verticalLayoutWidget">
    <property name="geometry">
     <rect>

--- a/src/citra_qt/configuration/configure_motion_touch.cpp
+++ b/src/citra_qt/configuration/configure_motion_touch.cpp
@@ -77,13 +77,13 @@ void CalibrationConfigurationDialog::UpdateButtonText(const QString& text) {
 
 constexpr std::array<std::pair<const char*, const char*>, 3> MotionProviders = {{
     {"motion_emu", QT_TRANSLATE_NOOP("ConfigureMotionTouch", "Mouse (Right Click)")},
-    {"cemuhookudp", QT_TRANSLATE_NOOP("ConfigureMotionTouch", "CemuhookUDP")},
-    {"sdl", QT_TRANSLATE_NOOP("ConfigureMotionTouch", "SDL")},
+    {"cemuhookudp", "CemuhookUDP"},
+    {"sdl", "SDL"},
 }};
 
 constexpr std::array<std::pair<const char*, const char*>, 2> TouchProviders = {{
     {"emu_window", QT_TRANSLATE_NOOP("ConfigureMotionTouch", "Emulator Window")},
-    {"cemuhookudp", QT_TRANSLATE_NOOP("ConfigureMotionTouch", "CemuhookUDP")},
+    {"cemuhookudp", "CemuhookUDP"},
 }};
 
 ConfigureMotionTouch::ConfigureMotionTouch(QWidget* parent)
@@ -371,7 +371,7 @@ void ConfigureMotionTouch::OnConfigureTouchFromButton() {
 
 bool ConfigureMotionTouch::CanCloseDialog() {
     if (udp_test_in_progress) {
-        QMessageBox::warning(this, tr("Azahar"),
+        QMessageBox::warning(this, QStringLiteral("Azahar"),
                              tr("UDP Test or calibration configuration is in progress.<br>Please "
                                 "wait for them to finish."));
         return false;

--- a/src/citra_qt/configuration/configure_motion_touch.ui
+++ b/src/citra_qt/configuration/configure_motion_touch.ui
@@ -10,9 +10,6 @@
     <height>659</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Configure Motion / Touch</string>
-  </property>
   <layout class="QVBoxLayout">
    <item>
     <widget class="QGroupBox" name="motion_group_box">

--- a/src/citra_qt/configuration/configure_network.ui
+++ b/src/citra_qt/configuration/configure_network.ui
@@ -10,9 +10,6 @@
     <height>561</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QGroupBox" name="discord_group">

--- a/src/citra_qt/configuration/configure_per_game.cpp
+++ b/src/citra_qt/configuration/configure_per_game.cpp
@@ -86,7 +86,7 @@ ConfigurePerGame::~ConfigurePerGame() = default;
 void ConfigurePerGame::ResetDefaults() {
     const auto config_file_name = title_id == 0 ? filename : fmt::format("{:016X}", title_id);
     QMessageBox::StandardButton answer = QMessageBox::question(
-        this, tr("Azahar"),
+        this, QStringLiteral("Azahar"),
         tr("Are you sure you want to <b>reset your settings for this application</b>?"),
         QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
 

--- a/src/citra_qt/configuration/configure_per_game.ui
+++ b/src/citra_qt/configuration/configure_per_game.ui
@@ -16,9 +16,6 @@
     <height>0</height>
    </size>
   </property>
-  <property name="windowTitle">
-   <string>Dialog</string>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">

--- a/src/citra_qt/configuration/configure_storage.ui
+++ b/src/citra_qt/configuration/configure_storage.ui
@@ -10,9 +10,6 @@
     <height>375</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout_1">
    <item>
     <layout class="QVBoxLayout" name="verticalLayout_2">

--- a/src/citra_qt/configuration/configure_system.ui
+++ b/src/citra_qt/configuration/configure_system.ui
@@ -10,9 +10,6 @@
     <height>619</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout_scrollbar">
    <property name="spacing">
     <number>0</number>
@@ -397,7 +394,7 @@ installed applications.</string>
             <item row="12" column="1">
              <widget class="QDateTimeEdit" name="edit_init_time">
               <property name="displayFormat">
-               <string>yyyy-MM-ddTHH:mm:ss</string>
+               <string notr="true">yyyy-MM-ddTHH:mm:ss</string>
               </property>
              </widget>
             </item>
@@ -426,7 +423,7 @@ installed applications.</string>
               <item row="0" column="1">
                <widget class="QTimeEdit" name="edit_init_time_offset_time">
                 <property name="displayFormat">
-                 <string>HH:mm:ss</string>
+                 <string notr="true">HH:mm:ss</string>
                 </property>
                </widget>
               </item>
@@ -622,7 +619,7 @@ installed applications.</string>
                 <item row="1" column="0">
                  <widget class="QLabel" name="label_otp">
                   <property name="text">
-                   <string>OTP</string>
+                   <string notr="true">OTP</string>
                   </property>
                  </widget>
                 </item>
@@ -658,7 +655,7 @@ installed applications.</string>
                 <item row="2" column="0">
                  <widget class="QLabel" name="label_secure_info">
                   <property name="text">
-                   <string>SecureInfo_A/B</string>
+                   <string notr="true">SecureInfo_A/B</string>
                   </property>
                  </widget>
                 </item>
@@ -694,7 +691,7 @@ installed applications.</string>
                 <item row="3" column="0">
                  <widget class="QLabel" name="label_friend_code_seed">
                   <property name="text">
-                   <string>LocalFriendCodeSeed_A/B</string>
+                   <string notr="true">LocalFriendCodeSeed_A/B</string>
                   </property>
                  </widget>
                 </item>
@@ -733,7 +730,7 @@ installed applications.</string>
             <item row="1" column="0">
              <widget class="QLabel" name="label_movable">
               <property name="text">
-               <string>movable.sed</string>
+               <string notr="true">movable.sed</string>
               </property>
              </widget>
             </item>

--- a/src/citra_qt/configuration/configure_touch_from_button.ui
+++ b/src/citra_qt/configuration/configure_touch_from_button.ui
@@ -10,9 +10,6 @@
     <height>500</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Configure Touchscreen Mappings</string>
-  </property>
   <layout class="QVBoxLayout">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">

--- a/src/citra_qt/configuration/configure_ui.ui
+++ b/src/citra_qt/configuration/configure_ui.ui
@@ -2,9 +2,6 @@
 <ui version="4.0">
  <class>ConfigureUi</class>
  <widget class="QWidget" name="ConfigureUi">
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/citra_qt/debugger/graphics/graphics_surface.cpp
+++ b/src/citra_qt/debugger/graphics/graphics_surface.cpp
@@ -650,8 +650,8 @@ void GraphicsSurfaceWidget::OnUpdate() {
 }
 
 void GraphicsSurfaceWidget::SaveSurface() {
-    const QString png_filter = tr("Portable Network Graphic (*.png)");
-    const QString bin_filter = tr("Binary data (*.bin)");
+    const QString png_filter = tr("Portable Network Graphic") + QStringLiteral(" (*.png)");
+    const QString bin_filter = tr("Binary data") + QStringLiteral(" (*.bin)");
 
     QString selected_filter;
     const QString filename = QFileDialog::getSaveFileName(

--- a/src/citra_qt/debugger/graphics/graphics_tracing.cpp
+++ b/src/citra_qt/debugger/graphics/graphics_tracing.cpp
@@ -113,8 +113,9 @@ void GraphicsTracingWidget::StopRecording() {
     if (!context)
         return;
 
-    QString filename = QFileDialog::getSaveFileName(
-        this, tr("Save CiTrace"), QStringLiteral("citrace.ctf"), tr("CiTrace File (*.ctf)"));
+    QString filename =
+        QFileDialog::getSaveFileName(this, tr("Save CiTrace"), QStringLiteral("citrace.ctf"),
+                                     tr("CiTrace File") + QStringLiteral(" (*.ctf)"));
 
     if (filename.isEmpty()) {
         // If the user canceled the dialog, keep recording

--- a/src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp
+++ b/src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp
@@ -343,9 +343,9 @@ QVariant GraphicsVertexShaderModel::data(const QModelIndex& index, int role) con
 }
 
 void GraphicsVertexShaderWidget::DumpShader() {
-    QString filename = QFileDialog::getSaveFileName(this, tr("Save Shader Dump"),
-                                                    QStringLiteral("shader_dump.shbin"),
-                                                    tr("Shader Binary (*.shbin)"));
+    QString filename = QFileDialog::getSaveFileName(
+        this, tr("Save Shader Dump"), QStringLiteral("shader_dump.shbin"),
+        tr("Shader Binary") + QStringLiteral(" (*.shbin)"));
 
     if (filename.isEmpty()) {
         // If the user canceled the dialog, don't dump anything.
@@ -563,31 +563,31 @@ void GraphicsVertexShaderWidget::OnCycleIndexChanged(int index) {
 
     auto& record = debug_data.records[index];
     if (record.mask & Pica::Shader::DebugDataRecord::SRC1)
-        text += tr("SRC1: %1, %2, %3, %4\n")
+        text += QStringLiteral("SRC1: %1, %2, %3, %4\n")
                     .arg(record.src1.x.ToFloat32())
                     .arg(record.src1.y.ToFloat32())
                     .arg(record.src1.z.ToFloat32())
                     .arg(record.src1.w.ToFloat32());
     if (record.mask & Pica::Shader::DebugDataRecord::SRC2)
-        text += tr("SRC2: %1, %2, %3, %4\n")
+        text += QStringLiteral("SRC2: %1, %2, %3, %4\n")
                     .arg(record.src2.x.ToFloat32())
                     .arg(record.src2.y.ToFloat32())
                     .arg(record.src2.z.ToFloat32())
                     .arg(record.src2.w.ToFloat32());
     if (record.mask & Pica::Shader::DebugDataRecord::SRC3)
-        text += tr("SRC3: %1, %2, %3, %4\n")
+        text += QStringLiteral("SRC3: %1, %2, %3, %4\n")
                     .arg(record.src3.x.ToFloat32())
                     .arg(record.src3.y.ToFloat32())
                     .arg(record.src3.z.ToFloat32())
                     .arg(record.src3.w.ToFloat32());
     if (record.mask & Pica::Shader::DebugDataRecord::DEST_IN)
-        text += tr("DEST_IN: %1, %2, %3, %4\n")
+        text += QStringLiteral("DEST_IN: %1, %2, %3, %4\n")
                     .arg(record.dest_in.x.ToFloat32())
                     .arg(record.dest_in.y.ToFloat32())
                     .arg(record.dest_in.z.ToFloat32())
                     .arg(record.dest_in.w.ToFloat32());
     if (record.mask & Pica::Shader::DebugDataRecord::DEST_OUT)
-        text += tr("DEST_OUT: %1, %2, %3, %4\n")
+        text += QStringLiteral("DEST_OUT: %1, %2, %3, %4\n")
                     .arg(record.dest_out.x.ToFloat32())
                     .arg(record.dest_out.y.ToFloat32())
                     .arg(record.dest_out.z.ToFloat32())
@@ -618,9 +618,10 @@ void GraphicsVertexShaderWidget::OnCycleIndexChanged(int index) {
     text +=
         tr("Instruction offset: 0x%1").arg(4 * record.instruction_offset, 4, 16, QLatin1Char('0'));
     if (record.mask & Pica::Shader::DebugDataRecord::NEXT_INSTR) {
-        text += tr(" -> 0x%2").arg(4 * record.next_instruction, 4, 16, QLatin1Char('0'));
+        text +=
+            QStringLiteral(" -> 0x%2").arg(4 * record.next_instruction, 4, 16, QLatin1Char('0'));
     } else {
-        text += tr(" (last instruction)");
+        text += QStringLiteral(" ") + tr("(last instruction)");
     }
 
     instruction_description->setText(text);

--- a/src/citra_qt/debugger/ipc/recorder.ui
+++ b/src/citra_qt/debugger/ipc/recorder.ui
@@ -47,7 +47,7 @@
       </property>
       <column>
        <property name="text">
-        <string>#</string>
+        <string notr="true">#</string>
        </property>
       </column>
       <column>

--- a/src/citra_qt/debugger/registers.ui
+++ b/src/citra_qt/debugger/registers.ui
@@ -10,9 +10,6 @@
     <height>300</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>ARM Registers</string>
-  </property>
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>

--- a/src/citra_qt/debugger/wait_tree.cpp
+++ b/src/citra_qt/debugger/wait_tree.cpp
@@ -105,7 +105,7 @@ bool WaitTreeExpandableItem::IsExpandable() const {
 }
 
 QString WaitTreeWaitObject::GetText() const {
-    return tr("[%1]%2 %3")
+    return QStringLiteral("[%1]%2 %3")
         .arg(object.GetObjectId())
         .arg(QString::fromStdString(object.GetTypeName()),
              QString::fromStdString(object.GetName()));
@@ -205,7 +205,7 @@ QString WaitTreeThread::GetText() const {
         status = tr("dead");
         break;
     }
-    QString pc_info = tr(" PC = 0x%1 LR = 0x%2")
+    QString pc_info = QStringLiteral(" PC = 0x%1 LR = 0x%2")
                           .arg(thread.context.GetProgramCounter(), 8, 16, QLatin1Char('0'))
                           .arg(thread.context.GetLinkRegister(), 8, 16, QLatin1Char('0'));
     return QStringLiteral("%1%2 (%3) ").arg(WaitTreeWaitObject::GetText(), pc_info, status);
@@ -253,10 +253,10 @@ std::vector<std::unique_ptr<WaitTreeItem>> WaitTreeThread::GetChildren() const {
         processor = tr("all");
         break;
     case Kernel::ThreadProcessorId::ThreadProcessorId0:
-        processor = tr("AppCore");
+        processor = QStringLiteral("AppCore");
         break;
     case Kernel::ThreadProcessorId::ThreadProcessorId1:
-        processor = tr("SysCore");
+        processor = QStringLiteral("SysCore");
         break;
     default:
         processor = tr("Unknown processor %1").arg(thread.processor_id);

--- a/src/citra_qt/dumping/dumping_dialog.cpp
+++ b/src/citra_qt/dumping/dumping_dialog.cpp
@@ -22,7 +22,8 @@ DumpingDialog::DumpingDialog(QWidget* parent, Core::System& system_)
     connect(ui->pathExplore, &QToolButton::clicked, this, &DumpingDialog::OnToolButtonClicked);
     connect(ui->buttonBox, &QDialogButtonBox::accepted, [this] {
         if (ui->pathLineEdit->text().isEmpty()) {
-            QMessageBox::critical(this, tr("Azahar"), tr("Please specify the output path."));
+            QMessageBox::critical(this, QStringLiteral("Azahar"),
+                                  tr("Please specify the output path."));
             return;
         }
         ApplyConfiguration();
@@ -82,7 +83,7 @@ void DumpingDialog::Populate() {
     }
 
     if (!missing.isEmpty()) {
-        QMessageBox::critical(this, tr("Azahar"),
+        QMessageBox::critical(this, QStringLiteral("Azahar"),
                               tr("Could not find any available %1.\nPlease check your FFmpeg "
                                  "installation used for compilation.")
                                   .arg(missing));
@@ -115,9 +116,10 @@ void DumpingDialog::Populate() {
         if (!has_audio)
             continue;
 
-        ui->formatComboBox->addItem(tr("%1 (%2)").arg(QString::fromStdString(format.long_name),
-                                                      QString::fromStdString(format.name)),
-                                    static_cast<unsigned long long>(i));
+        ui->formatComboBox->addItem(
+            QStringLiteral("%1 (%2)").arg(QString::fromStdString(format.long_name),
+                                          QString::fromStdString(format.name)),
+            static_cast<unsigned long long>(i));
         if (format.name == Settings::values.output_format) {
             ui->formatComboBox->setCurrentIndex(ui->formatComboBox->count() - 1);
         }
@@ -136,8 +138,8 @@ void DumpingDialog::PopulateEncoders() {
         }
 
         ui->videoEncoderComboBox->addItem(
-            tr("%1 (%2)").arg(QString::fromStdString(video_encoder.long_name),
-                              QString::fromStdString(video_encoder.name)),
+            QStringLiteral("%1 (%2)").arg(QString::fromStdString(video_encoder.long_name),
+                                          QString::fromStdString(video_encoder.name)),
             static_cast<unsigned long long>(i));
         if (video_encoder.name == Settings::values.video_encoder) {
             ui->videoEncoderComboBox->setCurrentIndex(ui->videoEncoderComboBox->count() - 1);
@@ -152,8 +154,8 @@ void DumpingDialog::PopulateEncoders() {
         }
 
         ui->audioEncoderComboBox->addItem(
-            tr("%1 (%2)").arg(QString::fromStdString(audio_encoder.long_name),
-                              QString::fromStdString(audio_encoder.name)),
+            QStringLiteral("%1 (%2)").arg(QString::fromStdString(audio_encoder.long_name),
+                                          QString::fromStdString(audio_encoder.name)),
             static_cast<unsigned long long>(i));
         if (audio_encoder.name == Settings::values.audio_encoder) {
             ui->audioEncoderComboBox->setCurrentIndex(ui->audioEncoderComboBox->count() - 1);
@@ -174,7 +176,7 @@ void DumpingDialog::OnToolButtonClicked() {
 
     const auto path = QFileDialog::getSaveFileName(
         this, tr("Select Video Output Path"), last_path,
-        tr("%1 (%2)").arg(QString::fromStdString(format.long_name), extensions));
+        QStringLiteral("%1 (%2)").arg(QString::fromStdString(format.long_name), extensions));
     if (!path.isEmpty()) {
         last_path = QFileInfo(ui->pathLineEdit->text()).path();
         ui->pathLineEdit->setText(path);

--- a/src/citra_qt/dumping/dumping_dialog.ui
+++ b/src/citra_qt/dumping/dumping_dialog.ui
@@ -43,7 +43,7 @@
       <item row="1" column="2">
        <widget class="QToolButton" name="formatOptionsButton">
         <property name="text">
-         <string>...</string>
+         <string notr="true">...</string>
         </property>
        </widget>
       </item>
@@ -60,7 +60,7 @@
       <item row="2" column="2">
        <widget class="QToolButton" name="pathExplore">
         <property name="text">
-         <string>...</string>
+         <string notr="true">...</string>
         </property>
        </widget>
       </item>
@@ -103,7 +103,7 @@
       <item row="1" column="2">
        <widget class="QToolButton" name="videoEncoderOptionsButton">
         <property name="text">
-         <string>...</string>
+         <string notr="true">...</string>
         </property>
        </widget>
       </item>
@@ -127,7 +127,7 @@
       <item row="2" column="2">
        <widget class="QLabel">
         <property name="text">
-         <string>bps</string>
+         <string notr="true">bps</string>
         </property>
        </widget>
       </item>
@@ -170,7 +170,7 @@
       <item row="1" column="2">
        <widget class="QToolButton" name="audioEncoderOptionsButton">
         <property name="text">
-         <string>...</string>
+         <string notr="true">...</string>
         </property>
        </widget>
       </item>

--- a/src/citra_qt/dumping/option_set_dialog.cpp
+++ b/src/citra_qt/dumping/option_set_dialog.cpp
@@ -70,7 +70,7 @@ std::vector<std::pair<QString, QString>> GetPresetValues(const VideoDumper::Opti
         std::vector<std::pair<QString, QString>> out;
         // Add in all named constants
         for (const auto& constant : option.named_constants) {
-            out.emplace_back(QObject::tr("%1 (0x%2)")
+            out.emplace_back(QStringLiteral("%1 (0x%2)")
                                  .arg(QString::fromStdString(constant.name))
                                  .arg(constant.value, 0, 16),
                              QString::fromStdString(constant.name));
@@ -85,7 +85,7 @@ std::vector<std::pair<QString, QString>> GetPresetValues(const VideoDumper::Opti
 void OptionSetDialog::InitializeUI(const std::string& initial_value) {
     const QString type_name =
         TypeNameMap.count(option.type) ? tr(TypeNameMap.at(option.type)) : tr("unknown");
-    ui->nameLabel->setText(tr("%1 &lt;%2> %3")
+    ui->nameLabel->setText(QStringLiteral("%1 &lt;%2> %3")
                                .arg(QString::fromStdString(option.name), type_name,
                                     QString::fromStdString(option.description)));
     if (TypeDescriptionMap.count(option.type)) {
@@ -160,7 +160,7 @@ void OptionSetDialog::InitializeUI(const std::string& initial_value) {
         layout_type = 2;
 
         for (const auto& constant : option.named_constants) {
-            auto* checkBox = new QCheckBox(tr("%1 (0x%2) %3")
+            auto* checkBox = new QCheckBox(QStringLiteral("%1 (0x%2) %3")
                                                .arg(QString::fromStdString(constant.name))
                                                .arg(constant.value, 0, 16)
                                                .arg(QString::fromStdString(constant.description)));

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -100,15 +100,7 @@ void GameListSearchField::setFilterResult(int visible, int total) {
     this->visible = visible;
     this->total = total;
 
-    QString result_of_text = tr("of");
-    QString result_text;
-    if (total == 1) {
-        result_text = tr("result");
-    } else {
-        result_text = tr("results");
-    }
-    label_filter_result->setText(
-        QStringLiteral("%1 %2 %3 %4").arg(visible).arg(result_of_text).arg(total).arg(result_text));
+    label_filter_result->setText(QStringLiteral("%1/%2").arg(visible).arg(total));
 }
 
 bool GameListSearchField::IsEmpty() const {
@@ -856,7 +848,7 @@ void GameList::AddGamePopup(QMenu& context_menu, const QString& path, const QStr
 #endif
     connect(uninstall_all, &QAction::triggered, this, [=, this] {
         QMessageBox::StandardButton answer = QMessageBox::question(
-            this, tr("Azahar"),
+            this, QStringLiteral("Azahar"),
             tr("Are you sure you want to completely uninstall '%1'?\n\nThis will "
                "delete the application if installed, as well as any installed updates or DLC.")
                 .arg(name),
@@ -878,9 +870,10 @@ void GameList::AddGamePopup(QMenu& context_menu, const QString& path, const QStr
         }
     });
     connect(uninstall_game, &QAction::triggered, this, [this, name, media_type, program_id] {
-        QMessageBox::StandardButton answer = QMessageBox::question(
-            this, tr("Azahar"), tr("Are you sure you want to uninstall '%1'?").arg(name),
-            QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+        QMessageBox::StandardButton answer =
+            QMessageBox::question(this, QStringLiteral("Azahar"),
+                                  tr("Are you sure you want to uninstall '%1'?").arg(name),
+                                  QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
         if (answer == QMessageBox::Yes) {
             std::vector<std::tuple<Service::FS::MediaType, u64, QString>> titles;
             titles.emplace_back(media_type, program_id, name);
@@ -889,7 +882,7 @@ void GameList::AddGamePopup(QMenu& context_menu, const QString& path, const QStr
     });
     connect(uninstall_update, &QAction::triggered, this, [this, name, update_program_id] {
         QMessageBox::StandardButton answer = QMessageBox::question(
-            this, tr("Azahar"),
+            this, QStringLiteral("Azahar"),
             tr("Are you sure you want to uninstall the update for '%1'?").arg(name),
             QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
         if (answer == QMessageBox::Yes) {
@@ -901,7 +894,7 @@ void GameList::AddGamePopup(QMenu& context_menu, const QString& path, const QStr
     });
     connect(uninstall_dlc, &QAction::triggered, this, [this, name, dlc_program_id] {
         QMessageBox::StandardButton answer = QMessageBox::question(
-            this, tr("Azahar"),
+            this, QStringLiteral("Azahar"),
             tr("Are you sure you want to uninstall all DLC for '%1'?").arg(name),
             QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
         if (answer == QMessageBox::Yes) {

--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -267,7 +267,7 @@ public:
         };
         // clang-format off
         static const std::map<QString, CompatStatus> status_data = {
-        {QStringLiteral("0"),  {QStringLiteral("#5c93ed"), QT_TR_NOOP("Perfect"),    QT_TR_NOOP("App functions flawless with no audio or graphical glitches, all tested functionality works as intended without\nany workarounds needed.")}},
+        {QStringLiteral("0"),  {QStringLiteral("#5c93ed"), QT_TR_NOOP("Perfect"),    QT_TR_NOOP("App functions flawlessly with no audio or graphical glitches, all tested functionality works as intended without\nany workarounds needed.")}},
         {QStringLiteral("1"),  {QStringLiteral("#47d35c"), QT_TR_NOOP("Great"),      QT_TR_NOOP("App functions with minor graphical or audio glitches and is playable from start to finish. May require some\nworkarounds.")}},
         {QStringLiteral("2"),  {QStringLiteral("#94b242"), QT_TR_NOOP("Okay"),       QT_TR_NOOP("App functions with major graphical or audio glitches, but app is playable from start to finish with\nworkarounds.")}},
         {QStringLiteral("3"),  {QStringLiteral("#f2d624"), QT_TR_NOOP("Bad"),        QT_TR_NOOP("App functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches\neven with workarounds.")}},

--- a/src/citra_qt/loading_screen.ui
+++ b/src/citra_qt/loading_screen.ui
@@ -108,7 +108,7 @@ font: 75 20pt &quot;Arial&quot;;</string>
 font: 75 20pt &quot;Arial&quot;;</string>
           </property>
           <property name="text">
-           <string>Loading Shaders 387 / 1628</string>
+           <string>Loading Shaders 0 out of 0</string>
           </property>
          </widget>
         </item>
@@ -159,7 +159,7 @@ border-radius: 15px;
 font: 75 15pt &quot;Arial&quot;;</string>
           </property>
           <property name="text">
-           <string>Estimated Time 5m 4s</string>
+           <string>Estimated Time 00:00</string>
           </property>
          </widget>
         </item>

--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Azahar</string>
+   <string notr="true">Azahar</string>
   </property>
   <property name="windowIcon">
    <iconset>
@@ -273,37 +273,37 @@
   </action>
   <action name="action_Boot_Home_Menu_JPN">
    <property name="text">
-    <string>JPN</string>
+    <string notr="true">JPN</string>
    </property>
   </action>
   <action name="action_Boot_Home_Menu_USA">
    <property name="text">
-    <string>USA</string>
+    <string notr="true">USA</string>
    </property>
   </action>
   <action name="action_Boot_Home_Menu_EUR">
    <property name="text">
-    <string>EUR</string>
+    <string notr="true">EUR</string>
    </property>
   </action>
   <action name="action_Boot_Home_Menu_AUS">
    <property name="text">
-    <string>AUS</string>
+    <string notr="true">AUS</string>
    </property>
   </action>
   <action name="action_Boot_Home_Menu_CHN">
    <property name="text">
-    <string>CHN</string>
+    <string notr="true">CHN</string>
    </property>
   </action>
   <action name="action_Boot_Home_Menu_KOR">
    <property name="text">
-    <string>KOR</string>
+    <string notr="true">KOR</string>
    </property>
   </action>
   <action name="action_Boot_Home_Menu_TWN">
    <property name="text">
-    <string>TWN</string>
+    <string notr="true">TWN</string>
    </property>
   </action>
   <action name="action_Exit">

--- a/src/citra_qt/movie/movie_play_dialog.cpp
+++ b/src/citra_qt/movie/movie_play_dialog.cpp
@@ -51,7 +51,7 @@ QString MoviePlayDialog::GetGamePath() const {
 void MoviePlayDialog::OnToolButtonClicked() {
     const QString path =
         QFileDialog::getOpenFileName(this, tr("Play Movie"), UISettings::values.movie_playback_path,
-                                     tr("Citra TAS Movie (*.ctm)"));
+                                     tr("Citra TAS Movie") + QStringLiteral(" (*.ctm)"));
     if (path.isEmpty()) {
         return;
     }

--- a/src/citra_qt/movie/movie_play_dialog.ui
+++ b/src/citra_qt/movie/movie_play_dialog.ui
@@ -29,7 +29,7 @@
      <item>
       <widget class="QToolButton" name="filePathButton">
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
       </widget>
      </item>

--- a/src/citra_qt/movie/movie_record_dialog.cpp
+++ b/src/citra_qt/movie/movie_record_dialog.cpp
@@ -47,7 +47,7 @@ QString MovieRecordDialog::GetAuthor() const {
 void MovieRecordDialog::OnToolButtonClicked() {
     const QString path =
         QFileDialog::getSaveFileName(this, tr("Record Movie"), UISettings::values.movie_record_path,
-                                     tr("Citra TAS Movie (*.ctm)"));
+                                     tr("Citra TAS Movie") + QStringLiteral(" (*.ctm)"));
     if (path.isEmpty()) {
         return;
     }

--- a/src/citra_qt/movie/movie_record_dialog.ui
+++ b/src/citra_qt/movie/movie_record_dialog.ui
@@ -29,7 +29,7 @@
      <item row="0" column="2">
       <widget class="QToolButton" name="filePathButton">
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
       </widget>
      </item>

--- a/src/citra_qt/multiplayer/direct_connect.ui
+++ b/src/citra_qt/multiplayer/direct_connect.ui
@@ -74,7 +74,7 @@
                <number>5</number>
               </property>
               <property name="placeholderText">
-               <string>24872</string>
+               <string notr="true">24872</string>
               </property>
               <property name="maximumSize">
                <size>

--- a/src/citra_qt/multiplayer/state.cpp
+++ b/src/citra_qt/multiplayer/state.cpp
@@ -184,7 +184,7 @@ void MultiplayerState::OnNetworkError(const Network::RoomMember::Error& error) {
 void MultiplayerState::OnAnnounceFailed(const Common::WebResult& result) {
     announce_multiplayer_session->Stop();
     QMessageBox::warning(this, tr("Error"),
-                         tr("Failed to update the room information. Please check your Internet "
+                         tr("Failed to update the room information. Please check your internet "
                             "connection and try hosting the room again.\nDebug Message: ") +
                              QString::fromStdString(result.result_string),
                          QMessageBox::Ok);


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

This PR corrects issues with many Qt strings. These include:

- Making strings which are incorrectly translatable untranslatable
- Making strings which are incorrectly untranslatable translatable
- Correct string formatting
- Fix minor grammatical issues