### PR TITLE
qt: Mark a couple of missed strings as untranslatable

### DIFF
--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -1425,7 +1425,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
             break;
         case Core::System::ResultStatus::ErrorLoader:
             QMessageBox::critical(this, tr("Generic load error"),
-                                  tr("An generic load error occurred while loading the "
+                                  tr("A generic load error occurred while loading the "
                                      "application.<br/>Please check the log for more details."));
             break;
         case Core::System::ResultStatus::ErrorLoader_ErrorPatches:

--- a/src/citra_qt/configuration/configure_motion_touch.ui
+++ b/src/citra_qt/configuration/configure_motion_touch.ui
@@ -117,7 +117,7 @@
         <item>
          <widget class="QLabel" name="touch_calibration">
           <property name="text">
-           <string>(100, 50) - (1800, 850)</string>
+           <string notr="true">(100, 50) - (1800, 850)</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/citra_qt/dumping/dumping_dialog.ui
+++ b/src/citra_qt/dumping/dumping_dialog.ui
@@ -194,7 +194,7 @@
       <item row="2" column="2">
        <widget class="QLabel">
         <property name="text">
-         <string>bps</string>
+         <string notr="true">bps</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
- [ ] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Final follow-up to #2432 which catches two more missed strings which don't need to be translated.

Also includes a single minor grammatical correction.
