### PR TITLE
video_core: vulkan: Fix linear filtering forcefully enabled in some drivers

### DIFF
--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -311,19 +311,23 @@ void RendererVulkan::CompileShaders() {
     cursor_fragment_shader =
         Compile(HostShaders::VULKAN_CURSOR_FRAG, vk::ShaderStageFlagBits::eFragment, device);
 
-    auto properties = instance.GetPhysicalDevice().getProperties();
     for (std::size_t i = 0; i < present_samplers.size(); i++) {
-        const vk::Filter filter_mode = i == 0 ? vk::Filter::eLinear : vk::Filter::eNearest;
+        const bool linear = i == 0;
+        const vk::Filter filter_mode = linear ? vk::Filter::eLinear : vk::Filter::eNearest;
+        const vk::SamplerMipmapMode mipmap_mode =
+            linear ? vk::SamplerMipmapMode::eLinear : vk::SamplerMipmapMode::eNearest;
         const vk::SamplerCreateInfo sampler_info = {
             .magFilter = filter_mode,
             .minFilter = filter_mode,
-            .mipmapMode = vk::SamplerMipmapMode::eLinear,
+            .mipmapMode = mipmap_mode,
             .addressModeU = vk::SamplerAddressMode::eClampToEdge,
             .addressModeV = vk::SamplerAddressMode::eClampToEdge,
-            .anisotropyEnable = instance.IsAnisotropicFilteringSupported(),
-            .maxAnisotropy = properties.limits.maxSamplerAnisotropy,
+            .anisotropyEnable = VK_FALSE,
+            .maxAnisotropy = 1.0f,
             .compareEnable = false,
             .compareOp = vk::CompareOp::eAlways,
+            .minLod = 0.0f,
+            .maxLod = 0.0f,
             .borderColor = vk::BorderColor::eIntOpaqueBlack,
             .unnormalizedCoordinates = false,
         };

--- a/src/video_core/renderer_vulkan/vk_present_window.cpp
+++ b/src/video_core/renderer_vulkan/vk_present_window.cpp
@@ -467,7 +467,8 @@ void PresentWindow::CopyToSwapchain(Frame* frame) {
         cmdbuf.blitImage(frame->image, vk::ImageLayout::eTransferSrcOptimal, swapchain_image,
                          vk::ImageLayout::eTransferDstOptimal,
                          MakeImageBlit(frame->width, frame->height, extent.width, extent.height),
-                         vk::Filter::eLinear);
+                         Settings::values.filter_mode.GetValue() ? vk::Filter::eLinear
+                                                                 : vk::Filter::eNearest);
     } else {
         cmdbuf.copyImage(frame->image, vk::ImageLayout::eTransferSrcOptimal, swapchain_image,
                          vk::ImageLayout::eTransferDstOptimal,

--- a/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
@@ -1531,6 +1531,14 @@ Sampler::Sampler(TextureRuntime& runtime, const VideoCore::SamplerParams& params
     const float lod_min = static_cast<float>(params.lod_min);
     const float lod_max = static_cast<float>(params.lod_max);
 
+    // Do not apply anisotropic filtering if nearest filtering is used at all, as drivers
+    // are only recommended (not enforced) to follow the mag/min filter in such cases.
+    // Adreno drivers are an example of this, as they force linear filtering when using
+    // anisotropic filtering.
+    const bool use_anisotropy = instance.IsAnisotropicFilteringSupported() &&
+                                mag_filter == vk::Filter::eLinear &&
+                                min_filter == vk::Filter::eLinear;
+
     const vk::SamplerCreateInfo sampler_info = {
         .pNext = use_border_color ? &border_color_info : nullptr,
         .magFilter = mag_filter,
@@ -1539,8 +1547,8 @@ Sampler::Sampler(TextureRuntime& runtime, const VideoCore::SamplerParams& params
         .addressModeU = wrap_u,
         .addressModeV = wrap_v,
         .mipLodBias = 0,
-        .anisotropyEnable = instance.IsAnisotropicFilteringSupported(),
-        .maxAnisotropy = properties.limits.maxSamplerAnisotropy,
+        .anisotropyEnable = use_anisotropy,
+        .maxAnisotropy = use_anisotropy ? properties.limits.maxSamplerAnisotropy : 1.0f,
         .compareEnable = false,
         .compareOp = vk::CompareOp::eAlways,
         .minLod = lod_min,


### PR DESCRIPTION
- [X] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.

AI was used to diagnose the problem, which found the Vulkan-Docs issue referencing the quirk.

---------

This PR fixes the linear filtering toggle doing nothing on Android when using the Vulkan renderer and stock Adreno drivers. In such cases, linear filtering would be permanently enabled.

This issue happened because the samplers for textures and for the final present quad had anisotropic filtering enabled. According to the Vulkan documentation, when anosotropic filtering is enabled the driver is only recommended (not enforced) to use the mag/min filtering options (https://github.com/KhronosGroup/Vulkan-Docs/issues/1361). This is the case for Adreno drivers, which ignore the filtering options and always enable linear filtering.