### PR TITLE
video_core: Harden stride aliasing validation

### DIFF
--- a/src/video_core/rasterizer_cache/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache/rasterizer_cache.h
@@ -1225,17 +1225,32 @@ bool RasterizerCache<T>::ValidateByReinterpretation(Surface& surface, SurfacePar
         return runtime.Reinterpret(src_surface, surface, reinterpret);
     }
 
-    // No surfaces were found in the cache that had a matching bit-width.
-    // Before entering the slow path, check if part of the interval is owned
-    // by a gpu modified surface with a different stride than ours. This is indicative
-    // of texture aliasing by the guest, which for the vast majority of cases we don't
-    // need to validate.
-    // TODO: While this works for the vast majority of cases, in Fire Emblem: Shadows of Valentia
-    // the warping effect when running in dugeons relies on this stride reinterpretation.
-    // In the future this transformation should be properly implemented with a GPU shader.
+    bool has_invalid = false;
+    const PAddr addr = boost::icl::lower(interval);
+    const u32 size = boost::icl::length(interval);
+
+    ForEachSurfaceInRegion(addr, size, [&](auto, auto& cached_surface) {
+        if (cached_surface.pixel_format == PixelFormat::Invalid) {
+            has_invalid = true;
+            return true;
+        }
+        return false;
+    });
+
+    if (has_invalid) {
+        return false;
+    }
+
+    if (!boost::icl::contains(dirty_regions, interval)) {
+        return false;
+    }
+
     const auto it = dirty_regions.find(interval);
-    return it != dirty_regions.end() && it->second &&
-           slot_surfaces[it->second].stride != surface.stride;
+    if (it == dirty_regions.end() || !it->second) {
+        return false;
+    }
+
+    return slot_surfaces[it->second].stride != surface.stride;
 }
 
 template <class T>


### PR DESCRIPTION
Avoid skipping surface validation when an Invalid-format surface overlaps the requested interval or when the dirty region only partially covers it. This prevents stale cached surface contents from being reused through the different-stride aliasing fast path.

- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Problem:

In Inazuma Eleven GO Galaxy, 2D VRAM regions are frequently reused while
entering and leaving menus. The current stride-aliasing heuristic can skip
validation for partially covered or cleared regions, allowing stale cached
texture contents to be displayed.

Symptoms include corrupted map/minimap textures and garbled special-move UI
textures after leaving menus or the save screen.

Reproduction used:

Launch Inazuma Eleven GO Galaxy.

Open and close submenus repeatedly.

Save the game and close the save menu.

Move around the map and inspect the minimap/UI.

Enter a match and inspect special-move names/UI.

Before the fix, texture corruption was reproducible. With this fix,
the corruption no longer occurs.

Fixes https://github.com/azahar-emu/azahar/issues/2340
Related to https://github.com/azahar-emu/azahar/issues/1384
