### PR TITLE
libretro: change android target to azahar_libretro_android to match g…

### DIFF
--- a/.ci/libretro-ci.yml
+++ b/.ci/libretro-ci.yml
@@ -105,7 +105,7 @@ android-arm64-v8a:
   variables:
     ANDROID_NDK_VERSION: 29.0.14206865
     NDK_ROOT: /android-sdk-linux/ndk/$ANDROID_NDK_VERSION
-    LIBNAME: ${CORENAME}_libretro.so
+    LIBNAME: ${CORENAME}_libretro_android.so
   artifacts:
     paths:
       - $LIBNAME

--- a/.ci/libretro-pack.sh
+++ b/.ci/libretro-pack.sh
@@ -9,5 +9,11 @@ if [ "$GITHUB_REF_TYPE" = "tag" ]; then
     REV_NAME="azahar-libretro-$OS-$TARGET-$GITHUB_REF_NAME"
 fi
 
+if [ "$OS" = "android" ]; then
+    CORE_FILE="$BUILD_DIR/$EXTRA_PATH/azahar_libretro_android.so"
+else
+    CORE_FILE="$BUILD_DIR/$EXTRA_PATH/azahar_libretro.*"
+fi
+
 # Create .zip
-zip -j -9 $REV_NAME.zip $BUILD_DIR/$EXTRA_PATH/azahar_libretro.*
+zip -j -9 "$REV_NAME.zip" $CORE_FILE

--- a/.github/workflows/libretro.yml
+++ b/.github/workflows/libretro.yml
@@ -50,7 +50,7 @@ jobs:
           export NDK_ROOT=${ANDROID_SDK_ROOT}/ndk/$ANDROID_NDK_VERSION
           ${ANDROID_SDK_ROOT}/cmake/3.30.3/bin/cmake $CORE_ARGS -DANDROID_PLATFORM=android-$API_LEVEL -DCMAKE_TOOLCHAIN_FILE=$NDK_ROOT/build/cmake/android.toolchain.cmake -DANDROID_STL=c++_static -DANDROID_ABI=$ANDROID_ABI . -B $BUILD_DIR
           ${ANDROID_SDK_ROOT}/cmake/3.30.3/bin/cmake --build $BUILD_DIR --target azahar_libretro --config Release -j $(nproc)
-          llvm-strip -s $BUILD_DIR/$EXTRA_PATH/azahar_libretro.*
+          llvm-strip -s $BUILD_DIR/$EXTRA_PATH/azahar_libretro_android.*
       - name: Pack
         run: ./.ci/libretro-pack.sh
       - name: Generate SBOM

--- a/src/citra_libretro/CMakeLists.txt
+++ b/src/citra_libretro/CMakeLists.txt
@@ -29,7 +29,11 @@ add_library(citra_libretro SHARED
         citra_libretro.h
         $<TARGET_OBJECTS:citra_libretro_common>)
 
-set_target_properties(citra_libretro PROPERTIES OUTPUT_NAME "azahar_libretro")
+if (ANDROID)
+  set_target_properties(citra_libretro PROPERTIES OUTPUT_NAME "azahar_libretro_android")
+else()
+  set_target_properties(citra_libretro PROPERTIES OUTPUT_NAME "azahar_libretro")
+endif()
 
 create_target_directory_groups(citra_libretro)
 


### PR DESCRIPTION
…itlab CI requirements

- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

The play packaging scripts for libretro look for modules called core_libretro_android.so, so it cannot find azahar. This fixes that issue.