### PR TITLE
audio_core: Fix live looping PCM playback

### DIFF
--- a/src/audio_core/hle/source.cpp
+++ b/src/audio_core/hle/source.cpp
@@ -237,6 +237,10 @@ void Source::ParseConfig(SourceConfiguration::Configuration& config,
                 break;
             case Format::PCM16:
                 state.current_buffer = Codec::DecodePCM16(num_channels, memory, config.length);
+                state.current_buffer_length = config.length;
+                state.current_buffer_mono_or_stereo = state.mono_or_stereo;
+                state.current_buffer_format = state.format;
+                state.current_buffer_is_looping = config.is_looping != 0;
                 valid = true;
                 break;
             case Format::ADPCM:
@@ -362,6 +366,32 @@ void Source::ParseConfig(SourceConfiguration::Configuration& config,
 void Source::GenerateFrame() {
     current_frame.fill({});
 
+    // A looping PCM buffer can be updated by the application while the DSP is
+    // playing it. Refresh only the not-yet-consumed part from emulated RAM.
+    //
+    // current_sample_number is maintained below from the exact amount of input
+    // removed by AudioInterp, so the memory offset and current_buffer stay in sync.
+    if (!state.current_buffer.empty() && state.current_buffer_is_looping &&
+        state.current_buffer_format == Format::PCM16 &&
+        state.current_buffer_physical_address != 0 &&
+        state.current_sample_number < state.current_buffer_length) {
+        const unsigned num_channels =
+            state.current_buffer_mono_or_stereo == MonoOrStereo::Stereo ? 2 : 1;
+
+        const u32 byte_offset =
+            state.current_sample_number * num_channels * static_cast<u32>(sizeof(s16));
+        const PAddr physical_address =
+            (state.current_buffer_physical_address & 0xFFFFFFFC) + byte_offset;
+        const u8* const memory = memory_system->GetPhysicalPointer(physical_address);
+
+        if (memory) {
+            const u32 remaining_samples =
+                state.current_buffer_length - state.current_sample_number;
+            state.current_buffer =
+                Codec::DecodePCM16(num_channels, memory, remaining_samples);
+        }
+    }
+
     if (state.current_buffer.empty()) {
         // TODO(SachinV): Should dequeue happen at the end of the frame generation?
         if (DequeueBuffer()) {
@@ -379,6 +409,11 @@ void Source::GenerateFrame() {
         if (state.current_buffer.empty() && !DequeueBuffer()) {
             break;
         }
+
+        // AudioInterp consumes samples from current_buffer and already preserves
+        // its own fractional phase/history. Use what it actually consumed instead
+        // of reconstructing the source position with a truncated float product.
+        const std::size_t input_size_before = state.current_buffer.size();
 
         switch (state.interpolation_mode) {
         case InterpolationMode::None:
@@ -398,10 +433,12 @@ void Source::GenerateFrame() {
             UNIMPLEMENTED();
             break;
         }
+
+        const std::size_t input_size_after = state.current_buffer.size();
+        ASSERT(input_size_after <= input_size_before);
+        state.current_sample_number +=
+            static_cast<u32>(input_size_before - input_size_after);
     }
-    // TODO(jroweboy): Keep track of frame_position independently so that it doesn't lose precision
-    // over time
-    state.current_sample_number += static_cast<u32>(frame_position * state.rate_multiplier);
 
     state.filters.ProcessFrame(current_frame);
 }
@@ -453,6 +490,10 @@ bool Source::DequeueBuffer() {
     // the first playthrough starts at play_position, loops start at the beginning of the buffer
     state.current_sample_number = (!buf.has_played) ? buf.play_position : 0;
     state.current_buffer_physical_address = buf.physical_address;
+    state.current_buffer_length = buf.length;
+    state.current_buffer_mono_or_stereo = buf.mono_or_stereo;
+    state.current_buffer_format = buf.format;
+    state.current_buffer_is_looping = buf.is_looping;
     state.current_buffer_id = buf.buffer_id;
     state.last_buffer_id = 0;
     state.buffer_update = buf.from_queue && !buf.has_played;

--- a/src/audio_core/hle/source.cpp
+++ b/src/audio_core/hle/source.cpp
@@ -385,10 +385,8 @@ void Source::GenerateFrame() {
         const u8* const memory = memory_system->GetPhysicalPointer(physical_address);
 
         if (memory) {
-            const u32 remaining_samples =
-                state.current_buffer_length - state.current_sample_number;
-            state.current_buffer =
-                Codec::DecodePCM16(num_channels, memory, remaining_samples);
+            const u32 remaining_samples = state.current_buffer_length - state.current_sample_number;
+            state.current_buffer = Codec::DecodePCM16(num_channels, memory, remaining_samples);
         }
     }
 
@@ -436,8 +434,7 @@ void Source::GenerateFrame() {
 
         const std::size_t input_size_after = state.current_buffer.size();
         ASSERT(input_size_after <= input_size_before);
-        state.current_sample_number +=
-            static_cast<u32>(input_size_before - input_size_after);
+        state.current_sample_number += static_cast<u32>(input_size_before - input_size_after);
     }
 
     state.filters.ProcessFrame(current_frame);

--- a/src/audio_core/hle/source.h
+++ b/src/audio_core/hle/source.h
@@ -143,6 +143,10 @@ private:
 
         u32 current_sample_number = 0;
         PAddr current_buffer_physical_address = 0;
+        u32 current_buffer_length = 0;
+        MonoOrStereo current_buffer_mono_or_stereo = MonoOrStereo::Mono;
+        Format current_buffer_format = Format::ADPCM;
+        bool current_buffer_is_looping = false;
         AudioInterp::StereoBuffer16 current_buffer = {};
 
         // buffer_id state
@@ -179,6 +183,10 @@ private:
             ar & format;
             ar & current_sample_number;
             ar & current_buffer_physical_address;
+            ar & current_buffer_length;
+            ar & current_buffer_mono_or_stereo;
+            ar & current_buffer_format;
+            ar & current_buffer_is_looping;
             ar & current_buffer;
             ar & buffer_update;
             ar & current_buffer_id;


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Fixes HLE audio crackling/stuttering in games that update looping PCM16 buffers while they are being played.

Previously, HLE kept a decoded copy of the PCM buffer while the application could continue modifying the underlying memory. The source position was also advanced using an approximation based on `frame_position * rate_multiplier`, which could lose precision over time.

This change:
- Refreshes the unconsumed portion of looping PCM16 buffers from emulated memory.
- Advances `current_sample_number` using the number of input samples actually consumed by the interpolator.
- Keeps the source position synchronized with the real playback state.

Tested with Inazuma Eleven 3 using HLE audio, where cutscenes and character voices no longer crackle, and also checked with other games for regressions.

Fixes #1416