### PR TITLE
Bugfix - Hat inputs were not correctly detecting release and press state

### DIFF
--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -908,18 +908,24 @@ Common::ParamPackage SDLEventToButtonParamPackage(SDLState& state, const SDL_Eve
         switch (event.jhat.value) {
         case SDL_HAT_UP:
             params.Set("direction", "up");
+            joystick->current_hat_down = "up";
             break;
         case SDL_HAT_DOWN:
             params.Set("direction", "down");
+            joystick->current_hat_down = "down";
             break;
         case SDL_HAT_LEFT:
             params.Set("direction", "left");
+            joystick->current_hat_down = "left";
             break;
         case SDL_HAT_RIGHT:
             params.Set("direction", "right");
+            joystick->current_hat_down = "right";
             break;
         case SDL_HAT_CENTERED:
-            params.Set("direction", "centered");
+            // register as release of whichever hat button was pressed
+            params.Set("direction", joystick->current_hat_down);
+            joystick->current_hat_down = "";
             break;
         default:
             return {};

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -848,10 +848,13 @@ SDLState::~SDLState() {
 Common::ParamPackage SDLEventToButtonParamPackage(SDLState& state, const SDL_Event& event,
                                                   const bool down = false) {
     Common::ParamPackage params({{"engine", "sdl"}});
+    // we need to track if this is a press or release
     if (down) {
         params.Set("down", "1");
+    } else {
+        params.Erase("down");
     }
-    // is it safe to always use event.jhat.which here regardless of event type?
+
     auto joystick = state.GetSDLJoystickBySDLID(event.jhat.which);
     if (!joystick)
         return {};
@@ -906,6 +909,9 @@ Common::ParamPackage SDLEventToButtonParamPackage(SDLState& state, const SDL_Eve
         params.Set("guid", joystick->GetGUID());
         params.Set("hat", event.jhat.hat);
         switch (event.jhat.value) {
+        // if the received motion is up, down, left, or right
+        // then it will be marked as "down" above and we need to store which
+        // button is pressed
         case SDL_HAT_UP:
             params.Set("direction", "up");
             joystick->current_hat_down = "up";
@@ -922,8 +928,9 @@ Common::ParamPackage SDLEventToButtonParamPackage(SDLState& state, const SDL_Eve
             params.Set("direction", "right");
             joystick->current_hat_down = "right";
             break;
+        // if the hat is now centered, we will interpret that as releasing
+        // the previously pressed button and clear the hat state
         case SDL_HAT_CENTERED:
-            // register as release of whichever hat button was pressed
             params.Set("direction", joystick->current_hat_down);
             joystick->current_hat_down = "";
             break;
@@ -1105,6 +1112,8 @@ public:
                 break;
             }
             case SDL_JOYHATMOTION: {
+                // send this as a pressed signal for every motion but SDL_HAT_CENTERED, which
+                // we will interpret as a release
                 return SDLEventToButtonParamPackage(state, event,
                                                     event.jhat.value != SDL_HAT_CENTERED);
                 break;

--- a/src/input_common/sdl/sdl_joystick.h
+++ b/src/input_common/sdl/sdl_joystick.h
@@ -56,8 +56,12 @@ public:
     SDL_GameController* GetSDLGameController() const;
 
     void SetSDLJoystick(SDL_Joystick* joystick, SDL_GameController* controller);
-    // tracks which if any hat button is currently pressed down, so a release can be correctly
-    // detected
+
+    // Hat presses under the SDL Joystick API do not send press and release signals like
+    // normal buttons, instead only sending directions up, down, left, right, and center.
+    // Thus we need to store which hat direction was pressed so we can interpret the
+    // center signal as a release for the appropriate direction.
+    // the empty string means we do not have anything currently stored as the pressed direction.
     std::string current_hat_down = "";
 
 private:

--- a/src/input_common/sdl/sdl_joystick.h
+++ b/src/input_common/sdl/sdl_joystick.h
@@ -56,6 +56,9 @@ public:
     SDL_GameController* GetSDLGameController() const;
 
     void SetSDLJoystick(SDL_Joystick* joystick, SDL_GameController* controller);
+    // tracks which if any hat button is currently pressed down, so a release can be correctly
+    // detected
+    std::string current_hat_down = "";
 
 private:
     struct State {


### PR DESCRIPTION
Controllers that were falling back to the Joystick API because they are not fully supported under SDL2, such as the 8bitdo pro 3 controller in DInput mode were having issues with the Hat inputs. This is because Hat inputs do not work like buttons and do not report their release, only their press. This PR adds tracking of which hat button was last pressed for a given joystick so it can correctly detect press and release and use hats correctly in input config and controller hotkeys.

No AI use here.

Fixes #2442

- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------
