### PR TITLE
ci: Unify AppImage builds due to resolved issues

### DIFF
--- a/.ci/linux.sh
+++ b/.ci/linux.sh
@@ -1,16 +1,14 @@
 #!/bin/bash -ex
 
-if [[ "$TARGET" == "appimage"* ]] || [[ "$TARGET" == "clang"* ]]; then
+if [[ "$TARGET" == "appimage" ]] || [[ "$TARGET" == "clang"* ]]; then
     # Compile the AppImage we distribute with Clang.
     export EXTRA_CMAKE_FLAGS=(-DCMAKE_CXX_COMPILER=clang++
                               -DCMAKE_C_COMPILER=clang
                               -DCMAKE_LINKER=/etc/bin/ld.lld
                               -DENABLE_ROOM_STANDALONE=OFF)
-    if [ "$TARGET" = "appimage-wayland" ]; then
-        # Bundle required QT wayland libraries
-        export EXTRA_QT_PLUGINS="waylandcompositor"
-        export EXTRA_PLATFORM_PLUGINS="libqwayland-egl.so;libqwayland-generic.so"
-    fi
+    # Bundle required QT wayland libraries
+    export EXTRA_QT_PLUGINS="waylandcompositor"
+    export EXTRA_PLATFORM_PLUGINS="libqwayland-egl.so;libqwayland-generic.so"
 else
     # For the linux-fresh verification target, verify compilation without PCH as well.
     export EXTRA_CMAKE_FLAGS=(-DCITRA_USE_PRECOMPILED_HEADERS=OFF)
@@ -31,7 +29,7 @@ cmake .. -G Ninja \
 ninja
 strip -s bin/Release/*
 
-if [[ "$TARGET" == "appimage"* ]]; then
+if [ "$TARGET" == "appimage" ]; then
     ninja bundle
     # TODO: Our AppImage environment currently uses an older ccache version without the verbose flag.
     ccache -s

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ["appimage", "appimage-wayland", "gcc-nopch"]
+        target: ["appimage", "gcc-nopch"]
     container:
       image: opensauce04/azahar-build-environment:latest
       options: -u 1001
@@ -58,15 +58,13 @@ jobs:
       CCACHE_SLOPPINESS: time_macros
       OS: linux
       TARGET: ${{ matrix.target }}
-      SHOULD_RUN: ${{ (matrix.target != 'appimage-wayland' || github.ref_type == 'tag') }}
       CACHE_ENABLED: ${{ github.ref_type != 'tag' }}
     steps:
       - uses: actions/checkout@v6
-        if: ${{ env.SHOULD_RUN == 'true' }}
         with:
           submodules: recursive
       - name: Set up cache
-        if: ${{ env.SHOULD_RUN == 'true' && env.CACHE_ENABLED == 'true' }}
+        if: ${{ env.CACHE_ENABLED == 'true' }}
         uses: actions/cache@v5
         with:
           path: ${{ env.CCACHE_DIR }}
@@ -74,19 +72,14 @@ jobs:
           restore-keys: |
             ${{ github.job }}-${{ matrix.target }}-
       - name: Build
-        if: ${{ env.SHOULD_RUN == 'true' }}
         run: ./.ci/linux.sh
       - name: Move AppImage to artifacts directory
-        if: ${{ contains(matrix.target, 'appimage') && env.SHOULD_RUN == 'true' }}
+        if: ${{ matrix.target == 'appimage' }}
         run: |
           mkdir -p artifacts
           mv build/bundle/*.AppImage artifacts/
-      - name: Rename AppImage
-        if: ${{ matrix.target == 'appimage-wayland' && env.SHOULD_RUN == 'true' }}
-        run: |
-          mv artifacts/azahar.AppImage artifacts/azahar-wayland.AppImage
       - name: Generate SBOM
-        if: ${{ contains(matrix.target, 'appimage') && github.ref_type == 'tag' && env.SHOULD_RUN == 'true' }}
+        if: ${{ matrix.target == 'appimage' && github.ref_type == 'tag' }}
         uses: anchore/sbom-action@v0
         with:
           path: build/
@@ -94,13 +87,13 @@ jobs:
           output-file: artifacts/linux-x86_64-${{ matrix.target }}.spdx.json
           upload-artifact: false
       - name: Upload
-        if: ${{ contains(matrix.target, 'appimage') && env.SHOULD_RUN == 'true' }}
+        if: ${{ matrix.target == 'appimage' }}
         uses: actions/upload-artifact@v7
         with:
           name: ${{ github.job }}-${{ matrix.target }}
           path: artifacts/
       - name: Attest artifacts
-        if: ${{ contains(matrix.target, 'appimage') && github.ref_type == 'tag' && env.SHOULD_RUN == 'true' }}
+        if: ${{ matrix.target == 'appimage' && github.ref_type == 'tag' }}
         uses: actions/attest@v4
         with:
           subject-path: |


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

The Wayland crashing issue described in #1162 appears to have now been resolved in master. As such, the X11/Wayland distinction in our distributed AppImage binaries is no longer necessary. From now, we will only distribute a single `azahar.AppImage` which includes native Wayland compatibility.