### PR TITLE
Fix/vc right eye disabler boot

### DIFF
--- a/src/video_core/right_eye_disabler.h
+++ b/src/video_core/right_eye_disabler.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Azahar Emulator Project
+// Copyright 2024-2026 Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -24,7 +24,8 @@ public:
 
 private:
     bool enabled = true;
-    bool enable_for_frame = true;
+    // Enabled by ReportEndFrame() once the user setting has been read.
+    bool enable_for_frame = false;
 
     bool top_screen_drawn = false;
     bool top_screen_transfered = false;


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

## Fix GB/GBC Virtual Console titles leaving menu graphics on the top screen

When running Pokémon Crystal VC in Azahar, the right-hand strip of the top screen shows chunks of the VC menu instead of black. It shows up during boot and stays there for the rest of the session, and I this was reported in a [reddit post](https://www.reddit.com/r/AynThor/comments/1rxg9r0/has_anyone_had_any_luck_running_gbc_virtual/) as well.

**Before** The small screen on the far right is the actual bottom screen, dimmed, so the green stuff on the top screen is clearly stale:
<img width="1470" height="745" alt="01-before-ingame" src="https://github.com/user-attachments/assets/c29b696d-cc78-4903-8b6e-4b6fc7e42c93" />

Same thing on the OpenGL backend, so it isn't renderer-specific. I also reproduced it identically with the software renderer:
<img width="1920" height="960" alt="03-before-opengl" src="https://github.com/user-attachments/assets/90e26567-66d8-40c5-81ad-ca6a620f09a2" />

**After:**
<img width="960" height="480" alt="02-after-ingame" src="https://github.com/user-attachments/assets/e1d20cb9-7d70-4e5e-aa31-12be88ee66c6" />

### Diagnosis

The VC app composes its whole top screen into one buffer in VRAM and display-transfers it out every frame. During boot it submits a small command list whose only job is to point the color buffer at the bottom screen's render target before drawing the VC menu there.

That list was getting swallowed by `RightEyeDisabler`, so the color buffer never moved, and the menu got drawn into the top screen's compose buffer instead. From then on the app only ever draws the Game Boy image over the middle of that buffer so nothing overwrites the leftovers sitting in the pillarbox regions.

`enable_for_frame` starts out `true` and is only refreshed from `disable_right_eye_render` in `ReportEndFrame()`, which first runs at the initial buffer swap. So the disabler is live during boot even for people who have the option switched off which is the default.

And `GuessCmdRenderProperties()` seeds `vp_height` and `paddr` from whatever is currently in the registers, only overwriting them if the scanned list writes those registers itself. The list in question doesn't touch the viewport, so it inherited the top screen's viewport height from the previous pass and got treated as a repeat render of the top screen.

### The changes

The first commit just defaults `enable_for_frame` to `false`. With the option off, the disabler now stays out of the way entirely instead of being active for the first frame.

The second commit I'm less sure of. `GuessCmdRenderProperties()` already tracks whether each value genuinely came from the list (`vp_heigh_found`, `paddr_found`), but the caller ignored those flags. I added a `has_draw` flag and made `ShouldAllowCmdQueueTrigger()` require it: a list that issues no geometry produces no pixels, so blocking it can never save any work- it can only throw away state that later lists need. The condition is strictly narrower than before, so it can't suppress anything that was previously allowed.

I checked that this doesn't neuter the optimization. On Ocarina of Time 3D with 3D enabled, the disabler still blocks 4141 lists per run versus 4441 before- the ~300 difference being the state-only lists it now lets through. On Luigi's Mansion 2, which the `RIGHT_EYE_DISABLE` hack list already disallows, blocking drops from 4601 to zero. I can't prove it, but that makes me suspect at least some of those hack-list entries exist because of this same misclassification. I've left the list alone.

Same commit also null-checks the two places a list address gets turned into a pointer, [which can be emitted here](https://github.com/azahar-emu/azahar/blob/master/src/core/memory.cpp#L940-L949). `CommandList::Reset()` only does a `reinterpret_cast`, so an unmapped address would be dereferenced on the next read. That was already true, but it matters more now that the scan doesn't stop as soon as `vp_height` and `paddr` are known and can follow more nested command buffer jumps.

### Testing

I tested with Pokemon Crystal VC with Vulkan and OpenGL and made sure the pillarboxes are black with both `disable_right_eye_render` on and off.

Then Ocarina of Time 3D and Luigi's Mansion 2 render identically with and without the change, with the option on and off. For Luigi's Mansion 2 I temporarily flipped its hack-list entry to `ALLOW` so the disabler would actually engage.

Existing test suite still passes (65 passed, 5 skipped — the skips need DSP firmware I don't have). I haven't added unit tests for `GuessCmdRenderProperties` here; happy to follow up with some if you'd like them.

### AI disclosure

Per the project's AI use policy: I used an LLM to help debug. It helped me trace the artifact back from the framebuffer contents to the swallowed command list, and identify `enable_for_frame` as the reason the disabler was live during boot. I've reproduced that chain myself. The before/after captures and the block counts above were my own manual verification before opening this.

The code changes were LLM-assisted as well. They're small and mechanical: one default flipped, a bool added to a struct, a two-case switch arm, two null checks, and one extra condition on an existing `if`.
