### PR TITLE
video_core: Only suppress command lists that issue geometry

### DIFF
--- a/src/video_core/pica/pica_core.cpp
+++ b/src/video_core/pica/pica_core.cpp
@@ -1182,16 +1182,19 @@ void PicaCore::LoadVertices(bool is_indexed) {
 }
 
 PicaCore::RenderPropertiesGuess PicaCore::GuessCmdRenderProperties(PAddr list, u32 size) {
-    // Initialize command list tracking.
-    const u8* head = memory.GetPhysicalPointer(list);
-    cmd_list.Reset(list, head, size);
-
     constexpr size_t max_iterations = 0x100;
 
     RenderPropertiesGuess find_info{};
 
     find_info.vp_height = regs.internal.rasterizer.viewport_size_y.Value();
     find_info.paddr = regs.internal.framebuffer.framebuffer.color_buffer_address.Value() * 8;
+
+    // Initialize command list tracking.
+    const u8* head = memory.GetPhysicalPointer(list);
+    if (head == nullptr) {
+        return find_info;
+    }
+    cmd_list.Reset(list, head, size);
 
     auto process_write = [this, &find_info](u32 cmd_id, u32 value) {
         switch (cmd_id) {
@@ -1203,6 +1206,10 @@ PicaCore::RenderPropertiesGuess PicaCore::GuessCmdRenderProperties(PAddr list, u
             find_info.paddr = value * 8;
             find_info.paddr_found = true;
             break;
+        case PICA_REG_INDEX(pipeline.trigger_draw):
+        case PICA_REG_INDEX(pipeline.trigger_draw_indexed):
+            find_info.has_draw = true;
+            break;
         [[unlikely]] case PICA_REG_INDEX(pipeline.command_buffer.trigger[0]):
         [[unlikely]] case PICA_REG_INDEX(pipeline.command_buffer.trigger[1]): {
             const u32 index =
@@ -1210,13 +1217,15 @@ PicaCore::RenderPropertiesGuess PicaCore::GuessCmdRenderProperties(PAddr list, u
             const PAddr addr = regs.internal.pipeline.command_buffer.GetPhysicalAddress(index);
             const u32 size = regs.internal.pipeline.command_buffer.GetSize(index);
             const u8* head = memory.GetPhysicalPointer(addr);
-            cmd_list.Reset(addr, head, size);
+            if (head != nullptr) {
+                cmd_list.Reset(addr, head, size);
+            }
             break;
         }
         default:
             break;
         }
-        return find_info.vp_heigh_found && find_info.paddr_found;
+        return find_info.vp_heigh_found && find_info.paddr_found && find_info.has_draw;
     };
 
     size_t iterations = 0;

--- a/src/video_core/pica/pica_core.h
+++ b/src/video_core/pica/pica_core.h
@@ -398,6 +398,8 @@ public:
         PAddr paddr;
         bool vp_heigh_found = false;
         bool paddr_found = false;
+        // Whether the scanned list issues any geometry.
+        bool has_draw = false;
     };
 
     RenderPropertiesGuess GuessCmdRenderProperties(PAddr list, u32 size);

--- a/src/video_core/right_eye_disabler.cpp
+++ b/src/video_core/right_eye_disabler.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Azahar Emulator Project
+// Copyright 2024-2026 Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -21,7 +21,7 @@ bool RightEyeDisabler::ShouldAllowCmdQueueTrigger(PAddr addr, u32 size) {
     cmd_queue_trigger_happened = true;
 
     auto guess = gpu.impl->pica.GuessCmdRenderProperties(addr, size);
-    if (guess.vp_height == top_screen_size && !top_screen_blocked) {
+    if (guess.has_draw && guess.vp_height == top_screen_size && !top_screen_blocked) {
         if (top_screen_buf == 0) {
             top_screen_buf = guess.paddr;
         }


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Follow-up to #2459. That PR stopped `RightEyeDisabler` from acting during boot before its setting has been read, which is what made GB/GBC Virtual Console titles leave menu graphics in the top screen's pillarbox regions. It fixed the symptom for the default configuration, where the disabler now never engages at all.

This PR fixes the misclassification underneath it, which still applies to anyone who turns `disable_right_eye_render` on.

### Diagnosis

`GuessCmdRenderProperties()` seeds `vp_height` and `paddr` from whatever is currently in the registers, and only overwrites them if the scanned list writes those registers itself. It already records whether each value genuinely came from the list (`vp_heigh_found`, `paddr_found`), but `ShouldAllowCmdQueueTrigger()` ignored those flags.

So a command list that only sets state gets classified using the *previous* pass's viewport. In the Virtual Console case, the app submits a small list whose only job is to point the color buffer at the bottom screen's render target before drawing the VC menu there. That list never touches the viewport, so it inherited the top screen's viewport height, was judged a repeat render of the top screen, and was dropped. The color buffer never moved and the menu was drawn into the top screen's compose buffer instead.

### The change

I added a `has_draw` flag to `RenderPropertiesGuess` and made `ShouldAllowCmdQueueTrigger()` require it before suppressing anything. A list that issues no geometry produces no pixels, so blocking it can never save work -- it can only throw away state that later lists depend on. The condition is strictly narrower than before, so this cannot suppress a list that was previously allowed.

I checked that this doesn't neuter the optimization. On Ocarina of Time 3D with 3D enabled, the disabler still blocks 4141 lists per run versus 4441 before -- the ~300 difference being the state-only lists it now lets through. On Luigi's Mansion 2, which the `RIGHT_EYE_DISABLE` hack list already disallows, blocking drops from 4601 to zero. I can't prove it, but that makes me suspect at least some of those hack-list entries exist because of this same misclassification. I've left the list alone.

The same commit also null-checks the two places a scanned list address gets turned into a pointer, [which can be emitted here](https://github.com/azahar-emu/azahar/blob/master/src/core/memory.cpp#L940-L949). `CommandList::Reset()` only does a `reinterpret_cast`, so an unmapped address would be dereferenced on the next read. That was already true, but it matters more now that the scan doesn't stop as soon as `vp_height` and `paddr` are known and can therefore follow more nested command buffer jumps.

### Testing

Tested with Pokémon Crystal VC on both Vulkan and OpenGL, with `disable_right_eye_render` on and off, and confirmed the top screen's pillarbox regions stay black in all four combinations.

Ocarina of Time 3D and Luigi's Mansion 2 render identically with and without the change, with the option on and off. For Luigi's Mansion 2 I temporarily flipped its hack-list entry to `ALLOW` so the disabler would actually engage.

Existing test suite still passes (65 passed, 5 skipped -- the skips need DSP firmware I don't have). I haven't added unit tests for `GuessCmdRenderProperties()` here; happy to follow up with some if you'd like them.

### AI disclosure

Per the project's AI use policy: I used an LLM to help debug. It helped me trace the artifact back from the framebuffer contents to the swallowed command list, and identify the ignored `vp_heigh_found`/`paddr_found` flags as the reason a state-only list was being misclassified. I've reproduced that chain myself. The block counts above were my own manual verification before opening this.

The code changes were LLM-assisted as well. They're small and mechanical: a bool added to a struct, a two-case switch arm, two null checks, and one extra condition on an existing `if`.