### PR TITLE
android: Adjust default portrait button layout face button positioning

### DIFF
--- a/src/android/app/src/main/res/values/integers.xml
+++ b/src/android/app/src/main/res/values/integers.xml
@@ -40,13 +40,13 @@
 
     <!-- Default N3DS portrait layout -->
     <integer name="N3DS_BUTTON_A_PORTRAIT_X">810</integer>
-    <integer name="N3DS_BUTTON_A_PORTRAIT_Y">870</integer>
+    <integer name="N3DS_BUTTON_A_PORTRAIT_Y">850</integer>
     <integer name="N3DS_BUTTON_B_PORTRAIT_X">710</integer>
-    <integer name="N3DS_BUTTON_B_PORTRAIT_Y">925</integer>
+    <integer name="N3DS_BUTTON_B_PORTRAIT_Y">905</integer>
     <integer name="N3DS_BUTTON_X_PORTRAIT_X">710</integer>
-    <integer name="N3DS_BUTTON_X_PORTRAIT_Y">815</integer>
+    <integer name="N3DS_BUTTON_X_PORTRAIT_Y">795</integer>
     <integer name="N3DS_BUTTON_Y_PORTRAIT_X">610</integer>
-    <integer name="N3DS_BUTTON_Y_PORTRAIT_Y">870</integer>
+    <integer name="N3DS_BUTTON_Y_PORTRAIT_Y">850</integer>
     <integer name="N3DS_BUTTON_UP_PORTRAIT_X">10</integer>
     <integer name="N3DS_BUTTON_UP_PORTRAIT_Y">730</integer>
     <integer name="N3DS_TRIGGER_L_PORTRAIT_X">10</integer>


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Moves the face buttons upwards slightly to account for slight positioning changes after the Android 17 edge-to-edge migration introduced for 2126.1. Improves ergonomics slightly in the default layout.
