### PR TITLE
build: skip the pre-commit hook install in linked worktrees

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,7 +222,8 @@ if (CITRA_USE_PRECOMPILED_HEADERS)
     endif()
 endif()
 
-if(NOT EXISTS ${PROJECT_SOURCE_DIR}/.git/hooks/pre-commit)
+# In a linked worktree .git is a file, not a directory; hooks come from the common gitdir.
+if(IS_DIRECTORY ${PROJECT_SOURCE_DIR}/.git AND NOT EXISTS ${PROJECT_SOURCE_DIR}/.git/hooks/pre-commit)
     message(STATUS "Copying pre-commit hook")
     file(COPY hooks/pre-commit
         DESTINATION ${PROJECT_SOURCE_DIR}/.git/hooks)

--- a/CMakeModules/GenerateBuildInfo.cmake
+++ b/CMakeModules/GenerateBuildInfo.cmake
@@ -15,13 +15,24 @@ macro(generate_build_info)
         string(STRIP "${GIT_REV_RAW}" GIT_REV)
         string(SUBSTRING "${GIT_REV_RAW}" 0 9 GIT_DESC)
         set(GIT_BRANCH "HEAD")
-    elseif (EXISTS "${CMAKE_SOURCE_DIR}/.git/objects")
+    # A linked worktree has a .git file pointing at the real gitdir, not a .git directory, so
+    # testing for objects/ inside it silently downgrades every worktree build to "UNKNOWN".
+    elseif (EXISTS "${CMAKE_SOURCE_DIR}/.git")
         # Find the package here with the known path so that the GetGit commands can find it as well
         find_package(Git QUIET PATHS "${GIT_EXECUTABLE}")
 
         # only use Git to check revision info when source is obtained via Git
         include(GetGitRevisionDescription)
         get_git_head_revision(GIT_REF_SPEC GIT_REV)
+        # In a linked worktree HEAD lives in the worktree's own gitdir, but the ref it names does
+        # not, so the lookup above finds no hash. Ask git, which knows where to look.
+        if (NOT GIT_REV MATCHES "^[0-9a-f]+$")
+            execute_process(COMMAND "${GIT_EXECUTABLE}" rev-parse HEAD
+                            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                            OUTPUT_VARIABLE GIT_REV
+                            OUTPUT_STRIP_TRAILING_WHITESPACE
+                            ERROR_QUIET)
+        endif()
         git_describe(GIT_DESC --always --long --dirty)
         git_branch_name(GIT_BRANCH)
         if (DEFINED ENV{CITRA_USE_TAG_AS_VERSION})


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

CMake copies hooks/pre-commit into .git/hooks, but in a linked worktree .git is a file rather than a directory, so .git/hooks does not exist and configuring fails. Worktrees inherit hooks from the common gitdir, so skipping the install there is correct.

I actually added a second commit to fix the "Azahar UNKNOWN" when building from a worktree- also a CMake config.