### PR TITLE
video_core: preserve SurfaceBase state for OpenGL custom surfaces

### DIFF
--- a/src/video_core/renderer_opengl/gl_texture_runtime.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_runtime.cpp
@@ -364,7 +364,7 @@ Surface::Surface(TextureRuntime& runtime_, const VideoCore::SurfaceParams& param
 
 Surface::Surface(TextureRuntime& runtime_, const VideoCore::SurfaceBase& surface,
                  const VideoCore::Material* mat)
-    : SurfaceBase{surface, {}}, driver{&runtime_.GetDriver()}, runtime{&runtime_},
+    : SurfaceBase{surface}, driver{&runtime_.GetDriver()}, runtime{&runtime_},
       tuple{runtime_.GetFormatTuple(mat->format)} {
     if (mat && !driver->IsCustomFormatSupported(mat->format)) {
         return;


### PR DESCRIPTION
## Summary

Preserve the complete `SurfaceBase` state when creating an OpenGL surface for a custom texture.

The OpenGL custom surface constructor currently uses:

```cpp
SurfaceBase{surface, {}}
```

while the equivalent Vulkan implementation uses:

```cpp
SurfaceBase{surface}
```

Passing an empty flag set causes the replacement OpenGL surface to lose its existing surface flags, including `SurfaceFlagBits::Registered`.

This can later trigger the assertion:

```text
Assertion Failed!
Trying to unregister an already unregistered surface
```

when the surface is passed to `UnregisterSurface()`.

## Change

```diff
-    : SurfaceBase{surface, {}}, driver{&runtime_.GetDriver()}, runtime{&runtime_},
+    : SurfaceBase{surface}, driver{&runtime_.GetDriver()}, runtime{&runtime_},
```

This also makes the OpenGL custom surface constructor consistent with the Vulkan implementation.

## Testing

Tested on Azahar 2126.0 (`fbd3fb0`).

I reproduced the issue using:

- The Legend of Zelda: A Link Between Worlds
- OpenGL backend
- Henriko Magnifico's 4K texture pack
- Custom textures enabled
- 10x internal resolution

With the original code, the game consistently hit:

```text
Trying to unregister an already unregistered surface
```

With `SurfaceBase{surface}`, the game ran normally with the custom texture pack enabled.

The test ran for approximately 3 minutes and ended normally, with no:

```text
Assertion Failed
Trying to unregister an already unregistered surface
<Critical>
```

## AI disclosure

AI was used to assist with investigating the issue, suggesting the one-line change, and drafting parts of this pull request description.

I independently reproduced the issue, built the modified version, and verified the change at runtime on Azahar 2126.0 (`fbd3fb0`). The game ran normally with OpenGL and custom textures enabled, without reproducing the original assertion.

Fixes #2116

- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.