### PR TITLE
Feat/graceful guest shutdown

### DIFF
--- a/CMakeModules/GenerateSettingKeys.cmake
+++ b/CMakeModules/GenerateSettingKeys.cmake
@@ -14,6 +14,7 @@ foreach(KEY IN ITEMS
     "lle_applets"
     "deterministic_async_operations"
     "enable_required_online_lle_modules"
+    "notify_guest_on_shutdown"
     "use_virtual_sd"
     "use_custom_storage"
     "compress_cia_installs"

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/SettingKeys.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/SettingKeys.kt
@@ -16,6 +16,7 @@ object SettingKeys {
     external fun lle_applets(): String
     external fun deterministic_async_operations(): String
     external fun enable_required_online_lle_modules(): String
+    external fun notify_guest_on_shutdown(): String
     external fun use_virtual_sd(): String
     external fun compress_cia_installs(): String
     external fun async_fs_operations(): String

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
@@ -109,6 +109,11 @@ enum class BooleanSetting(
         Settings.SECTION_RENDERER,
         false
     ),
+    NOTIFY_GUEST_ON_SHUTDOWN(
+        SettingKeys.notify_guest_on_shutdown(),
+        Settings.SECTION_SYSTEM,
+        false
+    ),
     USE_ARTIC_BASE_CONTROLLER(
         SettingKeys.use_artic_base_controller(),
         Settings.SECTION_CONTROLS,

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -373,6 +373,15 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
             )
             add(
                 SwitchSetting(
+                    BooleanSetting.NOTIFY_GUEST_ON_SHUTDOWN,
+                    R.string.notify_guest_on_shutdown,
+                    R.string.notify_guest_on_shutdown_desc,
+                    BooleanSetting.NOTIFY_GUEST_ON_SHUTDOWN.key,
+                    BooleanSetting.NOTIFY_GUEST_ON_SHUTDOWN.defaultValue
+                )
+            )
+            add(
+                SwitchSetting(
                     BooleanSetting.REQUIRED_ONLINE_LLE_MODULES,
                     R.string.enable_required_online_lle_modules,
                     R.string.enable_required_online_lle_modules_desc,

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -258,6 +258,7 @@ void Config::ReadValues() {
     ReadSetting("System", Settings::values.is_new_3ds);
     ReadSetting("System", Settings::values.lle_applets);
     ReadSetting("System", Settings::values.enable_required_online_lle_modules);
+    ReadSetting("System", Settings::values.notify_guest_on_shutdown);
     ReadSetting("System", Settings::values.region_value);
     ReadSetting("System", Settings::values.init_clock);
     {

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -466,6 +466,11 @@ static const char* android_config_default_file_content = (BOOST_HANA_STRING(R"(
 # 0 (default): No, 1: Yes
 )") DECLARE_KEY(enable_required_online_lle_modules) BOOST_HANA_STRING(R"(
 
+# Whether to ask the application to save and exit before stopping emulation. Titles that buffer
+# their save, such as Virtual Console games, lose it otherwise; costs a short wait on every stop.
+# 0 (default): No, 1: Yes
+)") DECLARE_KEY(notify_guest_on_shutdown) BOOST_HANA_STRING(R"(
+
 # The system region that Citra will use during emulation
 # -1: Auto-select (default), 0: Japan, 1: USA, 2: Europe, 3: Australia, 4: China, 5: Korea, 6: Taiwan
 )") DECLARE_KEY(region_value) BOOST_HANA_STRING(R"(

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <chrono>
 #include <codecvt>
 #include <thread>
 #include <dlfcn.h>
@@ -35,10 +36,14 @@
 #include "common/scope_exit.h"
 #include "common/settings.h"
 #include "common/string_util.h"
+#include "common/thread.h"
 #include "core/core.h"
 #include "core/frontend/applets/default_applets.h"
 #include "core/frontend/camera/factory.h"
+#include "core/hle/kernel/kernel.h"
 #include "core/hle/service/am/am.h"
+#include "core/hle/service/apt/applet_manager.h"
+#include "core/hle/service/apt/apt.h"
 #include "core/hle/service/fs/archive.h"
 #include "core/hle/service/nfc/nfc.h"
 #include "core/hw/unique_data.h"
@@ -102,6 +107,11 @@ std::atomic<bool> pause_emulation{false};
 std::mutex paused_mutex;
 std::mutex running_mutex;
 std::condition_variable running_cv;
+
+// Signaled once the emulation thread leaves RunCitra, so a stop can wait for the guest.
+std::atomic<bool> emulation_finished{true};
+std::mutex emulation_finished_mutex;
+std::condition_variable emulation_finished_cv;
 
 // Guards the lifetime of s_surface/s_secondary_surface and the (re)creation of the
 // EmuWindow_Android and renderer objects that consume them. Android may destroy or replace the
@@ -857,8 +867,56 @@ void Java_org_citra_citra_1emu_NativeLibrary_pauseEmulation([[maybe_unused]] JNI
     }
 }
 
+// stopEmulation() runs on the UI thread, so this is a freeze budget, not a save budget.
+constexpr int GUEST_SHUTDOWN_TIMEOUT_MS = 1000;
+constexpr int HLE_LOCK_TIMEOUT_MS = 250;
+
+/// Android port of GMainWindow::RequestGuestShutdown().
+static void RequestGuestShutdown() {
+    Core::System& system{Core::System::GetInstance()};
+    if (stop_run || !system.IsPoweredOn()) {
+        return;
+    }
+
+    // A paused loop never sees the notification; paused_mutex keeps the wakeup from being missed.
+    {
+        std::scoped_lock pause_guard{paused_mutex};
+        pause_emulation = false;
+    }
+    running_cv.notify_all();
+
+    {
+        // Ordering rules as in GMainWindow::RequestGuestShutdown(), src/citra_qt/citra_qt.cpp.
+        std::scoped_lock session_guard{system.GetSessionLock()};
+        if (!system.IsPoweredOn()) {
+            return;
+        }
+
+        std::unique_lock hle_guard{system.Kernel().GetHLELock(), std::defer_lock};
+        if (!Common::TryLockFor(hle_guard, HLE_LOCK_TIMEOUT_MS)) {
+            LOG_WARNING(Frontend, "HLE lock still held, stopping without notifying the guest");
+            return;
+        }
+
+        auto apt = Service::APT::GetModule(system);
+        if (!apt) {
+            return;
+        }
+        apt->GetAppletManager()->SendNotificationToAll(Service::APT::Notification::Shutdown);
+    }
+
+    std::unique_lock lock{emulation_finished_mutex};
+    const bool clean =
+        emulation_finished_cv.wait_for(lock, std::chrono::milliseconds(GUEST_SHUTDOWN_TIMEOUT_MS),
+                                       [] { return emulation_finished.load(); });
+    LOG_INFO(Frontend, "Guest shutdown {} after notification",
+             clean ? "completed cleanly" : "timed out; forcing stop");
+}
+
 void Java_org_citra_citra_1emu_NativeLibrary_stopEmulation([[maybe_unused]] JNIEnv* env,
                                                            [[maybe_unused]] jobject obj) {
+    RequestGuestShutdown();
+
     if (stop_run.exchange(true)) {
         // stop_run was already true
         return;
@@ -1055,7 +1113,17 @@ void Java_org_citra_citra_1emu_NativeLibrary_run__Ljava_lang_String_2(JNIEnv* en
         running_cv.notify_all();
     }
 
+    {
+        std::scoped_lock lock{emulation_finished_mutex};
+        emulation_finished = false;
+    }
     const Core::System::ResultStatus result{RunCitra(path)};
+    {
+        std::scoped_lock lock{emulation_finished_mutex};
+        emulation_finished = true;
+    }
+    emulation_finished_cv.notify_all();
+
     if (result != Core::System::ResultStatus::Success) {
         env->CallStaticVoidMethod(IDCache::GetNativeLibraryClass(),
                                   IDCache::GetExitEmulationActivity(), static_cast<int>(result));

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -40,6 +40,7 @@
 #include "core/core.h"
 #include "core/frontend/applets/default_applets.h"
 #include "core/frontend/camera/factory.h"
+#include "core/guest_shutdown.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/service/am/am.h"
 #include "core/hle/service/apt/applet_manager.h"
@@ -867,50 +868,39 @@ void Java_org_citra_citra_1emu_NativeLibrary_pauseEmulation([[maybe_unused]] JNI
     }
 }
 
-// stopEmulation() runs on the UI thread, so this is a freeze budget, not a save budget.
-constexpr int GUEST_SHUTDOWN_TIMEOUT_MS = 1000;
-constexpr int HLE_LOCK_TIMEOUT_MS = 250;
+// stopEmulation() runs on the UI thread, so this is a freeze budget, not a save budget. It also
+// caps the save data copy, which is otherwise as large as the title's save directory.
+constexpr auto GUEST_SHUTDOWN_TIMEOUT = std::chrono::milliseconds(1000);
+// Android kills an app that stops answering input for 5s. The copy is charged against this, so
+// the whole call returns within the ceiling however long the copy takes.
+constexpr auto GUEST_SHUTDOWN_MID_SAVE_CEILING = std::chrono::milliseconds(2500);
 
-/// Android port of GMainWindow::RequestGuestShutdown().
+/// Android side of Core::PerformGuestShutdown(); only the wait differs from
+/// GMainWindow::RequestGuestShutdown() in src/citra_qt/citra_qt.cpp.
 static void RequestGuestShutdown() {
     Core::System& system{Core::System::GetInstance()};
     if (stop_run || !system.IsPoweredOn()) {
         return;
     }
 
-    // A paused loop never sees the notification; paused_mutex keeps the wakeup from being missed.
-    {
-        std::scoped_lock pause_guard{paused_mutex};
-        pause_emulation = false;
-    }
-    running_cv.notify_all();
-
-    {
-        // Ordering rules as in GMainWindow::RequestGuestShutdown(), src/citra_qt/citra_qt.cpp.
-        std::scoped_lock session_guard{system.GetSessionLock()};
-        if (!system.IsPoweredOn()) {
-            return;
-        }
-
-        std::unique_lock hle_guard{system.Kernel().GetHLELock(), std::defer_lock};
-        if (!Common::TryLockFor(hle_guard, HLE_LOCK_TIMEOUT_MS)) {
-            LOG_WARNING(Frontend, "HLE lock still held, stopping without notifying the guest");
-            return;
-        }
-
-        auto apt = Service::APT::GetModule(system);
-        if (!apt) {
-            return;
-        }
-        apt->GetAppletManager()->SendNotificationToAll(Service::APT::Notification::Shutdown);
-    }
-
-    std::unique_lock lock{emulation_finished_mutex};
-    const bool clean =
-        emulation_finished_cv.wait_for(lock, std::chrono::milliseconds(GUEST_SHUTDOWN_TIMEOUT_MS),
-                                       [] { return emulation_finished.load(); });
-    LOG_INFO(Frontend, "Guest shutdown {} after notification",
-             clean ? "completed cleanly" : "timed out; forcing stop");
+    const Core::GuestShutdownTimeouts timeouts{GUEST_SHUTDOWN_TIMEOUT,
+                                               GUEST_SHUTDOWN_MID_SAVE_CEILING};
+    Core::PerformGuestShutdown(
+        system, timeouts,
+        [](std::chrono::milliseconds slice) {
+            std::unique_lock lock{emulation_finished_mutex};
+            return emulation_finished_cv.wait_for(lock, slice,
+                                                  [] { return emulation_finished.load(); });
+        },
+        [] {
+            // A paused loop never sees the notification; paused_mutex keeps the wakeup from being
+            // missed.
+            {
+                std::scoped_lock pause_guard{paused_mutex};
+                pause_emulation = false;
+            }
+            running_cv.notify_all();
+        });
 }
 
 void Java_org_citra_citra_1emu_NativeLibrary_stopEmulation([[maybe_unused]] JNIEnv* env,

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -213,6 +213,8 @@
     <string name="apply_region_free_patch_desc">Patches the region of installed applications to be region free, so that they always appear on the home menu.</string>
     <string name="enable_required_online_lle_modules">Enable required LLE modules for online features (if installed)</string>
     <string name="enable_required_online_lle_modules_desc">Enables the LLE modules required for online multiplayer, eShop access, etc.</string>
+    <string name="notify_guest_on_shutdown">Let the application save before stopping</string>
+    <string name="notify_guest_on_shutdown_desc">Asks the application to save and exit when emulation is stopped, as a real console does on power-off. Titles that only write their save periodically, such as Virtual Console games, lose progress without this. Stopping takes a little longer.</string>
     <string name="clock">Clock</string>
     <string name="init_clock">Clock</string>
     <string name="init_clock_description">Set the emulated 3DS clock to either reflect that of your device or start at a simulated date and time.</string>

--- a/src/citra_libretro/citra_libretro.cpp
+++ b/src/citra_libretro/citra_libretro.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <chrono>
 #include <list>
 #include <numeric>
 #include <vector>
@@ -44,6 +45,7 @@
 #include "core/core.h"
 #include "core/frontend/applets/default_applets.h"
 #include "core/frontend/image_interface.h"
+#include "core/guest_shutdown.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/memory.h"
 #include "core/hle/kernel/process.h"
@@ -490,8 +492,41 @@ static void context_destroy() {
     emu_instance->emu_window->DestroyContext();
 }
 
+/// The guest is driven from retro_run() on the frontend's own thread, so blocking here would
+/// freeze the frontend for as long as it takes. Kept close to the Android budget for that reason.
+static constexpr Core::GuestShutdownTimeouts GUEST_SHUTDOWN_TIMEOUTS{
+    std::chrono::milliseconds(1000), std::chrono::milliseconds(3000)};
+
+/// libretro side of Core::PerformGuestShutdown(). There is no emulation thread to wait on here:
+/// retro_run() advances the guest itself, so the wait has to do the same, as
+/// DrainAsyncOperations() does. Presentation is suppressed throughout, since the frontend is not
+/// expecting frames from us outside retro_run().
+static void RequestGuestShutdown() {
+    auto& system = Core::System::GetInstance();
+    if (!system.IsPoweredOn() || !system.KernelRunning()) {
+        return;
+    }
+
+    emu_instance->emu_window->suppressPresentation = true;
+    Core::PerformGuestShutdown(
+        system, GUEST_SHUTDOWN_TIMEOUTS, [&system](std::chrono::milliseconds slice) {
+            const auto deadline = std::chrono::steady_clock::now() + slice;
+            do {
+                // Anything but Success means the guest is done running, whether it exited as
+                // asked or fell over; either way there is nothing left to wait for.
+                if (system.RunLoop() != Core::System::ResultStatus::Success) {
+                    return true;
+                }
+            } while (std::chrono::steady_clock::now() < deadline);
+            return false;
+        });
+    emu_instance->emu_window->suppressPresentation = false;
+}
+
 void retro_reset() {
     LOG_DEBUG(Frontend, "retro_reset");
+    // A reset tears an in-flight save exactly as a stop does.
+    RequestGuestShutdown();
     Core::System::GetInstance().Shutdown();
     emu_instance->game_loaded = do_load_game();
     emu_instance->first_run_loop = true;
@@ -634,6 +669,7 @@ bool retro_load_game(const struct retro_game_info* info) {
 
 void retro_unload_game() {
     LOG_DEBUG(Frontend, "Unloading game...");
+    RequestGuestShutdown();
     Core::System::GetInstance().Shutdown();
 }
 

--- a/src/citra_libretro/core_settings.cpp
+++ b/src/citra_libretro/core_settings.cpp
@@ -46,6 +46,8 @@ namespace system {
 static constexpr const char* is_new_3ds = citra_setting(BaseKeys::is_new_3ds);
 static constexpr const char* region_value = citra_setting(BaseKeys::region_value);
 static constexpr const char* language_value = citra_setting(BaseKeys::language_value);
+static constexpr const char* notify_guest_on_shutdown =
+    citra_setting(BaseKeys::notify_guest_on_shutdown);
 } // namespace system
 
 namespace audio {
@@ -194,6 +196,22 @@ static constexpr retro_core_option_v2_definition option_definitions[] = {
             { nullptr, nullptr }
         },
         "New 3DS"
+    },
+    {
+        config::system::notify_guest_on_shutdown,
+        "Let the Application Save Before Stopping",
+        "Save Before Stopping",
+        "Ask the application to save and exit when content is unloaded or reset, as a real "
+        "console does on power-off. Titles that only write their save periodically, such as "
+        "Virtual Console games, lose progress without this. Unloading takes a little longer.",
+        nullptr,
+        config::category::system,
+        {
+            { config::enabled, "Enabled" },
+            { config::disabled, "Disabled" },
+            { nullptr, nullptr }
+        },
+        config::disabled
     },
     {
         config::system::region_value,
@@ -887,6 +905,10 @@ static void ParseSystemOptions(void) {
 
     LibRetro::settings.language_value =
         GetLanguageValue(LibRetro::FetchVariable(config::system::language_value, "English"));
+
+    Settings::values.notify_guest_on_shutdown =
+        LibRetro::FetchVariable(config::system::notify_guest_on_shutdown, config::disabled) ==
+        config::enabled;
 }
 
 static Settings::AudioEmulation GetAudioEmulation(const std::string& name) {

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -113,6 +113,9 @@ void EmuThread::run() {
 
             const Core::System::ResultStatus result = system.RunLoop();
             if (result == Core::System::ResultStatus::ShutdownRequested) {
+                // Set before the signal: the slot runs on the GUI thread while this one has yet to
+                // reach System::Shutdown(), so IsPoweredOn() alone still reports a live session.
+                guest_exiting = true;
                 // Notify frontend we shutdown
                 emit ErrorThrown(result, "");
                 // End emulation execution

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -70,6 +70,15 @@ public:
     }
 
     /**
+     * Check whether the guest asked to exit and this thread is on its way out because of it
+     * @note This is set before ErrorThrown is emitted, so a slot handling that signal can tell a
+     *       guest-initiated exit from a frontend-initiated one. Thread-safe.
+     */
+    bool IsGuestExiting() const {
+        return guest_exiting;
+    }
+
+    /**
      * Requests for the emulation thread to stop running
      */
     void RequestStop() {
@@ -81,6 +90,7 @@ private:
     bool exec_step = false;
     bool running = false;
     std::atomic<bool> stop_run{false};
+    std::atomic<bool> guest_exiting{false};
     std::mutex running_mutex;
     std::condition_variable running_cv;
 

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -119,6 +119,7 @@
 #include "core/file_sys/archive_extsavedata.h"
 #include "core/file_sys/archive_source_sd_savedata.h"
 #include "core/frontend/applets/default_applets.h"
+#include "core/guest_shutdown.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/service/am/am.h"
 #include "core/hle/service/apt/applet_manager.h"
@@ -1728,7 +1729,8 @@ void GMainWindow::OnUnixTerminationSignal() {
 
 #ifdef _WIN32
 /// Windows kills us a few seconds into a session end, so the guest gets less than usual.
-static constexpr int SESSION_END_SHUTDOWN_TIMEOUT_MS = 1500;
+static constexpr Core::GuestShutdownTimeouts SESSION_END_SHUTDOWN_TIMEOUTS{
+    std::chrono::milliseconds(1500), std::chrono::milliseconds(3500)};
 
 void GMainWindow::SetupWindowsSessionHandler() {
     // Windows has no POSIX signals; shutdown and logoff arrive as WM_QUERYENDSESSION.
@@ -1746,7 +1748,7 @@ void GMainWindow::OnWindowsSessionEnd(QSessionManager& manager) {
     // What closeEvent() does, minus closing the windows: Qt forbids close() from a session end.
     PersistUISettings();
     if (emulation_running) {
-        ShutdownGame(SESSION_END_SHUTDOWN_TIMEOUT_MS);
+        ShutdownGame(SESSION_END_SHUTDOWN_TIMEOUTS);
     }
     config->Save();
     // A room that is never told we are leaving sees a dead peer instead of a clean departure.
@@ -1754,65 +1756,44 @@ void GMainWindow::OnWindowsSessionEnd(QSessionManager& manager) {
 }
 #endif
 
-/// Upper bound on the wait for the guest to save and exit before we force a stop.
-static constexpr int GUEST_SHUTDOWN_TIMEOUT_MS = 3000;
-/// How often that wait comes up for air to deliver events the guest may be blocked on.
-static constexpr int GUEST_SHUTDOWN_POLL_MS = 50;
-/// Upper bound on the wait for an in-flight SVC to give the HLE lock back.
-static constexpr int HLE_LOCK_TIMEOUT_MS = 250;
+/// How long the guest gets to save and exit, and the same again while it is still writing.
+static constexpr Core::GuestShutdownTimeouts GUEST_SHUTDOWN_TIMEOUTS{
+    std::chrono::milliseconds(3000), std::chrono::milliseconds(10000)};
 
-void GMainWindow::RequestGuestShutdown(int timeout_ms) {
+void GMainWindow::RequestGuestShutdown(Core::GuestShutdownTimeouts timeouts) {
     // The guest exiting calls us again once the core is gone, hence IsPoweredOn().
     if (!emulation_running || !emu_thread || guest_shutdown_requested || !system.IsPoweredOn()) {
         return;
     }
+    // IsPoweredOn() does not cover a guest-initiated exit: EmuThread::run() in
+    // src/citra_qt/bootmanager.cpp emits ErrorThrown before System::Shutdown(), so the queued
+    // OnCoreError() runs while the session still reports powered on.
+    if (emu_thread->IsGuestExiting()) {
+        return;
+    }
     guest_shutdown_requested = true;
 
-    // Pausing parks the emulation thread in the frame limiter, so both have to be undone.
-    system.frame_limiter.SetFrameAdvancing(false);
-    emu_thread->SetRunning(true);
-
-    {
-        // Held across the IsPoweredOn() check. Both locks and the reference go before the wait:
-        // System::Shutdown() runs on the emu thread and frees what they guard.
-        std::scoped_lock session_guard{system.GetSessionLock()};
-        if (!system.IsPoweredOn()) {
-            return;
-        }
-
-        // An applet dialog holds the HLE lock while blocking on us, so never wait on it forever.
-        std::unique_lock hle_guard{system.Kernel().GetHLELock(), std::defer_lock};
-        if (!Common::TryLockFor(hle_guard, HLE_LOCK_TIMEOUT_MS)) {
-            LOG_WARNING(Frontend, "HLE lock still held, stopping without notifying the guest");
-            return;
-        }
-
-        auto apt = Service::APT::GetModule(system);
-        if (!apt) {
-            return;
-        }
-        apt->GetAppletManager()->SendNotificationToAll(Service::APT::Notification::Shutdown);
-    }
-
-    // The guest runs on through this wait and can post a Qt::BlockingQueuedConnection metacall
-    // (software keyboard, Mii selector, camera), which deadlocks against a GUI thread parked in
-    // wait(). User input stays queued, so nothing re-enters ShutdownGame() while we are in here.
-    bool clean = false;
-    const auto deadline =
-        std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
-    do {
-        QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
-        clean = emu_thread->wait(GUEST_SHUTDOWN_POLL_MS);
-    } while (!clean && std::chrono::steady_clock::now() < deadline);
-    LOG_INFO(Frontend, "Guest shutdown {} after notification",
-             clean ? "completed cleanly" : "timed out; forcing stop");
+    Core::PerformGuestShutdown(
+        system, timeouts,
+        [this](std::chrono::milliseconds slice) {
+            // The guest can post a Qt::BlockingQueuedConnection metacall (swkbd, Mii, camera)
+            // that deadlocks against a GUI thread parked in wait(). User input stays queued.
+            QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
+            return emu_thread->wait(static_cast<unsigned long>(slice.count()));
+        },
+        [this] {
+            // Pausing parks the emulation thread in the frame limiter; both have to be undone
+            // before it can see the notification.
+            system.frame_limiter.SetFrameAdvancing(false);
+            emu_thread->SetRunning(true);
+        });
 }
 
 void GMainWindow::ShutdownGame() {
-    ShutdownGame(GUEST_SHUTDOWN_TIMEOUT_MS);
+    ShutdownGame(GUEST_SHUTDOWN_TIMEOUTS);
 }
 
-void GMainWindow::ShutdownGame(int guest_timeout_ms) {
+void GMainWindow::ShutdownGame(Core::GuestShutdownTimeouts guest_timeouts) {
     // RequestGuestShutdown() pumps events, so the guest exiting can re-enter us via OnCoreError().
     if (!emulation_running || shutting_down) {
         return;
@@ -1837,7 +1818,8 @@ void GMainWindow::ShutdownGame(int guest_timeout_ms) {
 
     shutting_down = true;
 
-    RequestGuestShutdown(guest_timeout_ms);
+    // Virtual Console titles flush their SRAM on a long timer; stopping outright loses it.
+    RequestGuestShutdown(guest_timeouts);
 
     emu_thread->RequestStop();
 

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -18,6 +18,9 @@
 #include <QMessageBox>
 #include <QPalette>
 #include <QSocketNotifier>
+#ifdef _WIN32
+#include <QSessionManager>
+#endif
 #include <QSysInfo>
 #include <QtConcurrent/QtConcurrentMap>
 #include <QtConcurrent/QtConcurrentRun>
@@ -503,6 +506,9 @@ GMainWindow::GMainWindow(Core::System& system_)
 
 #if defined(__unix__) || defined(__APPLE__)
     SetupUnixSignalHandlers();
+#endif
+#ifdef _WIN32
+    SetupWindowsSessionHandler();
 #endif
 
     show();
@@ -1720,6 +1726,34 @@ void GMainWindow::OnUnixTerminationSignal() {
 }
 #endif
 
+#ifdef _WIN32
+/// Windows kills us a few seconds into a session end, so the guest gets less than usual.
+static constexpr int SESSION_END_SHUTDOWN_TIMEOUT_MS = 1500;
+
+void GMainWindow::SetupWindowsSessionHandler() {
+    // Windows has no POSIX signals; shutdown and logoff arrive as WM_QUERYENDSESSION.
+    connect(qApp, &QGuiApplication::commitDataRequest, this, &GMainWindow::OnWindowsSessionEnd,
+            Qt::DirectConnection);
+}
+
+void GMainWindow::OnWindowsSessionEnd(QSessionManager& manager) {
+    manager.setRestartHint(QSessionManager::RestartNever);
+
+    LOG_INFO(Frontend, "Session ending, shutting the guest down cleanly");
+    // Only the query phase is exposed, so a veto elsewhere still costs the running game.
+    force_close = true;
+
+    // What closeEvent() does, minus closing the windows: Qt forbids close() from a session end.
+    PersistUISettings();
+    if (emulation_running) {
+        ShutdownGame(SESSION_END_SHUTDOWN_TIMEOUT_MS);
+    }
+    config->Save();
+    // A room that is never told we are leaving sees a dead peer instead of a clean departure.
+    ReleaseExternalResources();
+}
+#endif
+
 /// Upper bound on the wait for the guest to save and exit before we force a stop.
 static constexpr int GUEST_SHUTDOWN_TIMEOUT_MS = 3000;
 /// How often that wait comes up for air to deliver events the guest may be blocked on.
@@ -1727,7 +1761,7 @@ static constexpr int GUEST_SHUTDOWN_POLL_MS = 50;
 /// Upper bound on the wait for an in-flight SVC to give the HLE lock back.
 static constexpr int HLE_LOCK_TIMEOUT_MS = 250;
 
-void GMainWindow::RequestGuestShutdown() {
+void GMainWindow::RequestGuestShutdown(int timeout_ms) {
     // The guest exiting calls us again once the core is gone, hence IsPoweredOn().
     if (!emulation_running || !emu_thread || guest_shutdown_requested || !system.IsPoweredOn()) {
         return;
@@ -1764,8 +1798,8 @@ void GMainWindow::RequestGuestShutdown() {
     // (software keyboard, Mii selector, camera), which deadlocks against a GUI thread parked in
     // wait(). User input stays queued, so nothing re-enters ShutdownGame() while we are in here.
     bool clean = false;
-    const auto deadline = std::chrono::steady_clock::now() +
-                          std::chrono::milliseconds(GUEST_SHUTDOWN_TIMEOUT_MS);
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
     do {
         QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
         clean = emu_thread->wait(GUEST_SHUTDOWN_POLL_MS);
@@ -1775,6 +1809,10 @@ void GMainWindow::RequestGuestShutdown() {
 }
 
 void GMainWindow::ShutdownGame() {
+    ShutdownGame(GUEST_SHUTDOWN_TIMEOUT_MS);
+}
+
+void GMainWindow::ShutdownGame(int guest_timeout_ms) {
     // RequestGuestShutdown() pumps events, so the guest exiting can re-enter us via OnCoreError().
     if (!emulation_running || shutting_down) {
         return;
@@ -1799,8 +1837,7 @@ void GMainWindow::ShutdownGame() {
 
     shutting_down = true;
 
-    // Virtual Console titles flush their SRAM on a long timer; stopping outright loses it.
-    RequestGuestShutdown();
+    RequestGuestShutdown(guest_timeout_ms);
 
     emu_thread->RequestStop();
 
@@ -4193,15 +4230,24 @@ bool GMainWindow::ConfirmClose() {
     return answer != QMessageBox::No;
 }
 
+void GMainWindow::PersistUISettings() {
+    UpdateUISettings();
+    game_list->SaveInterfaceLayout();
+    hotkey_registry.SaveHotkeys();
+}
+
+void GMainWindow::ReleaseExternalResources() {
+    multiplayer_state->Close();
+    InputCommon::Shutdown();
+}
+
 void GMainWindow::closeEvent(QCloseEvent* event) {
     if (!ConfirmClose()) {
         event->ignore();
         return;
     }
 
-    UpdateUISettings();
-    game_list->SaveInterfaceLayout();
-    hotkey_registry.SaveHotkeys();
+    PersistUISettings();
 
     // Shutdown session if the emu thread is active...
     if (emu_thread) {
@@ -4213,8 +4259,7 @@ void GMainWindow::closeEvent(QCloseEvent* event) {
 
     render_window->close();
     secondary_window->close();
-    multiplayer_state->Close();
-    InputCommon::Shutdown();
+    ReleaseExternalResources();
     QWidget::closeEvent(event);
 }
 

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -2,18 +2,22 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <chrono>
 #include <clocale>
 #include <iostream>
 #include <memory>
 #include <optional>
 #include <thread>
 #include <unordered_map>
+#include <QCoreApplication>
+#include <QEventLoop>
 #include <QFileDialog>
 #include <QFutureWatcher>
 #include <QIcon>
 #include <QLabel>
 #include <QMessageBox>
 #include <QPalette>
+#include <QSocketNotifier>
 #include <QSysInfo>
 #include <QtConcurrent/QtConcurrentMap>
 #include <QtConcurrent/QtConcurrentRun>
@@ -22,6 +26,12 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#if defined(__unix__) || defined(__APPLE__)
+#include <errno.h>
+#include <signal.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
 #ifdef __APPLE__
 #include <unistd.h> // for chdir
 #endif
@@ -98,6 +108,7 @@
 #endif
 #include "common/settings.h"
 #include "common/string_util.h"
+#include "common/thread.h"
 #include "common/zstd_compression.h"
 #include "core/arm/exception_handler.h"
 #include "core/core.h"
@@ -105,7 +116,10 @@
 #include "core/file_sys/archive_extsavedata.h"
 #include "core/file_sys/archive_source_sd_savedata.h"
 #include "core/frontend/applets/default_applets.h"
+#include "core/hle/kernel/kernel.h"
 #include "core/hle/service/am/am.h"
+#include "core/hle/service/apt/applet_manager.h"
+#include "core/hle/service/apt/apt.h"
 #include "core/hle/service/fs/archive.h"
 #include "core/hle/service/nfc/nfc.h"
 #include "core/loader/loader.h"
@@ -486,6 +500,10 @@ GMainWindow::GMainWindow(Core::System& system_)
     QIcon azahar_icon = QIcon(QString::fromStdString(":/icons/default/256x256/azahar.png"));
     render_window->setWindowIcon(azahar_icon);
     secondary_window->setWindowIcon(azahar_icon);
+
+#if defined(__unix__) || defined(__APPLE__)
+    SetupUnixSignalHandlers();
+#endif
 
     show();
 
@@ -1355,6 +1373,12 @@ void GMainWindow::AllowOSSleep() {
 }
 
 bool GMainWindow::LoadROM(const QString& filename) {
+    // ShutdownGame() refuses to re-enter itself, so it may not have ended the previous session.
+    if (shutting_down) {
+        LOG_WARNING(Frontend, "Ignoring load request while a shutdown is in progress");
+        return false;
+    }
+
     // Shutdown previous session if the emu thread is still active...
     if (emu_thread) {
         ShutdownGame();
@@ -1465,6 +1489,12 @@ bool GMainWindow::LoadROM(const QString& filename) {
 }
 
 void GMainWindow::BootGame(const QString& filename) {
+    // As in LoadROM(): booting over a live EmuThread double-initializes the core.
+    if (shutting_down) {
+        LOG_WARNING(Frontend, "Ignoring boot request while a shutdown is in progress");
+        return;
+    }
+
     if (emu_thread) {
         ShutdownGame();
     }
@@ -1613,6 +1643,7 @@ void GMainWindow::BootGame(const QString& filename) {
     loading_screen->Prepare(system.GetAppLoader());
     loading_screen->show();
 
+    guest_shutdown_requested = false;
     emulation_running = true;
     if (ui->action_Fullscreen->isChecked()) {
         ShowFullscreen();
@@ -1621,8 +1652,131 @@ void GMainWindow::BootGame(const QString& filename) {
     OnResumeGame(true);
 }
 
+#if defined(__unix__) || defined(__APPLE__)
+namespace {
+int g_signal_fd[2] = {-1, -1};
+
+void UnixTerminationHandler(int) {
+    // Only async-signal-safe calls belong here; the notifier does the real work.
+    const int saved_errno = errno;
+    const char byte = 1;
+    [[maybe_unused]] const auto ignored = ::write(g_signal_fd[0], &byte, sizeof(byte));
+    errno = saved_errno;
+}
+} // namespace
+
+void GMainWindow::SetupUnixSignalHandlers() {
+    if (::socketpair(AF_UNIX, SOCK_STREAM, 0, g_signal_fd) != 0) {
+        LOG_ERROR(Frontend, "Could not create socketpair for signal handling");
+        return;
+    }
+
+    struct sigaction sa{};
+    sa.sa_handler = UnixTerminationHandler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_RESTART;
+    if (::sigaction(SIGTERM, &sa, nullptr) != 0 || ::sigaction(SIGINT, &sa, nullptr) != 0) {
+        LOG_ERROR(Frontend, "Could not install termination signal handlers");
+        // One may have installed; undo both so nothing writes into a socket nobody reads.
+        ::signal(SIGTERM, SIG_DFL);
+        ::signal(SIGINT, SIG_DFL);
+        ::close(g_signal_fd[0]);
+        ::close(g_signal_fd[1]);
+        g_signal_fd[0] = g_signal_fd[1] = -1;
+        return;
+    }
+
+    unix_signal_notifier = new QSocketNotifier(g_signal_fd[1], QSocketNotifier::Read, this);
+    connect(unix_signal_notifier, &QSocketNotifier::activated, this,
+            &GMainWindow::OnUnixTerminationSignal);
+}
+
+void GMainWindow::OnUnixTerminationSignal() {
+    unix_signal_notifier->setEnabled(false);
+    char byte{};
+    [[maybe_unused]] const auto ignored = ::read(g_signal_fd[1], &byte, sizeof(byte));
+
+    // A second signal, or a logout's follow-up SIGTERM, has to be able to kill us.
+    ::signal(SIGTERM, SIG_DFL);
+    ::signal(SIGINT, SIG_DFL);
+
+    LOG_INFO(Frontend, "Termination signal received, shutting the guest down cleanly");
+    // BootGame() sets emu_thread before emulation_running, so a signal mid-boot could raise a
+    // modal nobody can answer.
+    force_close = true;
+
+    // QSocketNotifier activations survive ExcludeUserInputEvents, so this can arrive from inside
+    // RequestGuestShutdown()'s pump, where closeEvent() would tear the window down under the
+    // wait() further up the stack. Let the shutdown in progress close us as it unwinds.
+    if (shutting_down) {
+        close_when_shutdown_finishes = true;
+        return;
+    }
+
+    if (emulation_running) {
+        ShutdownGame();
+    }
+    close();
+}
+#endif
+
+/// Upper bound on the wait for the guest to save and exit before we force a stop.
+static constexpr int GUEST_SHUTDOWN_TIMEOUT_MS = 3000;
+/// How often that wait comes up for air to deliver events the guest may be blocked on.
+static constexpr int GUEST_SHUTDOWN_POLL_MS = 50;
+/// Upper bound on the wait for an in-flight SVC to give the HLE lock back.
+static constexpr int HLE_LOCK_TIMEOUT_MS = 250;
+
+void GMainWindow::RequestGuestShutdown() {
+    // The guest exiting calls us again once the core is gone, hence IsPoweredOn().
+    if (!emulation_running || !emu_thread || guest_shutdown_requested || !system.IsPoweredOn()) {
+        return;
+    }
+    guest_shutdown_requested = true;
+
+    // Pausing parks the emulation thread in the frame limiter, so both have to be undone.
+    system.frame_limiter.SetFrameAdvancing(false);
+    emu_thread->SetRunning(true);
+
+    {
+        // Held across the IsPoweredOn() check. Both locks and the reference go before the wait:
+        // System::Shutdown() runs on the emu thread and frees what they guard.
+        std::scoped_lock session_guard{system.GetSessionLock()};
+        if (!system.IsPoweredOn()) {
+            return;
+        }
+
+        // An applet dialog holds the HLE lock while blocking on us, so never wait on it forever.
+        std::unique_lock hle_guard{system.Kernel().GetHLELock(), std::defer_lock};
+        if (!Common::TryLockFor(hle_guard, HLE_LOCK_TIMEOUT_MS)) {
+            LOG_WARNING(Frontend, "HLE lock still held, stopping without notifying the guest");
+            return;
+        }
+
+        auto apt = Service::APT::GetModule(system);
+        if (!apt) {
+            return;
+        }
+        apt->GetAppletManager()->SendNotificationToAll(Service::APT::Notification::Shutdown);
+    }
+
+    // The guest runs on through this wait and can post a Qt::BlockingQueuedConnection metacall
+    // (software keyboard, Mii selector, camera), which deadlocks against a GUI thread parked in
+    // wait(). User input stays queued, so nothing re-enters ShutdownGame() while we are in here.
+    bool clean = false;
+    const auto deadline = std::chrono::steady_clock::now() +
+                          std::chrono::milliseconds(GUEST_SHUTDOWN_TIMEOUT_MS);
+    do {
+        QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
+        clean = emu_thread->wait(GUEST_SHUTDOWN_POLL_MS);
+    } while (!clean && std::chrono::steady_clock::now() < deadline);
+    LOG_INFO(Frontend, "Guest shutdown {} after notification",
+             clean ? "completed cleanly" : "timed out; forcing stop");
+}
+
 void GMainWindow::ShutdownGame() {
-    if (!emulation_running) {
+    // RequestGuestShutdown() pumps events, so the guest exiting can re-enter us via OnCoreError().
+    if (!emulation_running || shutting_down) {
         return;
     }
 
@@ -1642,6 +1796,11 @@ void GMainWindow::ShutdownGame() {
 #ifdef ENABLE_DISCORD_RPC
     discord_rpc->Pause();
 #endif
+
+    shutting_down = true;
+
+    // Virtual Console titles flush their SRAM on a long timer; stopping outright loses it.
+    RequestGuestShutdown();
 
     emu_thread->RequestStop();
 
@@ -1711,6 +1870,7 @@ void GMainWindow::ShutdownGame() {
     UpdateSaveStates();
 
     emulation_running = false;
+    shutting_down = false;
 
     game_title.clear();
     UpdateWindowTitle();
@@ -1724,6 +1884,13 @@ void GMainWindow::ShutdownGame() {
     // When closing the game, destroy the GLWindow to clear the context after the game is closed
     render_window->ReleaseRenderTarget();
     secondary_window->ReleaseRenderTarget();
+
+    // A termination signal deferred its close to us. Last of all, so closeEvent() cannot pull the
+    // render windows out from under the cleanup above.
+    if (close_when_shutdown_finishes) {
+        close_when_shutdown_finishes = false;
+        close();
+    }
 }
 
 #ifdef ENABLE_DEVELOPER_OPTIONS
@@ -4016,7 +4183,7 @@ void GMainWindow::OnMenuAboutCitra() {
 }
 
 bool GMainWindow::ConfirmClose() {
-    if (!emu_thread || !UISettings::values.confirm_before_closing) {
+    if (!emu_thread || force_close || !UISettings::values.confirm_before_closing) {
         return true;
     }
 

--- a/src/citra_qt/citra_qt.h
+++ b/src/citra_qt/citra_qt.h
@@ -59,6 +59,9 @@ class QFutureWatcher;
 class QLabel;
 class QProgressBar;
 class QPushButton;
+#if defined(__unix__) || defined(__APPLE__)
+class QSocketNotifier;
+#endif
 class QSlider;
 class RegistersWidget;
 class WaitTreeWidget;
@@ -174,6 +177,11 @@ private:
     bool LoadROM(const QString& filename);
     void BootGame(const QString& filename);
     void ShutdownGame();
+    /// Asks the running application to save and exit, as a real system power-off does.
+    void RequestGuestShutdown();
+#if defined(__unix__) || defined(__APPLE__)
+    void SetupUnixSignalHandlers();
+#endif
 
 #ifdef ENABLE_DISCORD_RPC
     void SetDiscordEnabled(bool state);
@@ -237,6 +245,9 @@ private slots:
     void OnPauseGame();
     void OnPauseContinueGame();
     void OnStopGame();
+#if defined(__unix__) || defined(__APPLE__)
+    void OnUnixTerminationSignal();
+#endif
     void OnSaveState();
     void OnLoadState();
     /// Called whenever a user selects a game in the game list widget.
@@ -409,6 +420,20 @@ private:
     bool game_shutdown_delayed = false;
     // Whether game was paused due to stopping video dumping
     bool game_paused_for_dumping = false;
+
+    // Guest shutdown
+    /// Stops us asking twice when the resulting unwind re-enters ShutdownGame().
+    bool guest_shutdown_requested = false;
+    /// True while ShutdownGame() is running, which it cannot survive re-entering.
+    bool shutting_down = false;
+    /// Set when something outside the UI is closing us, so ConfirmClose() does not stall on a
+    /// dialog nobody will answer.
+    bool force_close = false;
+    /// A termination signal arrived mid-shutdown; ShutdownGame() closes us once it unwinds.
+    bool close_when_shutdown_finishes = false;
+#if defined(__unix__) || defined(__APPLE__)
+    QSocketNotifier* unix_signal_notifier = nullptr;
+#endif
 
     int gdbport_from_arg = -1;
 

--- a/src/citra_qt/citra_qt.h
+++ b/src/citra_qt/citra_qt.h
@@ -24,6 +24,7 @@
 #include "citra_qt/notification_led.h"
 #include "citra_qt/user_data_migration.h"
 #include "core/core.h"
+#include "core/guest_shutdown.h"
 #include "core/savestate.h"
 #include "video_core/rasterizer_interface.h"
 
@@ -182,9 +183,9 @@ private:
     void ShutdownGame();
     /// Same, with an explicit budget for the guest; the argumentless form uses the interactive
     /// one.
-    void ShutdownGame(int guest_timeout_ms);
+    void ShutdownGame(Core::GuestShutdownTimeouts guest_timeouts);
     /// Asks the running application to save and exit, as a real system power-off does.
-    void RequestGuestShutdown(int timeout_ms);
+    void RequestGuestShutdown(Core::GuestShutdownTimeouts timeouts);
     /// Writes out everything the UI persists on the way out. Shared by closeEvent() and the
     /// session-end path, which must not drift from it.
     void PersistUISettings();

--- a/src/citra_qt/citra_qt.h
+++ b/src/citra_qt/citra_qt.h
@@ -59,6 +59,9 @@ class QFutureWatcher;
 class QLabel;
 class QProgressBar;
 class QPushButton;
+#ifdef _WIN32
+class QSessionManager;
+#endif
 #if defined(__unix__) || defined(__APPLE__)
 class QSocketNotifier;
 #endif
@@ -177,10 +180,21 @@ private:
     bool LoadROM(const QString& filename);
     void BootGame(const QString& filename);
     void ShutdownGame();
+    /// Same, with an explicit budget for the guest; the argumentless form uses the interactive
+    /// one.
+    void ShutdownGame(int guest_timeout_ms);
     /// Asks the running application to save and exit, as a real system power-off does.
-    void RequestGuestShutdown();
+    void RequestGuestShutdown(int timeout_ms);
+    /// Writes out everything the UI persists on the way out. Shared by closeEvent() and the
+    /// session-end path, which must not drift from it.
+    void PersistUISettings();
+    /// Lets go of what outlives the window: the multiplayer room and the input backend.
+    void ReleaseExternalResources();
 #if defined(__unix__) || defined(__APPLE__)
     void SetupUnixSignalHandlers();
+#endif
+#ifdef _WIN32
+    void SetupWindowsSessionHandler();
 #endif
 
 #ifdef ENABLE_DISCORD_RPC
@@ -247,6 +261,9 @@ private slots:
     void OnStopGame();
 #if defined(__unix__) || defined(__APPLE__)
     void OnUnixTerminationSignal();
+#endif
+#ifdef _WIN32
+    void OnWindowsSessionEnd(QSessionManager& manager);
 #endif
     void OnSaveState();
     void OnLoadState();

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -773,6 +773,7 @@ void QtConfig::ReadSystemValues() {
     ReadGlobalSetting(Settings::values.is_new_3ds);
     ReadGlobalSetting(Settings::values.lle_applets);
     ReadGlobalSetting(Settings::values.enable_required_online_lle_modules);
+    ReadGlobalSetting(Settings::values.notify_guest_on_shutdown);
     ReadGlobalSetting(Settings::values.region_value);
 
     if (global) {
@@ -1325,6 +1326,7 @@ void QtConfig::SaveSystemValues() {
     WriteGlobalSetting(Settings::values.is_new_3ds);
     WriteGlobalSetting(Settings::values.lle_applets);
     WriteGlobalSetting(Settings::values.enable_required_online_lle_modules);
+    WriteGlobalSetting(Settings::values.notify_guest_on_shutdown);
     WriteGlobalSetting(Settings::values.region_value);
 
     if (global) {

--- a/src/citra_qt/configuration/configure_system.cpp
+++ b/src/citra_qt/configuration/configure_system.cpp
@@ -353,6 +353,7 @@ void ConfigureSystem::SetConfiguration() {
     ui->toggle_lle_applets->setChecked(Settings::values.lle_applets.GetValue());
     ui->enable_required_online_lle_modules->setChecked(
         Settings::values.enable_required_online_lle_modules.GetValue());
+    ui->notify_guest_on_shutdown->setChecked(Settings::values.notify_guest_on_shutdown.GetValue());
     ui->plugin_loader->setChecked(Settings::values.plugin_loader_enabled.GetValue());
     ui->allow_plugin_loader->setChecked(Settings::values.allow_plugin_loader.GetValue());
 }
@@ -471,6 +472,9 @@ void ConfigureSystem::ApplyConfiguration() {
         ConfigurationShared::ApplyPerGameSetting(
             &Settings::values.enable_required_online_lle_modules,
             ui->enable_required_online_lle_modules, required_online_lle_modules);
+        ConfigurationShared::ApplyPerGameSetting(&Settings::values.notify_guest_on_shutdown,
+                                                 ui->notify_guest_on_shutdown,
+                                                 notify_guest_on_shutdown);
 
         Settings::values.init_clock =
             static_cast<Settings::InitClock>(ui->combo_init_clock->currentIndex());
@@ -495,6 +499,7 @@ void ConfigureSystem::ApplyConfiguration() {
         Settings::values.lle_applets = ui->toggle_lle_applets->isChecked();
         Settings::values.enable_required_online_lle_modules =
             ui->enable_required_online_lle_modules->isChecked();
+        Settings::values.notify_guest_on_shutdown = ui->notify_guest_on_shutdown->isChecked();
         Settings::values.apply_region_free_patch.SetValue(ui->apply_region_free_patch->isChecked());
 
         Settings::values.plugin_loader_enabled.SetValue(ui->plugin_loader->isChecked());
@@ -717,6 +722,8 @@ void ConfigureSystem::SetupPerGameUI() {
         ui->toggle_lle_applets->setEnabled(Settings::values.lle_applets.UsingGlobal());
         ui->enable_required_online_lle_modules->setEnabled(
             Settings::values.enable_required_online_lle_modules.UsingGlobal());
+        ui->notify_guest_on_shutdown->setEnabled(
+            Settings::values.notify_guest_on_shutdown.UsingGlobal());
         ui->region_combobox->setEnabled(Settings::values.region_value.UsingGlobal());
         return;
     }
@@ -769,6 +776,9 @@ void ConfigureSystem::SetupPerGameUI() {
     ConfigurationShared::SetColoredTristate(ui->enable_required_online_lle_modules,
                                             Settings::values.enable_required_online_lle_modules,
                                             required_online_lle_modules);
+    ConfigurationShared::SetColoredTristate(ui->notify_guest_on_shutdown,
+                                            Settings::values.notify_guest_on_shutdown,
+                                            notify_guest_on_shutdown);
     ConfigurationShared::SetColoredComboBox(
         ui->region_combobox, ui->region_label,
         static_cast<u32>(Settings::values.region_value.GetValue(true) + 1));

--- a/src/citra_qt/configuration/configure_system.h
+++ b/src/citra_qt/configuration/configure_system.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2025 Citra Emulator Project / Azahar Emulator Project
+// Copyright 2016-2026 Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -66,6 +66,7 @@ private:
     ConfigurationShared::CheckState is_new_3ds;
     ConfigurationShared::CheckState lle_applets;
     ConfigurationShared::CheckState required_online_lle_modules;
+    ConfigurationShared::CheckState notify_guest_on_shutdown;
     bool enabled = false;
 
     std::shared_ptr<Service::CFG::Module> cfg;

--- a/src/citra_qt/configuration/configure_system.ui
+++ b/src/citra_qt/configuration/configure_system.ui
@@ -575,6 +575,16 @@ installed applications.</string>
               </property>
              </widget>
             </item>
+            <item row="23" column="0" colspan="2">
+             <widget class="QCheckBox" name="notify_guest_on_shutdown">
+              <property name="text">
+               <string>Let the application save before stopping</string>
+              </property>
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Let the application save before stopping&lt;/p&gt;&lt;p&gt;Asks the application to save and exit when emulation is stopped, as a real console does on power-off. Titles that keep their save in memory and only write it periodically, such as Virtual Console games, lose progress without this. Stopping takes up to a few seconds longer.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </widget>
          </item>

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -747,22 +747,26 @@ bool DeleteDirRecursively(const std::string& directory, unsigned int recursion) 
     return true;
 }
 
-void CopyDir([[maybe_unused]] const std::string& source_path,
-             [[maybe_unused]] const std::string& dest_path) {
+bool CopyDir(const std::string& source_path, const std::string& dest_path,
+             const std::function<bool()>& should_continue) {
     if (source_path == dest_path)
-        return;
+        return false;
 
     if (!FileUtil::Exists(source_path))
-        return;
+        return false;
 
-    if (!FileUtil::Exists(dest_path))
-        FileUtil::CreateFullPath(dest_path);
+    if (!FileUtil::Exists(dest_path) && !FileUtil::CreateFullPath(dest_path))
+        return false;
 
     const auto entries = ListDirectoryEntries(source_path);
-    if (!entries.has_value() || (*entries).empty())
-        return;
+    if (!entries.has_value())
+        return false;
 
+    bool copied_everything = true;
     for (const std::string& virtual_name : *entries) {
+        if (should_continue && !should_continue())
+            return false;
+
         if (virtual_name == "." || virtual_name == "..")
             continue;
 
@@ -773,15 +777,18 @@ void CopyDir([[maybe_unused]] const std::string& source_path,
             source += '/';
             dest += '/';
 
-            if (!FileUtil::Exists(dest))
-                FileUtil::CreateFullPath(dest);
+            if (!FileUtil::Exists(dest) && !FileUtil::CreateFullPath(dest)) {
+                copied_everything = false;
+                continue;
+            }
 
-            CopyDir(source, dest);
+            copied_everything &= CopyDir(source, dest, should_continue);
         } else {
-            if (!FileUtil::Exists(dest))
-                FileUtil::Copy(source, dest);
+            if (!FileUtil::Exists(dest) && !FileUtil::Copy(source, dest))
+                copied_everything = false;
         }
     }
+    return copied_everything;
 }
 
 std::optional<std::string> GetCurrentDir() {

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -207,7 +207,15 @@ bool DeleteDirRecursively(const std::string& directory, unsigned int recursion =
 [[nodiscard]] std::optional<std::string> GetCurrentDir();
 
 // Create directory and copy contents (does not overwrite existing files)
-void CopyDir(const std::string& source_path, const std::string& dest_path);
+/**
+ * Recursively copies a directory. Existing files in the destination are left alone.
+ * @param should_continue Consulted before each entry; returning false aborts the copy. Lets a
+ *                        caller on a deadline bound a copy whose size it cannot know up front.
+ * @returns True if every entry was copied, false if the source is unreadable, any copy failed,
+ *          or the copy was aborted.
+ */
+bool CopyDir(const std::string& source_path, const std::string& dest_path,
+             const std::function<bool()>& should_continue = {});
 
 // Set the current directory to given directory
 bool SetCurrentDir(const std::string& directory);

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -113,6 +113,7 @@ void LogSettings() {
     log_setting("Renderer_DelayGameRenderThreadUs", values.delay_game_render_thread_us.GetValue());
     log_setting("Renderer_Simulate3DSGPUTimings", values.simulate_3ds_gpu_timings.GetValue());
     log_setting("Renderer_DisableRightEyeRender", values.disable_right_eye_render.GetValue());
+    log_setting("Core_NotifyGuestOnShutdown", values.notify_guest_on_shutdown.GetValue());
     log_setting("Stereoscopy_Render3d", values.render_3d.GetValue());
     log_setting("Stereoscopy_Factor3d", values.factor_3d.GetValue());
     log_setting("Stereoscopy_Swap_Eyes", values.swap_eyes_3d.GetValue());
@@ -246,6 +247,7 @@ void RestoreGlobalState(bool is_powered_on) {
     values.custom_textures.SetGlobal(true);
     values.preload_textures.SetGlobal(true);
     values.disable_right_eye_render.SetGlobal(true);
+    values.notify_guest_on_shutdown.SetGlobal(true);
 }
 
 /// Gets the graphics API that should be used; not necessarily one set in settings

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -491,6 +491,7 @@ struct Values {
                                                            Keys::deterministic_async_operations};
     SwitchableSetting<bool> enable_required_online_lle_modules{
         false, Keys::enable_required_online_lle_modules};
+    SwitchableSetting<bool> notify_guest_on_shutdown{false, Keys::notify_guest_on_shutdown};
 
     // Data Storage
     Setting<bool> use_virtual_sd{true, Keys::use_virtual_sd};

--- a/src/common/thread.h
+++ b/src/common/thread.h
@@ -1,4 +1,8 @@
-// Copyright 2013 Dolphin Emulator Project / 2014 Citra Emulator Project
+// Copyright 2014-2026 Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+// Copyright 2013 Dolphin Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -99,6 +103,23 @@ private:
     std::size_t waiting = 0;
     std::size_t generation = 0; // Incremented once each time the barrier is used
 };
+
+/**
+ * Acquires a lock, giving up if it is still held after `timeout_ms`. std::recursive_mutex has
+ * no timed acquisition of its own, hence the poll.
+ * @returns True if the lock was acquired, otherwise false.
+ */
+template <typename Mutex>
+[[nodiscard]] bool TryLockFor(std::unique_lock<Mutex>& lock, int timeout_ms) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+    while (!lock.try_lock()) {
+        if (std::chrono::steady_clock::now() >= deadline) {
+            return false;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return true;
+}
 
 enum class ThreadPriority : u32 {
     Low = 0,

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -128,6 +128,8 @@ add_library(citra_core STATIC EXCLUDE_FROM_ALL
     frontend/image_interface.cpp
     frontend/image_interface.h
     frontend/input.h
+    guest_shutdown.cpp
+    guest_shutdown.h
     hle/applets/applet.cpp
     hle/applets/applet.h
     hle/applets/erreula.cpp

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -713,6 +713,7 @@ void System::RegisterImageInterface(std::shared_ptr<Frontend::ImageInterface> im
 }
 
 void System::Shutdown(bool is_deserializing) {
+    std::scoped_lock session_guard{session_lock};
 
     // Shutdown emulation session
     is_powered_on = false;

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -619,6 +619,14 @@ System::ResultStatus System::Init(Frontend::EmuWindow& emu_window,
 
     LOG_DEBUG(Core, "Initialized OK");
 
+    // Nothing the previous session left behind applies to this one, and System outlives both.
+    guest_shutdown_acknowledged = false;
+    last_guest_save_write = {};
+    {
+        std::scoped_lock lock{guest_save_mutex};
+        uncommitted_save_archives.clear();
+    }
+
     is_powered_on = true;
 
     return ResultStatus::Success;

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -173,6 +173,12 @@ public:
         return is_powered_on;
     }
 
+    /// Serializes Shutdown() against threads that inspect the running session. Hold it across an
+    /// IsPoweredOn() check and whatever it guards, or the emulation thread frees it in between.
+    [[nodiscard]] std::recursive_mutex& GetSessionLock() {
+        return session_lock;
+    }
+
     /// Prepare the core emulation for a reschedule
     void PrepareReschedule();
 
@@ -513,6 +519,7 @@ private:
     static System s_instance;
 
     std::atomic_bool is_powered_on{};
+    std::recursive_mutex session_lock;
 
     SaveStateStatus save_state_status = SaveStateStatus::NONE;
     SaveStateStatus save_state_request_status = SaveStateStatus::NONE;

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -4,11 +4,13 @@
 
 #pragma once
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <unordered_map>
 #include <boost/optional.hpp>
 #include <boost/serialization/version.hpp>
 #include "common/common_types.h"
@@ -177,6 +179,59 @@ public:
     /// IsPoweredOn() check and whatever it guards, or the emulation thread frees it in between.
     [[nodiscard]] std::recursive_mutex& GetSessionLock() {
         return session_lock;
+    }
+
+    // Guest shutdown progress. Here rather than on ArchiveManager and AppletManager because the
+    // frontend reads them as the session is torn down, once those are gone. Init() clears them.
+    void ResetGuestShutdownProgress() {
+        // Only the acknowledgement: an outstanding save is live state, not shutdown progress.
+        guest_shutdown_acknowledged = false;
+    }
+
+    void NotifyGuestShutdownAcknowledged() {
+        guest_shutdown_acknowledged = true;
+    }
+
+    /// Records a write to the save archive behind `archive_handle`, which is now uncommitted.
+    /// `on_sd_savedata` marks the plain SD save data, the only archive SaveDataSnapshot copies.
+    void NotifyGuestSaveWritten(u64 archive_handle, bool on_sd_savedata) {
+        // Stamped before the map is touched, so a reader that sees a handle never reads a stale
+        // time.
+        last_guest_save_write = std::chrono::steady_clock::now().time_since_epoch().count();
+        std::scoped_lock lock{guest_save_mutex};
+        uncommitted_save_archives.insert_or_assign(archive_handle, on_sd_savedata);
+    }
+
+    /// Records a successful commit of `archive_handle`. Per handle: a title routinely has several
+    /// save archives open at once, and committing one says nothing about the others.
+    void NotifyGuestSaveCommitted(u64 archive_handle) {
+        std::scoped_lock lock{guest_save_mutex};
+        uncommitted_save_archives.erase(archive_handle);
+    }
+
+    /// True once the guest has read the shutdown notification. One that never does won't answer.
+    [[nodiscard]] bool WasGuestShutdownAcknowledged() const {
+        return guest_shutdown_acknowledged;
+    }
+
+    /// True if the guest wrote save data without committing it, so stopping now could tear it.
+    [[nodiscard]] bool HasUncommittedGuestSave() const {
+        std::scoped_lock lock{guest_save_mutex};
+        return !uncommitted_save_archives.empty();
+    }
+
+    /// True if any of that sits outside the SD save data, which is all a snapshot can copy. Extra
+    /// and system save data are tracked as at risk but live elsewhere on disk.
+    [[nodiscard]] bool HasUncommittedSaveOutsideSdSaveData() const {
+        std::scoped_lock lock{guest_save_mutex};
+        return std::any_of(uncommitted_save_archives.begin(), uncommitted_save_archives.end(),
+                           [](const auto& entry) { return !entry.second; });
+    }
+
+    /// When that write happened. Only meaningful while HasUncommittedGuestSave().
+    [[nodiscard]] std::chrono::steady_clock::time_point LastGuestSaveWrite() const {
+        return std::chrono::steady_clock::time_point{
+            std::chrono::steady_clock::duration{last_guest_save_write.load()}};
     }
 
     /// Prepare the core emulation for a reschedule
@@ -520,6 +575,14 @@ private:
 
     std::atomic_bool is_powered_on{};
     std::recursive_mutex session_lock;
+
+    // Not serialized: a shutdown can't be in flight across a save state.
+    std::atomic<bool> guest_shutdown_acknowledged{false};
+    std::atomic<std::chrono::steady_clock::rep> last_guest_save_write{};
+    /// Save archives written to but not since committed, by handle. The value marks the plain SD
+    /// save data, which is the only archive a snapshot covers.
+    std::unordered_map<u64, bool> uncommitted_save_archives;
+    mutable std::mutex guest_save_mutex;
 
     SaveStateStatus save_state_status = SaveStateStatus::NONE;
     SaveStateStatus save_state_request_status = SaveStateStatus::NONE;

--- a/src/core/guest_shutdown.cpp
+++ b/src/core/guest_shutdown.cpp
@@ -9,6 +9,7 @@
 #include <fmt/format.h>
 #include "common/file_util.h"
 #include "common/logging/log.h"
+#include "common/settings.h"
 #include "common/thread.h"
 #include "core/core.h"
 #include "core/file_sys/archive_source_sd_savedata.h"
@@ -252,6 +253,12 @@ void SaveDataSnapshot::Discard() {
 GuestShutdownResult PerformGuestShutdown(System& system, GuestShutdownTimeouts timeouts,
                                          const GuestShutdownWaitSlice& wait_slice,
                                          const std::function<void()>& on_session_confirmed) {
+    // Off by default: a title that reads the notification and then ignores it still costs the
+    // whole budget, and most do. Worth turning on per game for the ones that buffer their save.
+    if (!Settings::values.notify_guest_on_shutdown.GetValue()) {
+        return GuestShutdownResult::NotDelivered;
+    }
+
     const auto started = std::chrono::steady_clock::now();
 
     SaveDataSnapshot snapshot;

--- a/src/core/guest_shutdown.cpp
+++ b/src/core/guest_shutdown.cpp
@@ -1,0 +1,297 @@
+// Copyright 2026 Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include <chrono>
+#include <ctime>
+#include <vector>
+#include <fmt/format.h>
+#include "common/file_util.h"
+#include "common/logging/log.h"
+#include "common/thread.h"
+#include "core/core.h"
+#include "core/file_sys/archive_source_sd_savedata.h"
+#include "core/guest_shutdown.h"
+#include "core/hle/kernel/kernel.h"
+#include "core/hle/service/apt/applet_manager.h"
+#include "core/hle/service/apt/apt.h"
+#include "core/loader/loader.h"
+
+namespace Core {
+
+namespace {
+using namespace std::chrono_literals;
+
+/// How long to wait for the guest to read the notification before deciding it never will.
+constexpr auto AcknowledgementGrace = 300ms;
+constexpr auto PollSlice = 50ms;
+/// A gap this long between savedata writes counts as the guest having finished writing.
+constexpr auto SaveWriteQuiescence = 1s;
+/// Cap on the search for an unused snapshot directory name.
+constexpr int MaxSnapshotNameAttempts = 100;
+/// Kept snapshots per title, so a title that keeps timing out cannot fill the disk.
+constexpr std::size_t MaxKeptSnapshots = 5;
+/// Upper bound on the wait for an in-flight SVC to give the HLE lock back.
+constexpr int HleLockTimeoutMs = 250;
+
+/// Under the user directory, not the cache: a cache is something the OS may delete.
+std::string SnapshotDirectory() {
+    return FileUtil::GetUserPath(FileUtil::UserPath::UserDir) + "save_snapshots/";
+}
+
+/// Deletes the oldest snapshots of `program_id`, leaving room for one more. Names carry a
+/// fixed-width timestamp, so they sort oldest first.
+void PruneOldSnapshots(u64 program_id) {
+    const std::string root = SnapshotDirectory();
+    if (!FileUtil::IsDirectory(root)) {
+        return;
+    }
+
+    FileUtil::FSTEntry listing{};
+    FileUtil::ScanDirectoryTree(root, listing);
+
+    const std::string prefix = fmt::format("{:016x}_", program_id);
+    std::vector<std::string> mine;
+    for (const auto& entry : listing.children) {
+        if (entry.isDirectory && entry.virtualName.rfind(prefix, 0) == 0) {
+            mine.push_back(entry.virtualName);
+        }
+    }
+    if (mine.size() < MaxKeptSnapshots) {
+        return;
+    }
+
+    std::sort(mine.begin(), mine.end());
+    const std::size_t excess = mine.size() - (MaxKeptSnapshots - 1);
+    for (std::size_t i = 0; i < excess; ++i) {
+        LOG_INFO(Core, "Pruning old save data snapshot {}", mine[i]);
+        FileUtil::DeleteDirRecursively(root + mine[i] + "/");
+    }
+}
+} // Anonymous namespace
+
+std::string_view DescribeGuestShutdown(GuestShutdownResult result) {
+    switch (result) {
+    case GuestShutdownResult::Clean:
+        return "completed cleanly";
+    case GuestShutdownResult::NotListening:
+        return "was not acknowledged; the title does not handle it, stopping now";
+    case GuestShutdownResult::NotDelivered:
+        return "could not be requested at all; stopping without the guest knowing";
+    case GuestShutdownResult::TimedOutIdle:
+        return "timed out with no save in progress; stopping is safe";
+    case GuestShutdownResult::TimedOutQuiet:
+        return "timed out with an uncommitted save, but the guest had stopped writing";
+    case GuestShutdownResult::TimedOutSaving:
+        return "timed out while the guest was still saving; the save may be inconsistent";
+    }
+    return "finished in an unknown state";
+}
+
+GuestShutdownTimeouts GuestShutdownTimeouts::Minus(
+    std::chrono::steady_clock::duration spent) const {
+    const auto charge = [spent](std::chrono::milliseconds budget) {
+        return std::max(budget - std::chrono::duration_cast<std::chrono::milliseconds>(spent),
+                        std::chrono::milliseconds::zero());
+    };
+    return {charge(deadline), charge(mid_save_ceiling)};
+}
+
+GuestShutdownResult WaitForGuestShutdown(System& system, GuestShutdownTimeouts timeouts,
+                                         const GuestShutdownWaitSlice& wait_slice) {
+    const auto start = std::chrono::steady_clock::now();
+    const auto deadline = start + timeouts.deadline;
+    const auto ceiling = start + std::max(timeouts.deadline, timeouts.mid_save_ceiling);
+    // Clamped: the grace period is part of the freeze budget, not extra on top of it.
+    const auto acknowledgement_deadline = std::min(start + AcknowledgementGrace, ceiling);
+
+    while (true) {
+        // Likewise the poll slice, so the last wait cannot overshoot the ceiling.
+        const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
+            ceiling - std::chrono::steady_clock::now());
+        const auto slice = std::clamp(remaining, std::chrono::milliseconds::zero(), PollSlice);
+        if (wait_slice(slice)) {
+            return GuestShutdownResult::Clean;
+        }
+        const auto now = std::chrono::steady_clock::now();
+
+        const bool has_save = system.HasUncommittedGuestSave();
+        // Before the acknowledgement: a title can autosave on its own timer without answering.
+        if (has_save && now - system.LastGuestSaveWrite() < SaveWriteQuiescence) {
+            if (now >= ceiling) {
+                return GuestShutdownResult::TimedOutSaving;
+            }
+            continue;
+        }
+
+        // Only when nothing was written, so a title that saves without answering isn't cut off.
+        if (!has_save && !system.WasGuestShutdownAcknowledged()) {
+            if (now >= acknowledgement_deadline) {
+                return GuestShutdownResult::NotListening;
+            }
+            continue;
+        }
+
+        if (now >= deadline) {
+            return has_save ? GuestShutdownResult::TimedOutQuiet
+                            : GuestShutdownResult::TimedOutIdle;
+        }
+    }
+}
+
+void SaveDataSnapshot::Take(System& system, std::chrono::milliseconds budget) {
+    if (!system.IsPoweredOn()) {
+        return;
+    }
+
+    // Nothing written since the last commit, so a stop has nothing to tear. Checked first: this is
+    // the common case, and copying regardless makes every stop pay for a copy it then deletes.
+    if (!system.HasUncommittedGuestSave()) {
+        return;
+    }
+
+    u64 program_id{};
+    if (system.GetAppLoader().ReadProgramId(program_id) != Loader::ResultStatus::Success) {
+        return;
+    }
+
+    const std::string save_path = FileSys::ArchiveSource_SDSaveData::GetSaveDataPathFor(
+        FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir), program_id);
+    if (!FileUtil::IsDirectory(save_path)) {
+        // Nothing on the SD card to lose. Titles that save elsewhere aren't covered.
+        return;
+    }
+
+    // Extra and system save data are tracked as at risk but live outside this directory, so
+    // Finish() has to stop short of promising a copy that covers them.
+    covers_everything = !system.HasUncommittedSaveOutsideSdSaveData();
+
+    // The guest keeps running, so this may copy a save mid-write. Kept anyway: a torn copy still
+    // beats the nothing the user is left with if the stop tears the real save.
+    const auto copy_started = std::chrono::steady_clock::now();
+    taken_mid_write = copy_started - system.LastGuestSaveWrite() < SaveWriteQuiescence;
+
+    PruneOldSnapshots(program_id);
+
+    // Timestamped so an earlier kept copy isn't clobbered; CopyDir merges into an existing dir.
+    const std::string prefix = fmt::format("{}{:016x}_{}", SnapshotDirectory(), program_id,
+                                           static_cast<u64>(std::time(nullptr)));
+    std::string destination = prefix + "/";
+    for (int attempt = 1; FileUtil::Exists(destination); ++attempt) {
+        if (attempt > MaxSnapshotNameAttempts) {
+            LOG_WARNING(Core, "Not snapshotting save data: no unused name left under {}", prefix);
+            return;
+        }
+        destination = fmt::format("{}_{}/", prefix, attempt);
+    }
+
+    // CopyDir creates the destination first, so only its return value proves the copy happened.
+    const auto copy_deadline = copy_started + budget;
+    const bool copied = FileUtil::CopyDir(save_path, destination, [copy_deadline] {
+        return std::chrono::steady_clock::now() < copy_deadline;
+    });
+    if (!copied) {
+        LOG_WARNING(Core, "Could not snapshot save data to {} within {}ms", destination,
+                    budget.count());
+        // A partial copy would be offered to the user as a recoverable save.
+        FileUtil::DeleteDirRecursively(destination);
+        return;
+    }
+    path = destination;
+
+    // It may also have started writing partway through a copy that began while it was quiet.
+    taken_mid_write = taken_mid_write || system.LastGuestSaveWrite() >= copy_started;
+    LOG_DEBUG(Core, "Snapshotted save data to {}", path);
+}
+
+SaveDataSnapshot::~SaveDataSnapshot() {
+    Discard();
+}
+
+void SaveDataSnapshot::Finish(GuestShutdownResult result) {
+    if (!MayHaveTornSave(result)) {
+        Discard();
+        return;
+    }
+
+    if (path.empty()) {
+        // Nothing was at risk when the copy would have been taken, or it could not be made. Say
+        // so: silence here reads as "the save is fine".
+        LOG_WARNING(Core,
+                    "Emulation was stopped and the guest may not have finished saving: it {}. No "
+                    "copy of its save data was available to keep",
+                    DescribeGuestShutdown(result));
+        return;
+    }
+
+    std::string caveats;
+    if (taken_mid_write) {
+        caveats +=
+            " The copy was made while the guest was writing, so it may be incomplete itself.";
+    }
+    if (!covers_everything) {
+        caveats += " It covers only the title's SD card save data; extra or system save data was "
+                   "also written and is not included.";
+    }
+    LOG_WARNING(Core,
+                "Emulation was stopped and the guest may not have finished saving: it {}. Its "
+                "save data as it was before the shutdown has been kept at {}.{}",
+                DescribeGuestShutdown(result), path, caveats);
+    path.clear(); // Don't delete it in the destructor.
+}
+
+void SaveDataSnapshot::Discard() {
+    if (path.empty()) {
+        return;
+    }
+    FileUtil::DeleteDirRecursively(path);
+    path.clear();
+}
+
+GuestShutdownResult PerformGuestShutdown(System& system, GuestShutdownTimeouts timeouts,
+                                         const GuestShutdownWaitSlice& wait_slice,
+                                         const std::function<void()>& on_session_confirmed) {
+    const auto started = std::chrono::steady_clock::now();
+
+    SaveDataSnapshot snapshot;
+    {
+        // Held across the IsPoweredOn() check. Both locks and the reference go before the wait:
+        // System::Shutdown() runs on the emu thread and frees what they guard.
+        std::scoped_lock session_guard{system.GetSessionLock()};
+        if (!system.IsPoweredOn()) {
+            return GuestShutdownResult::NotDelivered;
+        }
+        if (on_session_confirmed) {
+            on_session_confirmed();
+        }
+
+        // Taken while the save is intact; under the session lock because it reads the app loader.
+        snapshot.Take(system, timeouts.deadline);
+
+        // An applet dialog holds the HLE lock while blocking on us, so never wait on it forever.
+        std::unique_lock hle_guard{system.Kernel().GetHLELock(), std::defer_lock};
+        if (!Common::TryLockFor(hle_guard, HleLockTimeoutMs)) {
+            LOG_WARNING(Core, "HLE lock still held, stopping without notifying the guest");
+            // Usually a long-running FS call holds it, so a save may be in flight. Keep the copy.
+            snapshot.Finish(GuestShutdownResult::NotDelivered);
+            return GuestShutdownResult::NotDelivered;
+        }
+
+        auto apt = Service::APT::GetModule(system);
+        if (!apt) {
+            snapshot.Finish(GuestShutdownResult::NotDelivered);
+            return GuestShutdownResult::NotDelivered;
+        }
+        system.ResetGuestShutdownProgress();
+        apt->GetAppletManager()->SendNotificationToAll(Service::APT::Notification::Shutdown);
+    }
+
+    const auto result = WaitForGuestShutdown(
+        system, timeouts.Minus(std::chrono::steady_clock::now() - started), wait_slice);
+    snapshot.Finish(result);
+    LOG_INFO(Core, "Guest shutdown {}", DescribeGuestShutdown(result));
+    return result;
+}
+
+} // namespace Core

--- a/src/core/guest_shutdown.h
+++ b/src/core/guest_shutdown.h
@@ -1,0 +1,111 @@
+// Copyright 2026 Citra Emulator Project / Azahar Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <chrono>
+#include <functional>
+#include <string>
+#include <string_view>
+
+namespace Core {
+
+class System;
+
+enum class GuestShutdownResult {
+    Clean,          ///< The guest saved and exited on its own.
+    NotListening,   ///< The guest never read the notification, so it never wrote anything.
+    NotDelivered,   ///< The guest was never told at all, so anything in flight was cut off.
+    TimedOutIdle,   ///< Timed out, but with no save outstanding.
+    TimedOutQuiet,  ///< Timed out with a save written but never committed, and writes long over.
+    TimedOutSaving, ///< Timed out mid-save. The save may be inconsistent.
+};
+
+[[nodiscard]] constexpr bool MayHaveTornSave(GuestShutdownResult result) {
+    // Not TimedOutQuiet: plenty of titles write their save and never commit it, so that flag stays
+    // set for the rest of the session. Having gone quiet for SaveWriteQuiescence is the whole
+    // basis for calling the write finished, so keeping a copy and warning about it anyway would
+    // fire on every stop of those titles and mean nothing when it did.
+    // NotDelivered is kept: we never learned what the guest was doing, and a spare copy is cheap.
+    return result == GuestShutdownResult::TimedOutSaving ||
+           result == GuestShutdownResult::NotDelivered;
+}
+
+/// Human-readable form of the result, for logging.
+[[nodiscard]] std::string_view DescribeGuestShutdown(GuestShutdownResult result);
+
+/// Blocks for up to the given duration. Returns true once emulation has ended.
+using GuestShutdownWaitSlice = std::function<bool(std::chrono::milliseconds)>;
+
+struct GuestShutdownTimeouts {
+    std::chrono::milliseconds deadline;
+    /// Replaces the deadline while the guest is mid-save. Frontends that block a UI thread have
+    /// to keep this short enough that the OS doesn't kill them for going unresponsive.
+    std::chrono::milliseconds mid_save_ceiling;
+
+    /// Charges time already spent against both, clamped at zero: the budget is freeze time.
+    [[nodiscard]] GuestShutdownTimeouts Minus(std::chrono::steady_clock::duration spent) const;
+};
+
+/**
+ * Waits for the guest to exit after being sent an APT shutdown notification. Extends the wait
+ * while it is actively writing its save, and gives up early if it never reads the notification.
+ * "Actively" means recent writes: not every archive sends a commit, so a lull has to count as
+ * finished. Call System::ResetGuestShutdownProgress() just before sending the notification.
+ *
+ * Never blocks past the larger of the two budgets, the acknowledgement grace period included: all
+ * of it is time a frontend's UI thread spends frozen.
+ */
+GuestShutdownResult WaitForGuestShutdown(System& system, GuestShutdownTimeouts timeouts,
+                                         const GuestShutdownWaitSlice& wait_slice);
+
+/// Copy of the running title's save data, taken while still intact and kept only if the stop
+/// turned out to interrupt a save. Stands in for the atomicity Azahar doesn't emulate.
+class SaveDataSnapshot {
+public:
+    SaveDataSnapshot() = default;
+    ~SaveDataSnapshot();
+
+    SaveDataSnapshot(const SaveDataSnapshot&) = delete;
+    SaveDataSnapshot& operator=(const SaveDataSnapshot&) = delete;
+
+    /**
+     * Copies the save aside, but only when the guest has an uncommitted write to lose. An intact
+     * save needs no copy, and checking first is what keeps an ordinary stop from paying for a full
+     * copy and delete of the title's save directory for nothing.
+     * Call with System::GetSessionLock() held: it reads the app loader.
+     * @param budget Wall-clock cap on the copy, which is otherwise unbounded and runs on a
+     *               frontend's UI thread. A copy that runs out of budget is abandoned.
+     */
+    void Take(System& system, std::chrono::milliseconds budget);
+
+    /// Keeps the copy if the save may have been torn, otherwise deletes it.
+    void Finish(GuestShutdownResult result);
+
+private:
+    void Discard();
+
+    std::string path;              ///< Empty if no snapshot was taken.
+    bool taken_mid_write = false;  ///< The guest wrote to the save while it was being copied.
+    bool covers_everything = true; ///< No at-risk archive fell outside what was copied.
+};
+
+/**
+ * Asks the running title to save and exit, then waits for it, taking a save data snapshot
+ * beforehand and resolving it afterwards. Only `wait_slice` differs between frontends.
+ *
+ * Call with neither System::GetSessionLock() nor the HLE lock held: this takes both, and drops
+ * them before waiting, since System::Shutdown() runs on the emu thread and needs them.
+ *
+ * @param on_session_confirmed Run under the session lock once the session is known to still be
+ *                             live, before anything else touches it. Frontends resume emulation
+ *                             here: a paused guest never sees the notification, and doing it any
+ *                             earlier would leave a session that has already gone away resumed.
+ *                             Must not block.
+ */
+GuestShutdownResult PerformGuestShutdown(System& system, GuestShutdownTimeouts timeouts,
+                                         const GuestShutdownWaitSlice& wait_slice,
+                                         const std::function<void()>& on_session_confirmed = {});
+
+} // namespace Core

--- a/src/core/hle/service/apt/applet_manager.cpp
+++ b/src/core/hle/service/apt/applet_manager.cpp
@@ -527,6 +527,9 @@ ResultVal<Notification> AppletManager::InquireNotification(AppletId app_id) {
         if (slot_data->registered) {
             auto notification = slot_data->notification;
             slot_data->notification = Notification::None;
+            if (notification == Notification::Shutdown) {
+                system.NotifyGuestShutdownAcknowledged();
+            }
             return notification;
         }
     }

--- a/src/core/hle/service/apt/applet_manager.h
+++ b/src/core/hle/service/apt/applet_manager.h
@@ -314,6 +314,7 @@ public:
 
     ResultVal<Notification> InquireNotification(AppletId app_id);
     Result SendNotification(Notification notification);
+    void SendNotificationToAll(Notification notification);
 
     Result PrepareToStartLibraryApplet(AppletId applet_id);
     Result PreloadLibraryApplet(AppletId applet_id);
@@ -553,8 +554,6 @@ private:
     /// Checks if the Application slot has already been registered and sends the parameter to it,
     /// otherwise it queues for sending when the application registers itself with APT::Enable.
     void SendApplicationParameterAfterRegistration(const MessageParameter& parameter);
-
-    void SendNotificationToAll(Notification notification);
 
     void EnsureHomeMenuLoaded();
 

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -31,6 +31,27 @@
 
 namespace Service::FS {
 
+namespace {
+/// FS_ArchiveAction::ARCHIVE_ACTION_COMMIT_SAVE_DATA. See 3dbrew, FSUSER_ControlArchive.
+constexpr u32 ArchiveActionCommitSaveData = 0;
+
+/// Whether writes to this archive land in a title's save rather than the SD card or a ROM.
+constexpr bool IsSaveDataArchiveId(ArchiveIdCode id_code) {
+    switch (id_code) {
+    case ArchiveIdCode::SaveData:
+    case ArchiveIdCode::ExtSaveData:
+    case ArchiveIdCode::SharedExtSaveData:
+    case ArchiveIdCode::SystemSaveData:
+    case ArchiveIdCode::BossExtSaveData:
+    case ArchiveIdCode::OtherSaveDataGeneral:
+    case ArchiveIdCode::OtherSaveDataPermitted:
+        return true;
+    default:
+        return false;
+    }
+}
+} // Anonymous namespace
+
 bool IsInstalledApplication(std::string_view path) {
     return path.rfind(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) + "title", 0) == 0 ||
            path.rfind(FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir) + "Nintendo 3DS", 0) == 0;
@@ -51,6 +72,17 @@ ArchiveBackend* ArchiveManager::GetArchive(ArchiveHandle handle) {
     return (itr == handle_map.end()) ? nullptr : itr->second.get();
 }
 
+bool ArchiveManager::IsSaveDataArchive(ArchiveHandle handle) const {
+    const auto itr = handle_id_codes.find(handle);
+    // Absent for a handle restored from a save state written before this was recorded.
+    return itr != handle_id_codes.end() && IsSaveDataArchiveId(itr->second);
+}
+
+bool ArchiveManager::IsSdSaveDataArchive(ArchiveHandle handle) const {
+    const auto itr = handle_id_codes.find(handle);
+    return itr != handle_id_codes.end() && itr->second == ArchiveIdCode::SaveData;
+}
+
 ResultVal<ArchiveHandle> ArchiveManager::OpenArchive(ArchiveIdCode id_code,
                                                      const FileSys::Path& archive_path,
                                                      u64 program_id) {
@@ -69,6 +101,7 @@ ResultVal<ArchiveHandle> ArchiveManager::OpenArchive(ArchiveIdCode id_code,
         ++next_handle;
     }
     handle_map.emplace(next_handle, std::move(res));
+    handle_id_codes.emplace(next_handle, id_code);
     return next_handle++;
 }
 
@@ -80,6 +113,7 @@ Result ArchiveManager::CloseArchive(ArchiveHandle handle) {
         return FileSys::ResultInvalidArchiveHandle;
     }
     handle_map.erase(itr);
+    handle_id_codes.erase(handle);
     return ResultSuccess;
 }
 
@@ -87,7 +121,15 @@ Result ArchiveManager::ControlArchive(ArchiveHandle handle, u32 action, u8* inpu
                                       size_t input_size, u8* output, size_t output_size) {
     auto itr = handle_map.find(handle);
     if (itr != handle_map.end()) {
-        return itr->second->Control(action, input, input_size, output, output_size);
+        const Result result = itr->second->Control(action, input, input_size, output, output_size);
+        // The commit is stubbed, but a successful one still marks the save consistent: the only
+        // safe stop point. A failed commit leaves the save every bit as at risk as it already was,
+        // so it must not clear the flag.
+        if (result.IsSuccess() && action == ArchiveActionCommitSaveData &&
+            IsSaveDataArchive(handle)) {
+            system.NotifyGuestSaveCommitted(handle);
+        }
+        return result;
     } else {
         return FileSys::ResultInvalidArchiveHandle;
     }
@@ -123,6 +165,10 @@ ArchiveManager::OpenFileFromArchive(ArchiveHandle archive_handle, const FileSys:
     }
 
     auto file = std::make_shared<File>(system.Kernel(), std::move(backend).Unwrap(), path);
+    // File only knows the guest-side path, so it can't work this out itself. The handle rather
+    // than a flag: commits are per archive, and a title has several save archives open at once.
+    file->save_data_archive = IsSaveDataArchive(archive_handle) ? archive_handle : 0;
+    file->save_data_on_sd = IsSdSaveDataArchive(archive_handle);
     return std::make_pair(std::move(file), open_timeout_ns);
 }
 

--- a/src/core/hle/service/fs/archive.h
+++ b/src/core/hle/service/fs/archive.h
@@ -10,6 +10,7 @@
 #include <unordered_map>
 #include <boost/serialization/unique_ptr.hpp>
 #include <boost/serialization/unordered_map.hpp>
+#include <boost/serialization/version.hpp>
 #include "common/common_types.h"
 #include "core/file_sys/archive_backend.h"
 #include "core/file_sys/archive_source_sd_savedata.h"
@@ -319,6 +320,12 @@ private:
 
     ArchiveBackend* GetArchive(ArchiveHandle handle);
 
+    /// Whether writes through this handle land in a title's save data rather than plain files.
+    [[nodiscard]] bool IsSaveDataArchive(ArchiveHandle handle) const;
+
+    /// Narrower: the plain SD save data, which is the only archive SaveDataSnapshot copies.
+    [[nodiscard]] bool IsSdSaveDataArchive(ArchiveHandle handle) const;
+
     /**
      * Map of registered archives, identified by id code. Once an archive is registered here, it is
      * never removed until UnregisterArchiveTypes is called.
@@ -329,6 +336,9 @@ private:
      * Map of active archive handles to archive objects
      */
     std::unordered_map<ArchiveHandle, std::unique_ptr<ArchiveBackend>> handle_map;
+
+    /// Id code each open handle was opened with; an ArchiveBackend cannot say what it is.
+    std::unordered_map<ArchiveHandle, ArchiveIdCode> handle_id_codes;
     ArchiveHandle next_handle = 1;
 
     /**
@@ -337,13 +347,19 @@ private:
     std::shared_ptr<FileSys::ArchiveSource_SDSaveData> sd_savedata_source;
 
     template <class Archive>
-    void serialize(Archive& ar, const unsigned int) {
+    void serialize(Archive& ar, const unsigned int file_version) {
         ar & id_code_map;
         ar & handle_map;
         ar & next_handle;
         ar & sd_savedata_source;
+        if (file_version >= 1) {
+            ar & handle_id_codes;
+        }
     }
     friend class boost::serialization::access;
 };
 
 } // namespace Service::FS
+
+// Version 1 added handle_id_codes.
+BOOST_CLASS_VERSION(Service::FS::ArchiveManager, 1)

--- a/src/core/hle/service/fs/file.cpp
+++ b/src/core/hle/service/fs/file.cpp
@@ -21,10 +21,14 @@ SERIALIZE_EXPORT_IMPL(Service::FS::FileSessionSlot)
 namespace Service::FS {
 
 template <class Archive>
-void File::serialize(Archive& ar, const unsigned int) {
+void File::serialize(Archive& ar, const unsigned int file_version) {
     ar& boost::serialization::base_object<Kernel::SessionRequestHandler>(*this);
     ar & path;
     ar & backend;
+    if (file_version >= 1) {
+        ar & save_data_archive;
+        ar & save_data_on_sd;
+    }
 }
 
 File::File() : File(Core::Global<Kernel::KernelSystem>()) {}
@@ -170,6 +174,12 @@ void File::Read(Kernel::HLERequestContext& ctx) {
         really_async);
 }
 
+void File::MarkSaveDataWritten() {
+    if (save_data_archive != 0) {
+        Core::Global<Core::System>().NotifyGuestSaveWritten(save_data_archive, save_data_on_sd);
+    }
+}
+
 void File::Write(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     u64 offset = rp.Pop<u64>();
@@ -198,6 +208,11 @@ void File::Write(Kernel::HLERequestContext& ctx) {
         buffer.Read(data.data(), 0, data.size());
         ResultVal<std::size_t> written =
             backend->Write(offset, data.size(), flush, update_timestamp, data.data());
+        // A write that failed changed nothing, so it must not put the save at risk for the rest
+        // of the session.
+        if (written.Succeeded()) {
+            MarkSaveDataWritten();
+        }
 
         // Update file size
         file->size = backend->GetSize();
@@ -239,6 +254,9 @@ void File::Write(Kernel::HLERequestContext& ctx) {
             async_data->buffer->Read(data.data(), 0, data.size());
             async_data->written = backend->Write(async_data->offset, data.size(), async_data->flush,
                                                  async_data->update_timestamp, data.data());
+            if (async_data->written.Succeeded()) {
+                MarkSaveDataWritten();
+            }
 
             // Update file size
             async_data->file->size = backend->GetSize();
@@ -284,7 +302,10 @@ void File::SetSize(Kernel::HLERequestContext& ctx) {
     if (!backend->AllowsCachedReads() && !Settings::values.async_fs_operations) {
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
         file->size = size;
-        backend->SetSize(size);
+        // Truncating or extending a save file changes it just as a write does.
+        if (backend->SetSize(size)) {
+            MarkSaveDataWritten();
+        }
         rb.Push(ResultSuccess);
         return;
     }
@@ -292,7 +313,9 @@ void File::SetSize(Kernel::HLERequestContext& ctx) {
     ctx.RunAsync(
         [file, size, this](Kernel::HLERequestContext& ctx) {
             file->size = size;
-            backend->SetSize(size);
+            if (backend->SetSize(size)) {
+                MarkSaveDataWritten();
+            }
             return 0;
         },
         [](Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/fs/file.h
+++ b/src/core/hle/service/fs/file.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2024 Citra Emulator Project / Azahar Emulator Project
+// Copyright 2018-2026 Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <boost/serialization/base_object.hpp>
+#include <boost/serialization/version.hpp>
 #include "core/file_sys/archive_backend.h"
 #include "core/global.h"
 #include "core/hle/service/service.h"
@@ -50,6 +51,12 @@ public:
     FileSys::Path path;                            ///< Path of the file
     std::unique_ptr<FileSys::FileBackend> backend; ///< File backend interface
 
+    /// Archive this file was opened from, if that archive holds save data; zero otherwise. Set by
+    /// ArchiveManager::OpenFileFromArchive. Writes mark that archive's save as uncommitted.
+    u64 save_data_archive = 0;
+    /// Whether that archive is the plain SD save data, the only one a snapshot can copy.
+    bool save_data_on_sd = false;
+
     /// Creates a new session to this File and returns the ClientSession part of the connection.
     std::shared_ptr<Kernel::ClientSession> Connect();
 
@@ -73,6 +80,8 @@ private:
     void OpenLinkFile(Kernel::HLERequestContext& ctx);
     void OpenSubFile(Kernel::HLERequestContext& ctx);
 
+    void MarkSaveDataWritten();
+
     Kernel::KernelSystem& kernel;
 
     File(Kernel::KernelSystem& kernel);
@@ -87,3 +96,5 @@ private:
 
 BOOST_CLASS_EXPORT_KEY(Service::FS::FileSessionSlot)
 BOOST_CLASS_EXPORT_KEY(Service::FS::File)
+// Version 1 added is_save_data.
+BOOST_CLASS_VERSION(Service::FS::File, 1)


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

## Graceful Guest Shutdown

This might be a kinda niche feature but could be useful in general for games that listen for these 3DS signals Azahar doesn't yet send. I noticed when playing the Crystal VC game, my save data was not always being written after I saved and exited, and discovered the reason is that the VC games essentially only flush SRAM on a periodic timer (30-40s or so) and when getting certain signals from the console such as the power button being pressed.

This PR sends `APT::Notification::Shutdown` when emulation stops, as a real console does on power-off, and gives the application a moment to save and exit before the hard stop. That covers the ordinary Stop and window close, and also the ways the OS can take us down: on Unix-like systems we register a signal handler and route SIGTERM/SIGINT through a self-pipe, and on Windows it's `WM_QUERYENDSESSION`, which Qt delivers as `commitDataRequest`. The Android frontend and the libretro core get the same treatment through a shared `Core::PerformGuestShutdown()`.

When I first made these changes though I didn't realize it was degrading the exiting of some other 3DS titles. I measured five titles: Fire Emblem Awakening saved and exited in 0.08s, one other exited on its own but took 2.96s, and Ocarina of Time 3D, Mario Kart 7 and one more read the notification and then simply never exited, spending the full 3s budget. So this is not a 300ms grace period in practice, it seems many 3DS games wait until the timeout which is 3s. 

As such, I decided to make it opt-in behavior: `notify_guest_on_shutdown`, off by default and switchable per game, with the check in `PerformGuestShutdown()` so every frontend inherits it. With it off nothing is asked of the guest and nothing is resumed, and stopping behaves exactly as it did before.

One thing Azahar does not (yet) implement is the 3DS save filesystem journaling. `ArchiveBackend::Control()` returns success without doing anything, so `CommitSaveData` is a no-op, writes land in host files as they are made, and there is no committed state to roll back to. That means asking a title to save and then stopping it mid-flush can tear the save, which my initial attempts did. The snapshot code copies the save aside first and keeps it only if the shutdown looks like it interrupted something. This is really better fixed by emulating the journaling properly, but that's a bit out of scope for this PR.

## Technical details

The budgets are 3s to save and exit, extended to 10s while the guest is still writing. Windows session end gets 1.5s and 3.5s since Windows starts telling the user we are blocking their shutdown a few seconds in, Android gets 1s and 2.5s because `stopEmulation()` runs on the UI thread and Android calls an app unresponsive at 5s, and libretro gets 1s and 3s because it blocks the frontend's main thread. The snapshot copy comes out of that budget rather than adding to it, and a title that never reads the notification is detected after a 300ms grace period.

Snapshots go to `save_snapshots/` under the user directory, named by title ID and timestamp, and the five most recent per title are kept. One is only taken when the guest has an uncommitted write to lose and is deleted again unless the shutdown looks like it interrupted a save, so an ordinary stop does not pay for a copy it throws away. Only the SD save data is copied, so extra and system save data are tracked as at risk but reported rather than backed up, and there is no UI to restore one, just the path in the log.

libretro is the odd one out: there is no emulation thread to wait on, since `retro_run()` advances the guest itself on the frontend's thread, so a wait that blocked would stop the guest it is waiting for. The wait slice runs the guest instead, as `DrainAsyncOperations()` already does for savestates, with presentation suppressed since the frontend is not expecting frames from us outside `retro_run()`.

The wait pumps the Qt event loop, so a fair amount can re-enter the shutdown while it runs, and the flags guarding that are the subtlest part of the diff. `shutting_down` keeps `ShutdownGame()` from re-entering itself, and `LoadROM()` and `BootGame()` refuse to run while it is set rather than load a session over a live one. `guest_shutdown_requested` keeps us from asking twice, `close_when_shutdown_finishes` defers a termination signal's `close()` until teardown is done, and `EmuThread::IsGuestExiting()` distinguishes a guest that quit on its own, which `EmuThread::run()` reports before `System::Shutdown()` runs, so `IsPoweredOn()` alone cannot tell.

`FileUtil::CopyDir()` now returns bool and takes an optional predicate so a copy on a deadline can give up; it was void and nothing else in tree calls it. `Service::FS::File` and `Service::FS::ArchiveManager` each gain a serialization version for the archive handle and id code the tracking needs, so older save states still load.

## Testing

I built on Linux, Android, macOS, Windows, and the libretro core. Behavior checked on Linux and Android: Pokémon Crystal reports `completed cleanly` on both, with the save written before the process is torn down, and the timing numbers above come from stopping five titles under the Qt frontend. I wasn't actually able to test a VC title in RetroArch since I couldn't figure out how to "install to NAND" one of these titles in RetroArch, so if somebody knows how that would be good to test as well, but the theory checks out.

I will say that it's been a while since I wrote any signal handlers for Unix-like systems, and I've always done it in C and not C++ (though it's mostly the same). I used an LLM to help write the Windows equivalent since I've never really written Windows specific code before. Extra review of atomics and signal handling I think is critical for correctness, and I'd add the re-entrancy flags above to that list, since they're the part where the ordering actually matters.

### AI disclosure
I used an LLM to help write the Windows code in particular because I haven't written Windows specific code much before. The LLM code review I did also surfaced the potential save corruption because of lack of 3DS save file system journaling in Azahar.