### PR TITLE
android: Implement Logging settings UI

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/StringSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/StringSetting.kt
@@ -27,7 +27,9 @@ enum class StringSetting(
         "_back"
     ),
     WEB_API_URL(SettingKeys.web_api_url(), Settings.SECTION_NETWORK, ""),
-    NETWORK_TOKEN(SettingKeys.network_token(), Settings.SECTION_NETWORK, "");
+    NETWORK_TOKEN(SettingKeys.network_token(), Settings.SECTION_NETWORK, ""),
+    LOG_FILTER(SettingKeys.log_filter(), Settings.SECTION_DEBUG, "*:Info"),
+    LOG_REGEX_FILTER(SettingKeys.log_regex_filter(), Settings.SECTION_DEBUG, "");
 
     override var string: String = defaultValue
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -1950,24 +1950,6 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
             )
             add(
                 SwitchSetting(
-                    BooleanSetting.DEBUG_RENDERER,
-                    R.string.renderer_debug,
-                    R.string.renderer_debug_description,
-                    BooleanSetting.DEBUG_RENDERER.key,
-                    BooleanSetting.DEBUG_RENDERER.defaultValue
-                )
-            )
-            add(
-                SwitchSetting(
-                    BooleanSetting.INSTANT_DEBUG_LOG,
-                    R.string.instant_debug_log,
-                    R.string.instant_debug_log_description,
-                    BooleanSetting.INSTANT_DEBUG_LOG.key,
-                    BooleanSetting.INSTANT_DEBUG_LOG.defaultValue
-                )
-            )
-            add(
-                SwitchSetting(
                     BooleanSetting.ENABLE_RPC_SERVER,
                     R.string.enable_rpc_server,
                     R.string.enable_rpc_server_desc,
@@ -2000,6 +1982,52 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     R.string.deterministic_async_operations_description,
                     BooleanSetting.DETERMINISTIC_ASYNC_OPERATIONS.key,
                     BooleanSetting.DETERMINISTIC_ASYNC_OPERATIONS.defaultValue
+                )
+            )
+
+            add(HeaderSetting(R.string.logging))
+
+            val logFilterModes =
+                settingsActivity.resources.getStringArray(R.array.logFilterNameModes)
+            val logFilterValues =
+                settingsActivity.resources.getStringArray(R.array.logFilterNameValues)
+            add(
+                StringSingleChoiceSetting(
+                    StringSetting.LOG_FILTER,
+                    R.string.log_filter_name,
+                    R.string.log_filter_description,
+                    logFilterModes,
+                    logFilterValues,
+                    StringSetting.LOG_FILTER.key,
+                    StringSetting.LOG_FILTER.defaultValue
+                )
+            )
+            add(
+                StringInputSetting(
+                    StringSetting.LOG_REGEX_FILTER,
+                    R.string.log_regex_filter_name,
+                    R.string.log_regex_filter_description,
+                    StringSetting.LOG_REGEX_FILTER.key,
+                    StringSetting.LOG_REGEX_FILTER.defaultValue,
+                    255
+                )
+            )
+            add(
+                SwitchSetting(
+                    BooleanSetting.DEBUG_RENDERER,
+                    R.string.renderer_debug,
+                    R.string.renderer_debug_description,
+                    BooleanSetting.DEBUG_RENDERER.key,
+                    BooleanSetting.DEBUG_RENDERER.defaultValue
+                )
+            )
+            add(
+                SwitchSetting(
+                    BooleanSetting.INSTANT_DEBUG_LOG,
+                    R.string.instant_debug_log,
+                    R.string.instant_debug_log_description,
+                    BooleanSetting.INSTANT_DEBUG_LOG.key,
+                    BooleanSetting.INSTANT_DEBUG_LOG.defaultValue
                 )
             )
         }

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2026 Citra Emulator Project / Azahar Emulator Project
+// Copyright 2026 Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -26,7 +26,6 @@ constexpr std::array android_config_omitted_keys = {
     Settings::Keys::screen_bottom_leftright_padding,
     Settings::Keys::screen_bottom_topbottom_padding,
     Settings::Keys::mono_render_option,
-    Settings::Keys::log_regex_filter, // Niche
     Settings::Keys::video_encoder,
     Settings::Keys::video_encoder_options,
     Settings::Keys::video_bitrate,
@@ -535,9 +534,6 @@ static const char* android_config_default_file_content = (BOOST_HANA_STRING(R"(
 )") DECLARE_KEY(camera_inner_flip) BOOST_HANA_STRING(R"(
 
 [Miscellaneous]
-# A filter which removes logs below a certain logging level.
-# Examples: *:Debug Kernel.SVC:Trace Service.*:Critical
-)") DECLARE_KEY(log_filter) BOOST_HANA_STRING(R"(
 
 # Whether or not Azahar-related images should be hidden from the Android gallery
 # 0 (default): No, 1: Yes
@@ -562,6 +558,14 @@ static const char* android_config_default_file_content = (BOOST_HANA_STRING(R"(
 # Whether to enable PICA200 debugging (does nothing on Android)
 # 0 (default): Off, 1: On
 )") DECLARE_KEY(pica_debugging) BOOST_HANA_STRING(R"(
+
+# A filter which removes logs below a certain logging level.
+# Examples: *:Debug Kernel.SVC:Trace Service.*:Critical
+)") DECLARE_KEY(log_filter) BOOST_HANA_STRING(R"(
+
+# log_regex_filter is a filter that only displays logs based on the regex
+# expression in POSIX format supplied. Default is an empty string.
+)") DECLARE_KEY(log_regex_filter) BOOST_HANA_STRING(R"(
 
 # Flush log output on every message
 # Immediately commits the debug log to file. Use this if Azahar crashes and the log output is being cut.

--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -707,4 +707,22 @@
         <item>1</item>
     </integer-array>
 
+    <string-array name="logFilterNameModes">
+        <item>@string/log_none</item>
+        <item>@string/log_critical</item>
+        <item>@string/log_error</item>
+        <item>@string/log_warning</item>
+        <item>@string/log_info</item>
+        <item>@string/log_debug</item>
+        <item>@string/log_trace</item>
+    </string-array>
+    <string-array name="logFilterNameValues">
+        <item>@string/log_filter_none</item>
+        <item>@string/log_filter_critical</item>
+        <item>@string/log_filter_error</item>
+        <item>@string/log_filter_warning</item>
+        <item>@string/log_filter_info</item>
+        <item>@string/log_filter_debug</item>
+        <item>@string/log_filter_trace</item>
+    </string-array>
 </resources>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -389,6 +389,25 @@
     <string name="toggle_unique_data_console_type_desc">Toggles the unique data console type (Old 3DS &#8596; New 3DS) to be able to download the opposite system firmware type from system settings.</string>
     <string name="shader_jit">Enable Shader JIT</string>
     <string name="shader_jit_description">Use the JIT engine instead of the interpreter for software shader emulation.</string>
+    <string name="logging">Logging</string>
+    <string name="log_filter_name">Log Level</string>
+    <string name="log_filter_description">Select the level of verbosity to display in the log files. Ranges from <i>None</i> to <i>Trace</i> (i.e. everything). Default is <i>Info</i>.</string>
+    <string name="log_none">None</string>
+    <string name="log_critical">Critical</string>
+    <string name="log_error">Error</string>
+    <string name="log_warning">Warning</string>
+    <string name="log_info">Info</string>
+    <string name="log_debug">Debug</string>
+    <string name="log_trace">Trace</string>
+    <string name="log_filter_none">*:None</string>
+    <string name="log_filter_critical">*:Critical</string>
+    <string name="log_filter_error">*:Error</string>
+    <string name="log_filter_warning">*:Warning</string>
+    <string name="log_filter_info">*:Info</string>
+    <string name="log_filter_debug">*:Debug</string>
+    <string name="log_filter_trace">*:Trace</string>
+    <string name="log_regex_filter_name">Regex Log Filter</string>
+    <string name="log_regex_filter_description">Use POSIX-format regular expressions to display only log entries that match the regex. For example, to only display <i>&lt;Info&gt;</i> level messages, enter <font face="monospace">&lt;Info&gt;</font>.</string>
 
   <!-- Layout settings strings -->
     <string name="layout_screen_orientation">Screen Orientation</string>

--- a/src/common/logging/filter.cpp
+++ b/src/common/logging/filter.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2025 Citra Emulator Project / Azahar Emulator Project
+// Copyright 2026 Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -169,6 +169,7 @@ const char* GetLevelName(Level log_level) {
         LVL(Warning);
         LVL(Error);
         LVL(Critical);
+        LVL(None);
     case Level::Count:
     default:
         break;

--- a/src/common/logging/text_formatter.cpp
+++ b/src/common/logging/text_formatter.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 Citra Emulator Project
+// Copyright 2026 Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -66,6 +66,8 @@ void PrintColoredMessage(const Entry& entry) {
     case Level::Critical: // Bright magenta
         color = FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY;
         break;
+    case Level::None:
+        break;
     case Level::Count:
         UNREACHABLE();
     }
@@ -92,6 +94,8 @@ void PrintColoredMessage(const Entry& entry) {
         break;
     case Level::Critical: // Bright magenta
         color = ESC "[1;35m";
+        break;
+    case Level::None:
         break;
     case Level::Count:
         UNREACHABLE();
@@ -133,6 +137,8 @@ void PrintMessageToLogcat([[maybe_unused]] const Entry& entry) {
         break;
     case Level::Critical:
         android_log_priority = ANDROID_LOG_FATAL;
+        break;
+    case Level::None:
         break;
     case Level::Count:
         UNREACHABLE();

--- a/src/common/logging/types.h
+++ b/src/common/logging/types.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Citra Emulator Project / Azahar Emulator Project
+// Copyright 2026 Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -19,6 +19,7 @@ enum class Level : u8 {
     ///< completed.
     Critical, ///< Major problems during execution that threaten the stability of the entire
     ///< application.
+    None, ///< Don't log anything
 
     Count, ///< Total number of logging levels
 };


### PR DESCRIPTION
- [X] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------
This PR allows an Android user to choose the level of verbosity of the logging, ranging from 'None' to 'Trace' (i.e. everything). It also implements the regular expression filter that is already present on the Desktop version.

This may be useful for those who like to debug directly on their devices, or for those who would like to minimize disk writes.

It also moves the relevant existing logging options to a dedicated Logging section at the bottom of the screen to keep things organized.

(Note that the QuickEdit+ app screenshot of the log file is included just to show that the regexp filtering based on the example regexp term in the screenshots works properly)

No A.I. was used in the creation of this; It is basically a port of similar functionality from Borked3DS that I finally got off my butt to submit here, with the None option being something new.

<img width="1080" height="2400" alt="01" src="https://github.com/user-attachments/assets/131d24a3-3b51-46f4-927d-addb5258e778" />
<img width="1080" height="2400" alt="02" src="https://github.com/user-attachments/assets/a8dbf318-0c52-4853-8fbd-7af53ff50b37" />
<img width="1080" height="2400" alt="03" src="https://github.com/user-attachments/assets/795fbe01-a226-4d91-ac8e-f4499040f779" />
<img width="1080" height="2400" alt="04" src="https://github.com/user-attachments/assets/e3b820bc-258e-416c-b3a0-863f08ac1232" />
