### PR TITLE
audio_core: Revert audio stretch activation fix (#2439) due to subsequent audio issues

### DIFF
--- a/src/audio_core/dsp_interface.cpp
+++ b/src/audio_core/dsp_interface.cpp
@@ -72,13 +72,13 @@ void DspInterface::OutputSample(std::array<s16, 2> sample) {
 
 void DspInterface::OutputCallback(s16* buffer, std::size_t num_frames) {
     // Determine if we should stretch based on the current emulation speed.
-    const auto perf_stats = system.GetLastPerfStats();
-    const auto should_stretch = enable_time_stretching && perf_stats.emulation_speed <= 95;
-    if (performing_time_stretching && !should_stretch) {
+    // TODO: Only activate audio stretching when emulation speed goes below 95% threshold
+    //       (see #2487) -OS
+    if (performing_time_stretching && !enable_time_stretching) {
         // If we just stopped stretching, flush the stretcher before returning to normal output.
         flushing_time_stretcher = true;
     }
-    performing_time_stretching = should_stretch;
+    performing_time_stretching = enable_time_stretching.load();
 
     std::size_t frames_written = 0;
     if (performing_time_stretching) {

--- a/src/audio_core/dsp_interface.cpp
+++ b/src/audio_core/dsp_interface.cpp
@@ -73,7 +73,7 @@ void DspInterface::OutputSample(std::array<s16, 2> sample) {
 void DspInterface::OutputCallback(s16* buffer, std::size_t num_frames) {
     // Determine if we should stretch based on the current emulation speed.
     const auto perf_stats = system.GetLastPerfStats();
-    const auto should_stretch = enable_time_stretching && perf_stats.emulation_speed <= 0.95;
+    const auto should_stretch = enable_time_stretching && perf_stats.emulation_speed <= 95;
     if (performing_time_stretching && !should_stretch) {
         // If we just stopped stretching, flush the stretcher before returning to normal output.
         flushing_time_stretcher = true;


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Fixing the aforementioned check to work correctly was causing major audio issues, possibly because the original Citra implementation never correctly handled the check failing.

The old "incorrect" behaviour has existed for 3 years, so we can probably just leave things as they were for now until we can get a proper fix together.