### PR TITLE
video_core: Fix latent surface garbage collection

### DIFF
--- a/src/video_core/rasterizer_cache/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache/rasterizer_cache.h
@@ -128,13 +128,14 @@ void RasterizerCache<T>::TickFrame() {
 
 template <class T>
 void RasterizerCache<T>::RunGarbageCollector() {
-    const u64 remove_tick = runtime.GetResourceTick();
+    const u64 current_resource_tick = runtime.GetResourceTick();
     for (auto it = sentenced.begin(); it != sentenced.end();) {
-        const auto [surface_id, resource_tick] = *it;
-        // Anything older(lower tick-value) than the resource-free tick-value is done being used
-        // and is ready to be deleted
-        if (remove_tick >= resource_tick) {
-            // Resource is still possibly in-use, skip
+        const auto [surface_id, resource_last_used_tick] = *it;
+        // Tick-values less than or equal to the current resource-tick are possibly still in-use.
+        // Tick-values larger than the current resource-tick are not being utilized anymore and can
+        // be safely deleted.
+        if (current_resource_tick <= resource_last_used_tick) {
+            // Resource is still in-use, skip deletion
             it++;
             continue;
         }

--- a/src/video_core/rasterizer_cache/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache/rasterizer_cache.h
@@ -128,13 +128,13 @@ void RasterizerCache<T>::TickFrame() {
 
 template <class T>
 void RasterizerCache<T>::RunGarbageCollector() {
-    const u64 current_resource_tick = runtime.GetResourceTick();
+    const u64 resource_free_tick = runtime.GetResourceFreeTick();
     for (auto it = sentenced.begin(); it != sentenced.end();) {
         const auto [surface_id, resource_last_used_tick] = *it;
         // Tick-values less than or equal to the current resource-tick are possibly still in-use.
         // Tick-values larger than the current resource-tick are not being utilized anymore and can
         // be safely deleted.
-        if (current_resource_tick <= resource_last_used_tick) {
+        if (resource_free_tick <= resource_last_used_tick) {
             // Resource is still in-use, skip deletion
             it++;
             continue;

--- a/src/video_core/rasterizer_cache/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache/rasterizer_cache.h
@@ -1366,15 +1366,20 @@ template <class T>
 SurfaceId RasterizerCache<T>::CreateSurface(const SurfaceParams& params,
                                             const SurfaceFlagBits& initial_flags) {
     const SurfaceId surface_id = [&] {
+        const u64 resource_free_tick = runtime.GetResourceFreeTick();
+        // Try to find a matching texture in the deletion queue
         const auto it = std::find_if(sentenced.begin(), sentenced.end(), [&](const auto& pair) {
-            return slot_surfaces[pair.first] == params;
+            return (slot_surfaces[pair.first] == params) &&
+                   // Only recycle the texture if the texture runtime is completely done with it
+                   (resource_free_tick > pair.second);
         });
-        if (it == sentenced.end()) {
-            return slot_surfaces.insert(runtime, params, initial_flags);
+        // If a matching texture was found in the deletion queue, recycle it.
+        if (it != sentenced.end()) {
+            const SurfaceId surface_id = it->first;
+            sentenced.erase(it);
+            return surface_id;
         }
-        const SurfaceId surface_id = it->first;
-        sentenced.erase(it);
-        return surface_id;
+        return slot_surfaces.insert(runtime, params, initial_flags);
     }();
     Surface& surface = slot_surfaces[surface_id];
     if (params.res_scale > surface.res_scale) {

--- a/src/video_core/rasterizer_cache/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache/rasterizer_cache.h
@@ -1386,6 +1386,8 @@ SurfaceId RasterizerCache<T>::CreateSurface(const SurfaceParams& params,
     }();
     Surface& surface = slot_surfaces[surface_id];
     if (params.res_scale > surface.res_scale) {
+        // Texture is going to be upscaled, remove any previous framebuffer references
+        RemoveFramebuffers(surface_id);
         surface.ScaleUp(params.res_scale);
     }
     surface.MarkInvalid(surface.GetInterval());

--- a/src/video_core/rasterizer_cache/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache/rasterizer_cache.h
@@ -1370,6 +1370,9 @@ SurfaceId RasterizerCache<T>::CreateSurface(const SurfaceParams& params,
         // Try to find a matching texture in the deletion queue
         const auto it = std::find_if(sentenced.begin(), sentenced.end(), [&](const auto& pair) {
             return (slot_surfaces[pair.first] == params) &&
+                   // Only recycle the texture if its resolution scale is equal or less than the
+                   // incoming texture
+                   (slot_surfaces[pair.first].res_scale <= params.res_scale) &&
                    // Only recycle the texture if the texture runtime is completely done with it
                    (resource_free_tick > pair.second);
         });

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -584,6 +584,8 @@ bool RasterizerOpenGL::Draw(bool accelerate, bool is_indexed) {
     // Bind the framebuffer surfaces
     if (shadow_rendering) {
         state.image_shadow_buffer = framebuffer->Attachment(SurfaceType::Color);
+    } else {
+        state.image_shadow_buffer = res_cache.GetSurface(VideoCore::NULL_SURFACE_ID).Handle();
     }
     state.draw.draw_framebuffer = framebuffer->Handle();
 

--- a/src/video_core/renderer_opengl/gl_texture_runtime.h
+++ b/src/video_core/renderer_opengl/gl_texture_runtime.h
@@ -43,8 +43,13 @@ public:
     ~TextureRuntime();
 
     /// Gets an opaque tick-value used to indicate to the garbage collector when a surface was made.
-    /// Incrementing this variable indicates that all previous resource ticks can be safely deleted
     u64 GetResourceTick();
+
+    /// Gets an opaque tick-value used to indicate to the garbage collector what surfaces can be
+    /// safely deleted.
+    u64 GetResourceFreeTick() {
+        return GetResourceTick();
+    };
 
     /// Submits and waits for current GPU work.
     void Finish();

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -695,10 +695,20 @@ void RasterizerVulkan::SyncTextureUnits(const Framebuffer* framebuffer) {
 }
 
 void RasterizerVulkan::SyncUtilityTextures(const Framebuffer* framebuffer) {
-    const bool shadow_rendering = regs.framebuffer.IsShadowRendering();
+    const bool shadow_writing = regs.framebuffer.IsShadowRendering();
+    const bool shadow_reading = regs.lighting.config0.enable_shadow;
     const auto utility_set = pipeline_cache.Acquire(DescriptorHeapType::Utility);
-    if (shadow_rendering) {
+
+    // Reading and writing are mutually exclusive
+    assert(!(shadow_writing && shadow_reading));
+
+    if (shadow_writing) {
         update_queue.AddStorageImage(utility_set, 0, framebuffer->ImageView(SurfaceType::Color));
+    } else if (shadow_reading) {
+        const u32 shadow_texture_unit = regs.lighting.config0.shadow_selector.Value();
+        const auto shadow_texture = regs.texturing.GetTextures()[shadow_texture_unit];
+        Surface& shadow_surface = res_cache.GetTextureSurface(shadow_texture);
+        update_queue.AddStorageImage(utility_set, 0, shadow_surface.StorageView());
     } else {
         Surface& null_surface = res_cache.GetSurface(VideoCore::NULL_SURFACE_ID);
         update_queue.AddStorageImage(utility_set, 0, null_surface.StorageView());

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -696,12 +696,13 @@ void RasterizerVulkan::SyncTextureUnits(const Framebuffer* framebuffer) {
 
 void RasterizerVulkan::SyncUtilityTextures(const Framebuffer* framebuffer) {
     const bool shadow_rendering = regs.framebuffer.IsShadowRendering();
-    if (!shadow_rendering) {
-        return;
-    }
-
     const auto utility_set = pipeline_cache.Acquire(DescriptorHeapType::Utility);
-    update_queue.AddStorageImage(utility_set, 0, framebuffer->ImageView(SurfaceType::Color));
+    if (shadow_rendering) {
+        update_queue.AddStorageImage(utility_set, 0, framebuffer->ImageView(SurfaceType::Color));
+    } else {
+        Surface& null_surface = res_cache.GetSurface(VideoCore::NULL_SURFACE_ID);
+        update_queue.AddStorageImage(utility_set, 0, null_surface.StorageView());
+    }
 }
 
 void RasterizerVulkan::BindShadowCube(const Pica::TexturingRegs::FullTextureConfig& texture,

--- a/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
@@ -167,6 +167,9 @@ void Handle::Create(u32 width, u32 height, u32 levels, TextureType type, vk::For
                     vk::ImageUsageFlags usage, vk::ImageCreateFlags flags,
                     vk::ImageAspectFlags aspect, bool need_format_list,
                     std::string_view debug_name) {
+
+    Destroy();
+
     const bool is_cube_map = type == TextureType::CubeMap && instance.IsLayeredRenderingSupported();
     if (!is_cube_map) {
         flags &= ~vk::ImageCreateFlagBits::eCubeCompatible;

--- a/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
@@ -304,6 +304,9 @@ VideoCore::StagingData TextureRuntime::FindStaging(u32 size, bool upload) {
 }
 
 u64 TextureRuntime::GetResourceTick() {
+    // Ensure we are getting the latest GpuTick value to reduce garbage-collection latency and
+    // allows the deletion of resources immediately when they are done being used.
+    scheduler.GetMasterSemaphore()->Refresh();
     return scheduler.GetMasterSemaphore()->KnownGpuTick();
 }
 

--- a/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
@@ -1134,6 +1134,8 @@ void Surface::ScaleUp(u32 new_scale) {
                                  DebugName(true));
     current = Type::Scaled;
 
+    handles[Type::Copy].Destroy();
+
     runtime.renderpass_cache.EndRendering();
     scheduler.Record(
         [raw_images = std::array{Image()}, aspect = traits.aspect](vk::CommandBuffer cmdbuf) {

--- a/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
@@ -304,6 +304,10 @@ VideoCore::StagingData TextureRuntime::FindStaging(u32 size, bool upload) {
 }
 
 u64 TextureRuntime::GetResourceTick() {
+    return scheduler.GetMasterSemaphore()->CurrentTick();
+}
+
+u64 TextureRuntime::GetResourceFreeTick() {
     // Ensure we are getting the latest GpuTick value to reduce garbage-collection latency and
     // allows the deletion of resources immediately when they are done being used.
     scheduler.GetMasterSemaphore()->Refresh();
@@ -311,7 +315,7 @@ u64 TextureRuntime::GetResourceTick() {
 }
 
 void TextureRuntime::Finish() {
-    scheduler.Finish();
+    scheduler.Flush();
 }
 
 bool TextureRuntime::Reinterpret(Surface& source, Surface& dest,

--- a/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
@@ -775,6 +775,11 @@ Surface::Surface(TextureRuntime& runtime_, const VideoCore::SurfaceParams& param
     if (is_color) {
         usage |= vk::ImageUsageFlagBits::eColorAttachment;
     }
+    if (traits.native == vk::Format::eR8G8B8A8Unorm && traits.storage_support) {
+        // Add Storage-usage support when available in case it is found out later that this is a
+        // shadow-source texture that will get used in the utility descriptor-set
+        usage |= vk::ImageUsageFlagBits::eStorage;
+    }
 
     const bool need_format_list = is_mutable && instance.IsImageFormatListSupported();
     handles[Type::Base].Create(width, height, levels, texture_type, format, usage, flags,

--- a/src/video_core/renderer_vulkan/vk_texture_runtime.h
+++ b/src/video_core/renderer_vulkan/vk_texture_runtime.h
@@ -126,8 +126,11 @@ public:
     }
 
     /// Gets an opaque tick-value used to indicate to the garbage collector when a surface was made.
-    /// Incrementing this variable indicates that all previous resource ticks can be safely deleted.
     u64 GetResourceTick();
+
+    /// Gets an opaque tick-value used to indicate to the garbage collector what surfaces can be
+    /// safely deleted.
+    u64 GetResourceFreeTick();
 
     /// Submits and waits for current GPU work.
     void Finish();


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

The rasterizer cache garbage collection criteria was interpreting tick-values incorrectly, and was only incidentally able to garbage collect textures within 1 frame of latency. Textures that were invalidated farther back in time, such as when changing the rendering resolution and finding out that they need to be deleted later on, were not being properly deleted despite having older tick values(lower tick values). This fixes the issue by using the correct `<=` comparison and also fixes the Vulkan implementation of `GetResourceTick` to avoid a race-condition by ensuring we are using the latest tick value from the GPU and not the last-known tick-value.

Fixes https://github.com/azahar-emu/azahar/issues/2472