### PR TITLE
android: Region string display tweaks

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/adapters/GameAdapter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/adapters/GameAdapter.kt
@@ -213,7 +213,7 @@ class GameAdapter(
 
             binding.textGameTitle.text = game.title
             binding.textCompany.text = game.company
-            binding.textGameRegion.text = game.regions
+            binding.textGameRegion.text = translateRegions(game.regions)
             binding.imageCartridge.visibility =
                 if (preferences.getString("insertedCartridge", "") != game.path) {
                     View.GONE
@@ -435,6 +435,37 @@ class GameAdapter(
         popup.show()
     }
 
+    private fun translateRegions(regionsString: String): String {
+        val regions = regionsString.split("|")
+
+        var final = ""
+
+        regions.forEach {
+            var res: Int = -1
+
+            when (it) {
+                "Japan" -> res = R.string.japan
+                "North America" -> res = R.string.north_america
+                "Europe" -> res = R.string.europe
+                "Australia" -> res = R.string.australia
+                "China" -> res = R.string.china
+                "Korea" -> res = R.string.korea
+                "Taiwan" -> res = R.string.taiwan
+                "Region free" -> res = R.string.region_free
+                "Invalid region" -> res = R.string.invalid_region
+                else -> res = R.string.region_get_error
+            }
+
+            final += CitraApplication.appContext.getString(res) + "|"
+        }
+
+        final = final
+            .dropLast(1) // Remove trailing seperator
+            .replace("|", ", ")
+
+        return final
+    }
+
     private fun showAboutGameDialog(
         context: Context,
         game: Game,
@@ -451,7 +482,8 @@ class GameAdapter(
 
         bottomSheetView.findViewById<TextView>(R.id.about_game_title).text = game.title
         bottomSheetView.findViewById<TextView>(R.id.about_game_company).text = game.company
-        bottomSheetView.findViewById<TextView>(R.id.about_game_region).text = game.regions
+        bottomSheetView.findViewById<TextView>(R.id.about_game_region).text =
+            context.getString(R.string.game_context_region) + " " + translateRegions(game.regions)
         bottomSheetView.findViewById<TextView>(R.id.about_game_id).text =
             context.getString(R.string.game_context_id) + " " + String.format("%016X", game.titleId)
         bottomSheetView.findViewById<TextView>(R.id.about_game_filename).text =

--- a/src/android/app/src/main/jni/game_info.cpp
+++ b/src/android/app/src/main/jni/game_info.cpp
@@ -185,7 +185,7 @@ jstring Java_org_citra_citra_1emu_model_GameInfo_getRegions(JNIEnv* env, jobject
         return ToJString(env, "Region free");
     }
 
-    const std::string separator = ", ";
+    const std::string separator = "|";
     std::string result = regions_map.at(regions.front());
     for (auto region = ++regions.begin(); region != regions.end(); ++region) {
         result += separator + regions_map.at(*region);

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -672,6 +672,7 @@
     <string name="create_shortcut">Create Shortcut</string>
     <string name="shortcut_name_empty">Shortcut name cannot be empty</string>
     <string name="shortcut_image_stretch_toggle">Stretch to fit image</string>
+    <string name="game_context_region">Region:</string>
     <string name="game_context_id">ID:</string>
     <string name="game_context_file">File:</string>
     <string name="game_context_type">Type:</string>
@@ -766,7 +767,7 @@
     <string name="use_black_backgrounds">Black Backgrounds</string>
     <string name="use_black_backgrounds_description">When using the dark theme, apply black backgrounds.</string>
 
-    <!-- Region names -->
+    <!-- Region codes -->
     <string name="system_region_jpn" translatable="false">JPN</string>
     <string name="system_region_usa" translatable="false">USA</string>
     <string name="system_region_eur" translatable="false">EUR</string>
@@ -970,6 +971,14 @@
     <string name="san_marino">San Marino</string>
     <string name="vatican_city">Vatican City</string>
     <string name="bermuda">Bermuda</string>
+
+    <!-- Regions (Japan, Australia, China and Taiwan are above) -->
+    <string name="north_america">North America</string>
+    <string name="europe">Europe</string>
+    <string name="korea">Korea</string>
+    <string name="region_free">Region free</string>
+    <string name="invalid_region">Invalid region</string>
+    <string name="region_get_error">ERROR PLEASE REPORT</string>
 
     <!-- Months -->
     <string name="january">January</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -767,13 +767,13 @@
     <string name="use_black_backgrounds_description">When using the dark theme, apply black backgrounds.</string>
 
     <!-- Region names -->
-    <string name="system_region_jpn">JPN</string>
-    <string name="system_region_usa">USA</string>
-    <string name="system_region_eur">EUR</string>
-    <string name="system_region_aus">AUS</string>
-    <string name="system_region_chn">CHN</string>
-    <string name="system_region_kor">KOR</string>
-    <string name="system_region_twn">TWN</string>
+    <string name="system_region_jpn" translatable="false">JPN</string>
+    <string name="system_region_usa" translatable="false">USA</string>
+    <string name="system_region_eur" translatable="false">EUR</string>
+    <string name="system_region_aus" translatable="false">AUS</string>
+    <string name="system_region_chn" translatable="false">CHN</string>
+    <string name="system_region_kor" translatable="false">KOR</string>
+    <string name="system_region_twn" translatable="false">TWN</string>
 
     <!-- Language names -->
     <string name="language_japanese">Japanese (日本語)</string>


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

- Mark 3-letter region codes as untranslatable
- Make game region string displayed in frontend translatable (Closes #2492)
- Added a "Region:" label before the region string in the about game screen 