### PR TITLE
video_core: Display unimplemented reinterpretation underlying formats

### DIFF
--- a/src/video_core/renderer_opengl/gl_texture_runtime.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_runtime.cpp
@@ -189,9 +189,9 @@ bool TextureRuntime::Reinterpret(Surface& source, Surface& dest,
     } else if (src_format == PixelFormat::RGBA4 && dst_format == PixelFormat::RGB5A1) {
         blit_helper.ConvertRGBA4ToRGB5A1(source, dest, copy);
     } else {
-        LOG_WARNING(Render_OpenGL, "Unimplemented reinterpretation {} -> {}",
-                    VideoCore::PixelFormatAsString(src_format),
-                    VideoCore::PixelFormatAsString(dst_format));
+        LOG_WARNING(Render_OpenGL, "Unimplemented reinterpretation {}({:#x}) -> {}({:#x})",
+                    VideoCore::PixelFormatAsString(src_format), source.Tuple().internal_format,
+                    VideoCore::PixelFormatAsString(dst_format), dest.Tuple().internal_format);
         return false;
     }
     return true;

--- a/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
@@ -336,9 +336,9 @@ bool TextureRuntime::Reinterpret(Surface& source, Surface& dest,
     if (src_format == PixelFormat::D24S8 && dst_format == PixelFormat::RGBA8) {
         blit_helper.ConvertDS24S8ToRGBA8(source, dest, copy);
     } else {
-        LOG_WARNING(Render_Vulkan, "Unimplemented reinterpretation {} -> {}",
-                    VideoCore::PixelFormatAsString(src_format),
-                    VideoCore::PixelFormatAsString(dst_format));
+        LOG_WARNING(Render_Vulkan, "Unimplemented reinterpretation {}({}) -> {}({})",
+                    VideoCore::PixelFormatAsString(src_format), vk::to_string(source.traits.native),
+                    VideoCore::PixelFormatAsString(dst_format), vk::to_string(dest.traits.native));
         return false;
     }
     return true;


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Depending on the GPU, the guest pixel-format might map to a different underlying vulkan-format, such as RGBA8 in the case that a certain texture format is not supported.

This will display the actual underlying format being used in these warning messages to help better-diagnose nuanced reinterpretation issues like:
https://github.com/azahar-emu/azahar/issues/1645

Ex:
```
[  57.262836] Render.Vulkan <Warning> video_core\renderer_vulkan\vk_texture_runtime.cpp:Vulkan::TextureRuntime::Reinterpret:341: Unimplemented reinterpretation RGB565(R5G6B5UnormPack16) -> RGB5A1(R8G8B8A8Unorm)
[  57.445590] Render.Vulkan <Warning> video_core\renderer_vulkan\vk_texture_runtime.cpp:Vulkan::TextureRuntime::Reinterpret:341: Unimplemented reinterpretation RGB5A1(R8G8B8A8Unorm) -> RGB565(R5G6B5UnormPack16)
```