### PR TITLE
android: Display "Invalid ROM" label in game list for invalid ROMs

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/adapters/GameAdapter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/adapters/GameAdapter.kt
@@ -200,18 +200,22 @@ class GameAdapter(
             binding.imageGameScreen.scaleType = ImageView.ScaleType.CENTER_CROP
             GameIconUtils.loadGameIcon(activity, game, binding.imageGameScreen)
 
-            binding.textGameTitle.visibility = if (game.title.isEmpty()) {
-                View.GONE
-            } else {
-                View.VISIBLE
-            }
             binding.textCompany.visibility = if (game.company.isEmpty()) {
                 View.GONE
             } else {
                 View.VISIBLE
             }
+            binding.textGameRegion.visibility = if (game.regions.isEmpty()) {
+                View.GONE
+            } else {
+                View.VISIBLE
+            }
 
-            binding.textGameTitle.text = game.title
+            binding.textGameTitle.text = if (game.fileType == "unknown") {
+                CitraApplication.appContext.getString(R.string.invalid_rom)
+            } else {
+                game.title
+            }
             binding.textCompany.text = game.company
             binding.textGameRegion.text = translateRegions(game.regions)
             binding.imageCartridge.visibility =
@@ -445,15 +449,29 @@ class GameAdapter(
 
             when (it) {
                 "Japan" -> res = R.string.japan
+
                 "North America" -> res = R.string.north_america
+
                 "Europe" -> res = R.string.europe
+
                 "Australia" -> res = R.string.australia
+
                 "China" -> res = R.string.china
+
                 "Korea" -> res = R.string.korea
+
                 "Taiwan" -> res = R.string.taiwan
+
                 "Region free" -> res = R.string.region_free
+
                 "Invalid region" -> res = R.string.invalid_region
-                else -> res = R.string.region_get_error
+
+                "" -> res = R.string.invalid_region
+
+                else -> {
+                    Log.error("[GameAdapter] Unrecognized region string \"$it\"")
+                    res = R.string.region_get_error
+                }
             }
 
             final += CitraApplication.appContext.getString(res) + "|"

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -475,7 +475,7 @@
     <string name="loader_error_encrypted_description"><![CDATA[Azahar does not support encrypted applications. Read our <a href="https://azahar-emu.org/blog/game-loading-changes/">blog post</a> for more information.]]></string>
     <string name="loader_error_file_not_found">ROM file does not exist</string>
     <string name="no_game_present">No bootable game present!</string>
-
+    <string name="invalid_rom">Invalid ROM</string>
     <string name="loader_error_generic">An error occurred while loading ROM: \"%s (%d)\"</string>
     <string name="core_error_success">Success</string>
     <string name="core_error_not_initialized">Not initialized</string>


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

In current stable, invalid ROMs just display as a blank card in the game list, and in the latest prerelease an unrelated "ERROR PLEASE REPORT" message is displayed due to an oversight in some new region handling code.

Both of these behaviours have been superseded by new code which checks if the file type of the ROM is "unknown", and then displays the label "Invalid ROM" in place of the game title in the game list.