### PR TITLE
renderer_vulkan: Sanitize layers list during initialization

### DIFF
--- a/src/video_core/renderer_vulkan/vk_platform.cpp
+++ b/src/video_core/renderer_vulkan/vk_platform.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Citra Emulator Project / Azahar Emulator Project
+// Copyright 2023-2026 Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -326,6 +326,25 @@ vk::UniqueInstance CreateInstance(const Common::DynamicLibrary& library,
     if (dump_command_buffers) {
         layers.push_back("VK_LAYER_LUNARG_api_dump");
     }
+
+    // Sanitize layers list
+    const auto layer_properties = vk::enumerateInstanceLayerProperties();
+    if (layer_properties.empty()) {
+        LOG_ERROR(Render_Vulkan, "Failed to query layer properties");
+        return {};
+    }
+
+    boost::container::erase_if(layers, [&](const char* layer) -> bool {
+        const auto it = std::find_if(
+            layer_properties.begin(), layer_properties.end(),
+            [layer](const auto& prop) { return std::strcmp(layer, prop.layerName) == 0; });
+
+        if (it == layer_properties.end()) {
+            LOG_INFO(Render_Vulkan, "Candidate instance layer {} is not available", layer);
+            return true;
+        }
+        return false;
+    });
 
     vk::InstanceCreateInfo instance_ci = {
         .flags = GetInstanceFlags(),


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

We do this for extensions, but should also be doing it for layers as well to ensure we are not enabling instance-layers that the system does not support.

Addresses https://github.com/azahar-emu/azahar/issues/2507
