### PR TITLE
ci: More robust/safe compression method for source tarball(s)

### DIFF
--- a/.ci/source.sh
+++ b/.ci/source.sh
@@ -20,6 +20,11 @@ git archive-all --include "${COMPAT_LIST}" --include GIT-COMMIT --include GIT-TA
 
 cd artifacts/
 tarlz -v -9z "${REV_NAME}.tar"
-lziprecover -v -Fc "${REV_NAME}.tar.lz"
+lziprecover -v -Fc "${REV_NAME}.tar.lz" || fec_failed=1
+if [ ${fec_failed:-0} -eq 1 ]
+then
+ echo "fec file creation failed! this is likely due to lziprecover being out of date."
+fi
 sha256sum "${REV_NAME}.tar.lz" > "${REV_NAME}.tar.lz.sha256sum"
+touch "${REV_NAME}.tar.lz.fec" # THIS IS A TEST MAKE SURE TO REMOVE IT!!
 cd ..

--- a/.ci/source.sh
+++ b/.ci/source.sh
@@ -19,6 +19,7 @@ git describe --tags HEAD > GIT-TAG || echo 'unknown' > GIT-TAG
 git archive-all --include "${COMPAT_LIST}" --include GIT-COMMIT --include GIT-TAG --force-submodules artifacts/"${REV_NAME}.tar"
 
 cd artifacts/
-xz -T0 -9 "${REV_NAME}.tar"
-sha256sum "${REV_NAME}.tar.xz" > "${REV_NAME}.tar.xz.sha256sum"
+tarlz -v -9z "${REV_NAME}.tar"
+lziprecover -v -Fc "${REV_NAME}.tar.lz"
+sha256sum "${REV_NAME}.tar.lz" > "${REV_NAME}.tar.lz.sha256sum"
 cd ..

--- a/.ci/source.sh
+++ b/.ci/source.sh
@@ -23,8 +23,7 @@ tarlz -v -9z "${REV_NAME}.tar"
 lziprecover -v -Fc "${REV_NAME}.tar.lz" || fec_failed=1
 if [ ${fec_failed:-0} -eq 1 ]
 then
- echo "fec file creation failed! this is likely due to lziprecover being out of date."
+ echo "fec file creation failed! this is likely due to lziprecover either being out of date (minimum of 1.25 required) or simply not installed."
 fi
 sha256sum "${REV_NAME}.tar.lz" > "${REV_NAME}.tar.lz.sha256sum"
-touch "${REV_NAME}.tar.lz.fec" # THIS IS A TEST MAKE SURE TO REMOVE IT!!
 cd ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
     tags: [ "*" ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 permissions:
   id-token: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,9 @@ jobs:
         with:
           submodules: recursive
       - name: Pack
-        run: ./.ci/source.sh
+        run: |
+          sudo apt install -y tarlz lziprecover
+          ./.ci/source.sh
       - name: Generate SBOM
         if: ${{ github.ref_type == 'tag' }}
         uses: anchore/sbom-action@v0
@@ -40,7 +42,7 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-path: |
-            artifacts/*.tar.xz
+            artifacts/*.tar.lz
           sbom-path: artifacts/source.spdx.json
 
   linux-x86_64:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
     tags: [ "*" ]
   pull_request:
     branches: [ master ]
-  workflow_dispatch:
 
 permissions:
   id-token: write


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------


Currently the tarball which is created to hold the full source code (including submodules) is compressed with [XZ](https://tukaani.org/xz/) however I believe this is a very bad choice for long term storage/archival so this PR aims to switch it out with [Lzip](https://www.nongnu.org/lzip/) (supported by the `tar` utility since 2010) which has a very similar compression ratio (both are LZMA at their core) but is way more recoverable in case of damage/corruption (furthered by using `tarlz` which aligns itself based on how the tar it's compressing is internally split up: https://www.nongnu.org/lzip/lzip_talk_ghm_2019.pdf#page=16). this PR also makes it so that a [FEC file](https://www.nongnu.org/lzip/manual/lziprecover_manual.html#Fec-files) is attempted to be output if possible as well to further protect against corruption for those who want it, I've setup the FEC generation to not cause the whole script to give up if it fails because it's an optional side file and for some reason the `apt` repos currently hold an older version of lziprecover without FEC file support.

Note: this PR was partially inspired from https://www.nongnu.org/lzip/xz_inadequate.html which lists out core problems with XZ compared to Lzip, and while it is written by the creator of Lzip which implies a bias I do genuinely believe the arguments it lays out make sense.