### PR TITLE
renderer_gl: Fix unreliable resource-tick causing interframe memory-leaks

### DIFF
--- a/src/video_core/renderer_base.h
+++ b/src/video_core/renderer_base.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2025 Citra Emulator Project / Azahar Emulator Project
+// Copyright 2014-2026 Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -77,7 +77,7 @@ public:
         return current_fps;
     }
 
-    s32 GetCurrentFrame() const {
+    u64 GetCurrentFrame() const {
         return current_frame;
     }
 
@@ -112,7 +112,7 @@ protected:
 
 protected:
     f32 current_fps = 0.0f; /// Current framerate, should be set by the renderer
-    s32 current_frame = 0;  /// Current frame, should be set by the renderer
+    u64 current_frame = 0;  /// Current frame, should be set by the renderer
 };
 
 } // namespace VideoCore

--- a/src/video_core/renderer_opengl/gl_texture_runtime.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_runtime.cpp
@@ -113,8 +113,8 @@ static constexpr std::array<FormatTuple, 8> CUSTOM_TUPLES = {{
 
 } // Anonymous namespace
 
-TextureRuntime::TextureRuntime(const Driver& driver_, VideoCore::RendererBase& renderer)
-    : driver{driver_}, current_resource_tick{0}, blit_helper{driver} {
+TextureRuntime::TextureRuntime(const Driver& driver_, VideoCore::RendererBase& renderer_)
+    : driver{driver_}, renderer{renderer_}, blit_helper{driver} {
     for (std::size_t i = 0; i < draw_fbos.size(); ++i) {
         draw_fbos[i].Create();
         read_fbos[i].Create();
@@ -124,12 +124,10 @@ TextureRuntime::TextureRuntime(const Driver& driver_, VideoCore::RendererBase& r
 TextureRuntime::~TextureRuntime() = default;
 
 u64 TextureRuntime::GetResourceTick() {
-    return current_resource_tick;
+    return renderer.GetCurrentFrame();
 }
 
-void TextureRuntime::Finish() {
-    current_resource_tick++;
-}
+void TextureRuntime::Finish() {}
 
 bool TextureRuntime::NeedsConversion(const Surface& surface) const {
     const auto& pixel_format = surface.pixel_format;

--- a/src/video_core/renderer_opengl/gl_texture_runtime.h
+++ b/src/video_core/renderer_opengl/gl_texture_runtime.h
@@ -49,7 +49,7 @@ public:
     /// safely deleted.
     u64 GetResourceFreeTick() {
         return GetResourceTick();
-    };
+    }
 
     /// Submits and waits for current GPU work.
     void Finish();
@@ -95,7 +95,7 @@ private:
 
 private:
     const Driver& driver;
-    u64 current_resource_tick;
+    const VideoCore::RendererBase& renderer;
     BlitHelper blit_helper;
     std::vector<u8> staging_buffer;
     std::array<OGLFramebuffer, 3> draw_fbos;


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

OpenGL does not have tight synchronization primitives like Vulkan and instead must use whole frame-boundaries to determine when it is safe to delete a texture. Updates the `current_frame` index from renderer-base to be a 64-bit integer and derive the OpenGL texture-runtime resource-tick to be from the renderer's frame-index.