### PR TITLE
renderer_vulkan: Allow instance creation in systems with no layers.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_platform.cpp
+++ b/src/video_core/renderer_vulkan/vk_platform.cpp
@@ -329,6 +329,10 @@ vk::UniqueInstance CreateInstance(const Common::DynamicLibrary& library,
 
     // Sanitize layers list
     const auto layer_properties = vk::enumerateInstanceLayerProperties();
+    if (layer_properties.empty()) {
+        LOG_WARNING(Render_Vulkan, "Instance layer properties list is empty");
+    }
+
     boost::container::erase_if(layers, [&](const char* layer) -> bool {
         const auto it = std::find_if(
             layer_properties.begin(), layer_properties.end(),

--- a/src/video_core/renderer_vulkan/vk_platform.cpp
+++ b/src/video_core/renderer_vulkan/vk_platform.cpp
@@ -329,11 +329,6 @@ vk::UniqueInstance CreateInstance(const Common::DynamicLibrary& library,
 
     // Sanitize layers list
     const auto layer_properties = vk::enumerateInstanceLayerProperties();
-    if (layer_properties.empty()) {
-        LOG_ERROR(Render_Vulkan, "Failed to query layer properties");
-        return {};
-    }
-
     boost::container::erase_if(layers, [&](const char* layer) -> bool {
         const auto it = std::find_if(
             layer_properties.begin(), layer_properties.end(),


### PR DESCRIPTION

- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Fixes Vulkan instance creation on platforms that don't support any layers.