### PR TITLE
renderer_vulkan: Fix shadow-texture binding requirements

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -700,7 +700,14 @@ void RasterizerVulkan::SyncTextureUnits(const Framebuffer* framebuffer) {
 
 void RasterizerVulkan::SyncUtilityTextures(const Framebuffer* framebuffer) {
     const bool shadow_writing = regs.framebuffer.IsShadowRendering();
-    const bool shadow_reading = regs.lighting.config0.enable_shadow;
+    bool shadow_reading = regs.lighting.config0.enable_shadow;
+    // Ensure the shadow-texture slot is actually enabled
+    if (shadow_reading) {
+        const u32 shadow_texture_unit = regs.lighting.config0.shadow_selector.Value();
+        const auto shadow_texture = regs.texturing.GetTextures()[shadow_texture_unit];
+        shadow_reading &= shadow_texture.enabled;
+    }
+
     const auto utility_set = pipeline_cache.Acquire(DescriptorHeapType::Utility);
 
     // Reading and writing are mutually exclusive

--- a/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_runtime.cpp
@@ -1307,7 +1307,9 @@ vk::ImageView Surface::ImageView(ViewType view_type, Type type) noexcept {
     auto aspect = traits.aspect;
 
     if (view_type == ViewType::Storage) {
-        ASSERT(traits.native == vk::Format::eR8G8B8A8Unorm);
+        ASSERT_MSG(traits.storage_support,
+                   "Creating a storage-view for format({}) which doesn't have storage-support!",
+                   vk::to_string(traits.native));
         is_storage = true;
     }
     if (view_type == ViewType::Depth || view_type == ViewType::Stencil) {


### PR DESCRIPTION
renderer_vulkan: Relax surface storage image-view requirements

So long as the underlying format has `storage_support`, it should be totally fine to create a storage image-view and begin considering the surface as a storage-image.

Addresses https://github.com/azahar-emu/azahar/issues/2531