### PR TITLE
config: Promote config integer-types to 64-bit integers

### DIFF
--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -231,15 +231,18 @@ void QtConfig::WriteBasicSetting(const Settings::Setting<std::vector<Type>, rang
     }
     qt_config->setValue(name, stringList);
 }
-// Explicit u16 definition: Qt would store it as QMetaType otherwise, which is not human-readable
-template <>
-void QtConfig::WriteBasicSetting(const Settings::Setting<u16>& setting) {
-    const QString name = QString::fromStdString(setting.GetLabel());
-    const u16& value = setting.GetValue();
-    if (global)
-        qt_config->setValue(name + QStringLiteral("/default"), value == setting.GetDefault());
-    qt_config->setValue(name, static_cast<u32>(value));
-}
+
+// Promote configuration types into simpler types so that Qt does not implicitly convert
+// configuration values into a QMetaType and ensures the ini files are human-readable
+template <typename T>
+using config_promoted_t = std::conditional_t<
+    // Preserve bools
+    std::is_same_v<T, bool>, bool,
+    // Signed/Unsigned integers get promoted to s64/u64
+    std::conditional_t<std::is_integral_v<T>,
+                       std::conditional_t<std::is_signed_v<T>, std::int64_t, std::uint64_t>,
+                       // Otherwise, leave the type unchanged
+                       T>>;
 
 template <typename Type, bool ranged>
 void QtConfig::WriteBasicSetting(const Settings::Setting<Type, ranged>& setting) {
@@ -248,9 +251,11 @@ void QtConfig::WriteBasicSetting(const Settings::Setting<Type, ranged>& setting)
     if (global)
         qt_config->setValue(name + QStringLiteral("/default"), value == setting.GetDefault());
     if constexpr (std::is_enum_v<Type>) {
-        qt_config->setValue(name, static_cast<std::underlying_type_t<Type>>(value));
+        using TypeU = std::underlying_type_t<Type>;
+        qt_config->setValue(
+            name, QVariant::fromValue<config_promoted_t<TypeU>>(static_cast<TypeU>(value)));
     } else {
-        qt_config->setValue(name, QVariant::fromValue(value));
+        qt_config->setValue(name, QVariant::fromValue<config_promoted_t<Type>>(value));
     }
 }
 


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Promotes signed/unsigned integer-types like `u16` and `u8` into `u64` before writing into `.ini` files to ensure integer configuration values are always human-readable.

Currently, types like `u8` and `u16` get written as:
```
delay_game_render_thread_us=@Variant(\0\0\0\x85\0\0)
```

This ensures it gets written as:
```
delay_game_render_thread_us=0
```