### PR TITLE
qt: Add build variant info to log and about menu

### DIFF
--- a/CMakeModules/GenerateBuildInfo.cmake
+++ b/CMakeModules/GenerateBuildInfo.cmake
@@ -54,4 +54,18 @@ macro(generate_build_info)
         set(BUILD_VERSION "${GIT_TAG}")
         set(BUILD_FULLNAME "${BUILD_VERSION}")
     endif()
+
+    # Set build variant
+    set(BUILD_VARIANT "") # Empty string on non-Windows platforms
+    if (WIN32)
+        if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" AND MINGW)
+            set(BUILD_VARIANT "MXE")
+        elseif(MINGW)
+            set(BUILD_VARIANT "MSYS2")
+        elseif(MSVC)
+            set(BUILD_VARIANT "MSVC")
+        else()
+            set(BUILD_VARIANT "Unknown")
+        endif()
+    endif()
 endmacro()

--- a/src/citra_qt/aboutdialog.cpp
+++ b/src/citra_qt/aboutdialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2025 Citra Emulator Project / Azahar Emulator Project
+// Copyright 2017-2026 Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -13,7 +13,8 @@ AboutDialog::AboutDialog(QWidget* parent)
     ui->setupUi(this);
     ui->labelBuildInfo->setText(ui->labelBuildInfo->text().arg(
         QString::fromUtf8(Common::g_build_fullname), QString::fromUtf8(Common::g_scm_branch),
-        QString::fromUtf8(Common::g_scm_desc), QString::fromUtf8(Common::g_build_date).left(10)));
+        QString::fromUtf8(Common::g_scm_desc), QString::fromUtf8(Common::g_build_date).left(10),
+        QString::fromUtf8(Common::g_build_variant)));
 }
 
 AboutDialog::~AboutDialog() = default;

--- a/src/citra_qt/aboutdialog.ui
+++ b/src/citra_qt/aboutdialog.ui
@@ -70,7 +70,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3 (%4)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3 (%4)&lt;/p&gt;&lt;p&gt;%5&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </widget>
        </item>

--- a/src/citra_qt/citra_qt.cpp
+++ b/src/citra_qt/citra_qt.cpp
@@ -460,6 +460,11 @@ GMainWindow::GMainWindow(Core::System& system_)
 
     LOG_INFO(Frontend, "Azahar Version: {} | {}-{}", Common::g_build_fullname, Common::g_scm_branch,
              Common::g_scm_desc);
+    std::string build_variant = Common::g_build_variant;
+    if (build_variant == "") {
+        build_variant = "N/A";
+    }
+    LOG_INFO(Frontend, "Build Variant: {}", build_variant);
 #if CITRA_ARCH(x86_64)
     const auto& caps = Common::GetCPUCaps();
     std::string cpu_string = caps.cpu_string;

--- a/src/common/scm_rev.cpp.in
+++ b/src/common/scm_rev.cpp.in
@@ -1,4 +1,4 @@
-// Copyright 2014 Citra Emulator Project
+// Copyright 2014-2026 Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -11,6 +11,7 @@
 #define BUILD_DATE   "@BUILD_DATE@"
 #define BUILD_VERSION "@BUILD_VERSION@"
 #define BUILD_FULLNAME "@BUILD_FULLNAME@"
+#define BUILD_VARIANT "@BUILD_VARIANT@"
 #define SHADER_CACHE_VERSION "@SHADER_CACHE_VERSION@"
 
 namespace Common {
@@ -22,6 +23,7 @@ const char g_build_name[]   = BUILD_NAME;
 const char g_build_date[]   = BUILD_DATE;
 const char g_build_fullname[] = BUILD_FULLNAME;
 const char g_build_version[]  = BUILD_VERSION;
+const char g_build_variant[]  = BUILD_VARIANT;
 const char g_shader_cache_version[] = SHADER_CACHE_VERSION;
 
 } // namespace

--- a/src/common/scm_rev.h
+++ b/src/common/scm_rev.h
@@ -1,4 +1,4 @@
-// Copyright 2014 Citra Emulator Project
+// Copyright 2014-2026 Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -13,6 +13,7 @@ extern const char g_build_name[];
 extern const char g_build_date[];
 extern const char g_build_fullname[];
 extern const char g_build_version[];
+extern const char g_build_variant[];
 extern const char g_shader_cache_version[];
 
 } // namespace Common


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Displays the Windows build variant (MXE, MSVC or MSYS2) in the Azahar log and About screen, both for debugging and miscellaneous end-user purposes.

This technically applies to all platforms, but only currently does anything useful on Windows.