### PR TITLE
video_core: Skip zero-area renderpasses

### DIFF
--- a/src/common/math_util.h
+++ b/src/common/math_util.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2025 Citra Emulator Project / Azahar Emulator Project
+// Copyright 2014-2026 Citra Emulator Project / Azahar Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -57,6 +57,9 @@ struct Rectangle {
     }
     [[nodiscard]] T GetHeight() const {
         return std::abs(static_cast<std::make_signed_t<T>>(bottom - top));
+    }
+    [[nodiscard]] T GetArea() const {
+        return GetWidth() * GetHeight();
     }
     [[nodiscard]] Rectangle<T> TranslateX(const T x) const {
         return Rectangle{left + x, top, right + x, bottom};

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -581,6 +581,11 @@ bool RasterizerOpenGL::Draw(bool accelerate, bool is_indexed) {
         return true;
     }
 
+    const auto draw_rect = fb_helper.DrawRect();
+    if (draw_rect.GetArea() == 0) {
+        return true;
+    }
+
     // Bind the framebuffer surfaces
     if (shadow_rendering) {
         state.image_shadow_buffer = framebuffer->Attachment(SurfaceType::Color);
@@ -598,7 +603,6 @@ bool RasterizerOpenGL::Draw(bool accelerate, bool is_indexed) {
 
     // Viewport can have negative offsets or larger dimensions than our framebuffer sub-rect.
     // Enable scissor test to prevent drawing outside of the framebuffer region
-    const auto draw_rect = fb_helper.DrawRect();
     state.scissor.enabled = true;
     state.scissor.x = draw_rect.left;
     state.scissor.y = draw_rect.bottom;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -561,7 +561,7 @@ bool RasterizerVulkan::Draw(bool accelerate, bool is_indexed) {
     }
 
     const auto draw_rect = fb_helper.DrawRect();
-    if (draw_rect.GetHeight() * draw_rect.GetHeight() == 0) {
+    if (draw_rect.GetArea() == 0) {
         return true;
     }
 


### PR DESCRIPTION
- [x] I have read the [Azahar AI Policy document](https://github.com/azahar-emu/azahar/blob/master/AI-POLICY.md) and have disclosed any use of AI if applicable under those terms.
---------

Follow-up on https://github.com/azahar-emu/azahar/pull/2510 and also fixes a typo in the currently checked in fix.

This implements the same optimization on both Vulkan _and_ OpenGL. I've found that https://github.com/azahar-emu/azahar/issues/1645 will try to do zero-surface-area render-passes on both rendering APIs.